### PR TITLE
Service-worker previews (HMR without a relay) + local Supabase dev in the browser

### DIFF
--- a/apps/playground/index.html
+++ b/apps/playground/index.html
@@ -72,6 +72,9 @@
 					data-example="create-vite">create-vite (1:1)</button>
 				<button
 					class="sidebar-item block w-full px-4 py-2 bg-transparent border-none text-tokyo-muted text-[13px] text-left cursor-pointer transition-colors hover:bg-tokyo-hover hover:text-tokyo-fg-bright"
+					data-example="tinbase">Supabase Todo (tinbase)</button>
+				<button
+					class="sidebar-item block w-full px-4 py-2 bg-transparent border-none text-tokyo-muted text-[13px] text-left cursor-pointer transition-colors hover:bg-tokyo-hover hover:text-tokyo-fg-bright"
 					data-example="pglite">Postgres (PGlite)</button>
 			</div>
 			<div class="py-3 border-t border-tokyo-border">
@@ -231,11 +234,14 @@
 				<div id="out-vite-react" class="output-panel">
 					<div class="text-[13px] font-semibold text-tokyo-fg-bright mb-0.5">Vite with React</div>
 					<div class="text-[11px] text-tokyo-comment mb-3.5">A real Vite dev server with React fast-refresh, running
-						in your browser — <code>cd react-app && npm install && npm run dev &</code>, then open
-						<code>http://localhost:3005</code>
+						in your browser — <code>cd react-app && npm install && npm run dev &</code>. The preview below is
+						served through a service worker at <code>/_sw/5173/</code>.
 					</div>
-					<div class="w-full rounded-lg overflow-hidden border border-tokyo-border p-2 bg-tokyo-bg flex-1">
-						<div id="terminal-vite-react" class="w-full h-full"></div>
+					<div class="flex flex-col gap-2 flex-1 min-h-0">
+						<div class="h-2/5 min-h-0 rounded-lg overflow-hidden border border-tokyo-border p-2 bg-tokyo-bg">
+							<div id="terminal-vite-react" class="w-full h-full"></div>
+						</div>
+						<div id="preview-vite-react" class="flex flex-col flex-1 min-h-0"></div>
 					</div>
 				</div>
 
@@ -243,11 +249,13 @@
 				<div id="out-vite-react-ts" class="output-panel">
 					<div class="text-[13px] font-semibold text-tokyo-fg-bright mb-0.5">Vite with React + TypeScript</div>
 					<div class="text-[11px] text-tokyo-comment mb-3.5">The TypeScript variant —
-						<code>cd react-ts-app && npm install && npm run dev &</code>, then open
-						<code>http://localhost:3005</code>
+						<code>cd react-ts-app && npm install && npm run dev &</code>. Preview at <code>/_sw/5173/</code>.
 					</div>
-					<div class="w-full rounded-lg overflow-hidden border border-tokyo-border p-2 bg-tokyo-bg flex-1">
-						<div id="terminal-vite-react-ts" class="w-full h-full"></div>
+					<div class="flex flex-col gap-2 flex-1 min-h-0">
+						<div class="h-2/5 min-h-0 rounded-lg overflow-hidden border border-tokyo-border p-2 bg-tokyo-bg">
+							<div id="terminal-vite-react-ts" class="w-full h-full"></div>
+						</div>
+						<div id="preview-vite-react-ts" class="flex flex-col flex-1 min-h-0"></div>
 					</div>
 				</div>
 
@@ -256,10 +264,29 @@
 					<div class="text-[13px] font-semibold text-tokyo-fg-bright mb-0.5">create-vite — 1:1, untouched</div>
 					<div class="text-[11px] text-tokyo-comment mb-3.5">Scaffold with the real
 						<code>npx create-vite@7.1.3 my-app --template react</code> and run it with its own
-						<code>vite.config.js</code> — no Lifo-specific changes
+						<code>vite.config.js</code> — preview at <code>/_sw/5173/</code>.
 					</div>
-					<div class="w-full rounded-lg overflow-hidden border border-tokyo-border p-2 bg-tokyo-bg flex-1">
-						<div id="terminal-create-vite" class="w-full h-full"></div>
+					<div class="flex flex-col gap-2 flex-1 min-h-0">
+						<div class="h-2/5 min-h-0 rounded-lg overflow-hidden border border-tokyo-border p-2 bg-tokyo-bg">
+							<div id="terminal-create-vite" class="w-full h-full"></div>
+						</div>
+						<div id="preview-create-vite" class="flex flex-col flex-1 min-h-0"></div>
+					</div>
+				</div>
+
+				<!-- Supabase Todo (tinbase) -->
+				<div id="out-tinbase" class="output-panel">
+					<div class="text-[13px] font-semibold text-tokyo-fg-bright mb-0.5">Supabase Todo (tinbase)</div>
+					<div class="text-[11px] text-tokyo-comment mb-3.5">Local Supabase-style dev in Lifo:
+						<a href="https://tinbase.vercel.app" target="_blank" rel="noopener" class="text-tokyo-blue">tinbase</a>
+						runs as a server in the VM and a Vite + React + TS app talks to it via supabase-js —
+						<code>npm install && npm run backend & && npm run dev &</code>. React fast-refresh + persistent data.
+					</div>
+					<div class="flex flex-col gap-2 flex-1 min-h-0">
+						<div class="h-2/5 min-h-0 rounded-lg overflow-hidden border border-tokyo-border p-2 bg-tokyo-bg">
+							<div id="terminal-tinbase" class="w-full h-full"></div>
+						</div>
+						<div id="preview-tinbase" class="flex flex-col flex-1 min-h-0"></div>
 					</div>
 				</div>
 

--- a/apps/playground/public/sw.js
+++ b/apps/playground/public/sw.js
@@ -1,0 +1,326 @@
+/**
+ * Lifo service-worker transport — Phase 1 (HTTP).
+ *
+ * Routes requests into the in-page VM (portRegistry) via a MessageChannel to
+ * the controlling playground tab, as a zero-setup alternative to the tunnel
+ * relay.
+ *
+ * Routing principle: the /_sw/<port>/ prefix exists ONLY as the entry
+ * navigation. Everything after that is routed by REQUESTER (client), not by
+ * URL shape — so apps keep using absolute paths (/src/main.jsx) unmodified
+ * and never see the prefix. Requests from unmapped clients (the playground
+ * itself) pass through to the network untouched.
+ */
+
+const SW_PREFIX = /^\/_sw\/(\d+)(\/.*)?$/;
+const REQUEST_TIMEOUT_MS = 30000;
+
+/** MessagePort to the VM host page (last connected tab wins, like the relay). */
+let hostPort = null;
+/** requestId → { resolve, timer } */
+const pending = new Map();
+/** clientId → virtual port */
+const clientPorts = new Map();
+/** connId → clientId, for routing WebSocket messages back to the app client */
+const wsConnClient = new Map();
+
+/**
+ * Injected into every VM-served HTML page. Replaces same-origin WebSocket with
+ * a shim that tunnels through the service worker → host page → in-VM ws server
+ * (Vite HMR). WebSockets can't be intercepted by a SW's fetch handler, so the
+ * app's own WebSocket constructor is what we must stand in for. Runs as a
+ * classic inline script so it executes before Vite's deferred module scripts.
+ */
+const WS_SHIM = `(function(){
+  var sw = navigator.serviceWorker;
+  if (!sw || !sw.controller) return;
+  var OrigWS = window.WebSocket;
+  var conns = new Map();
+  var seq = 0;
+  function b64enc(u8){var s='';for(var i=0;i<u8.length;i++)s+=String.fromCharCode(u8[i]);return btoa(s);}
+  function b64dec(b){var s=atob(b),u=new Uint8Array(s.length);for(var i=0;i<s.length;i++)u[i]=s.charCodeAt(i);return u;}
+  sw.addEventListener('message', function(e){
+    var m = e.data||{}; if(!m.connId) return;
+    var c = conns.get(m.connId); if(!c) return;
+    if(m.type==='ws-opened') c.__open();
+    else if(m.type==='ws-message') c.__msg(m.data, m.binary);
+    else if(m.type==='ws-close'){ conns.delete(m.connId); c.__close(1006,''); }
+  });
+  function LifoWebSocket(url, protocols){
+    var u; try{ u = new URL(url, location.href); }catch(_){ return new OrigWS(url, protocols); }
+    // WebSocket URLs use ws:/wss: schemes, so URL.origin never equals the
+    // page's http(s) origin — compare host + scheme instead. Only same-host
+    // ws(s) connections tunnel through the SW; anything else stays native.
+    var sameHost = u.host === location.host && (u.protocol === 'ws:' || u.protocol === 'wss:');
+    if(!sameHost) return new OrigWS(url, protocols);
+    var self = this;
+    this.url = u.href;
+    this.readyState = 0;
+    this.bufferedAmount = 0;
+    this.extensions = '';
+    this.protocol = Array.isArray(protocols)?(protocols[0]||''):(protocols||'');
+    this.binaryType = 'blob';
+    this.onopen=null; this.onmessage=null; this.onclose=null; this.onerror=null;
+    this._listeners = {open:[],message:[],close:[],error:[]};
+    this.connId = 'ws'+(seq++)+'-'+Math.random().toString(36).slice(2);
+    conns.set(this.connId, this);
+    navigator.serviceWorker.controller.postMessage({type:'ws-open',connId:this.connId,url:u.pathname+u.search,protocol:this.protocol});
+    this.__open=function(){ self.readyState=1; self.__emit('open',{}); };
+    this.__msg=function(b64,binary){
+      var data;
+      if(binary){ var buf=b64dec(b64).buffer; data = self.binaryType==='arraybuffer'?buf:new Blob([buf]); }
+      else { data = new TextDecoder().decode(b64dec(b64)); }
+      self.__emit('message',{data:data});
+    };
+    this.__close=function(code,reason){ if(self.readyState===3)return; self.readyState=3; self.__emit('close',{code:code||1000,reason:reason||'',wasClean:code===1000}); };
+    this.__emit=function(type,init){
+      var ev;
+      try{ ev = type==='message'?new MessageEvent('message',init):new (type==='close'?CloseEvent:Event)(type,init); }
+      catch(_){ ev={type:type}; for(var k in init) ev[k]=init[k]; }
+      var h=self['on'+type]; if(h) try{h.call(self,ev);}catch(_){}
+      self._listeners[type].forEach(function(fn){ try{fn.call(self,ev);}catch(_){} });
+    };
+  }
+  LifoWebSocket.prototype.send=function(data){
+    var u8;
+    if(typeof data==='string') u8=new TextEncoder().encode(data);
+    else if(data instanceof ArrayBuffer) u8=new Uint8Array(data);
+    else if(ArrayBuffer.isView(data)) u8=new Uint8Array(data.buffer,data.byteOffset,data.byteLength);
+    else u8=new TextEncoder().encode(String(data));
+    navigator.serviceWorker.controller.postMessage({type:'ws-send',connId:this.connId,data:b64enc(u8),binary:typeof data!=='string'});
+  };
+  LifoWebSocket.prototype.close=function(code,reason){
+    if(this.readyState>=2)return; this.readyState=2;
+    navigator.serviceWorker.controller.postMessage({type:'ws-close',connId:this.connId});
+    this.__close(code||1000,reason||'');
+  };
+  LifoWebSocket.prototype.addEventListener=function(t,fn){ if(this._listeners[t]) this._listeners[t].push(fn); };
+  LifoWebSocket.prototype.removeEventListener=function(t,fn){ if(this._listeners[t]){var i=this._listeners[t].indexOf(fn); if(i>=0)this._listeners[t].splice(i,1);} };
+  LifoWebSocket.prototype.dispatchEvent=function(){ return true; };
+  LifoWebSocket.CONNECTING=0; LifoWebSocket.OPEN=1; LifoWebSocket.CLOSING=2; LifoWebSocket.CLOSED=3;
+  window.WebSocket = LifoWebSocket;
+})();`;
+
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));
+
+async function routeToClient(connId, msg) {
+	const clientId = wsConnClient.get(connId);
+	if (!clientId) return;
+	const client = await self.clients.get(clientId);
+	if (client) client.postMessage(msg);
+	if (msg.type === 'ws-close') wsConnClient.delete(connId);
+}
+
+self.addEventListener('message', (event) => {
+	const data = event.data || {};
+
+	if (data.type === 'lifo-connect' && event.ports && event.ports[0]) {
+		if (hostPort) {
+			try { hostPort.close(); } catch { /* already closed */ }
+		}
+		hostPort = event.ports[0];
+		hostPort.onmessage = (ev) => {
+			const msg = ev.data || {};
+			if (msg.type === 'response') {
+				const entry = pending.get(msg.requestId);
+				if (entry) {
+					pending.delete(msg.requestId);
+					clearTimeout(entry.timer);
+					entry.resolve(msg);
+				}
+			} else if (msg.type === 'ws-opened' || msg.type === 'ws-message' || msg.type === 'ws-close') {
+				void routeToClient(msg.connId, msg);
+			}
+		};
+		hostPort.postMessage({ type: 'lifo-connected' });
+		return;
+	}
+
+	// WebSocket messages from an app client's shim → forward to the host bridge,
+	// tagged with the client's virtual port.
+	if (data.type === 'ws-open' && event.source) {
+		const client = event.source;
+		void (async () => {
+			// An explicit /_sw/<port>/ in the ws URL targets that port (e.g. a
+			// realtime socket to a sibling backend). Otherwise the socket belongs
+			// to the client's own app port.
+			const prefixMatch = data.url.match(SW_PREFIX);
+			let port = prefixMatch ? parseInt(prefixMatch[1], 10) : clientPorts.get(client.id);
+			if (port == null) {
+				// SW may have restarted — re-derive the client's port from its URL.
+				const m = new URL(client.url).pathname.match(SW_PREFIX);
+				if (m) { port = parseInt(m[1], 10); clientPorts.set(client.id, port); }
+			}
+			if (port == null || !(await ensureHost())) {
+				client.postMessage({ type: 'ws-close', connId: data.connId });
+				return;
+			}
+			wsConnClient.set(data.connId, client.id);
+			const clean = data.url.replace(SW_PREFIX, (_m, _p, rest) => rest || '/');
+			hostPort.postMessage({ type: 'ws-open', connId: data.connId, port, url: clean, protocol: data.protocol });
+		})();
+		return;
+	}
+	if ((data.type === 'ws-send' || data.type === 'ws-close') && data.connId) {
+		if (hostPort) hostPort.postMessage(data);
+		if (data.type === 'ws-close') wsConnClient.delete(data.connId);
+		return;
+	}
+});
+
+function bufToB64(buf) {
+	const bytes = new Uint8Array(buf);
+	let bin = '';
+	for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+	return btoa(bin);
+}
+
+function b64ToBuf(b64) {
+	const bin = atob(b64);
+	const bytes = new Uint8Array(bin.length);
+	for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+	return bytes;
+}
+
+/**
+ * Ensure a host page is connected. The SW may have just been revived from
+ * idle-termination with no hostPort — ask window clients (the playground tab)
+ * to re-announce, and wait briefly for the reconnect.
+ */
+async function ensureHost(timeoutMs = 5000) {
+	if (hostPort) return true;
+	const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+	for (const c of clients) c.postMessage({ type: 'lifo-need-host' });
+	const deadline = Date.now() + timeoutMs;
+	while (!hostPort && Date.now() < deadline) {
+		await new Promise((r) => setTimeout(r, 40));
+	}
+	return !!hostPort;
+}
+
+function vmRequest(port, path, request, bodyB64) {
+	return new Promise((resolve) => {
+		if (!hostPort) { resolve(null); return; }
+		const requestId = Math.random().toString(36).slice(2) + Date.now().toString(36);
+		const timer = setTimeout(() => {
+			pending.delete(requestId);
+			resolve(null);
+		}, REQUEST_TIMEOUT_MS);
+		pending.set(requestId, { resolve, timer });
+		const headers = {};
+		for (const [k, v] of request.headers.entries()) headers[k] = v;
+		hostPort.postMessage({
+			type: 'request',
+			requestId,
+			port,
+			method: request.method,
+			url: path,
+			headers,
+			body: bodyB64,
+		});
+	});
+}
+
+// Hop-by-hop / response-forbidden headers we must not replay
+const STRIP_HEADERS = new Set(['set-cookie', 'content-encoding', 'content-length', 'transfer-encoding', 'connection', 'keep-alive']);
+
+async function serveFromVm(event, port, path) {
+	let bodyB64 = '';
+	if (event.request.method !== 'GET' && event.request.method !== 'HEAD') {
+		bodyB64 = bufToB64(await event.request.arrayBuffer());
+	}
+	if (!hostPort) await ensureHost();
+	const res = await vmRequest(port, path, event.request, bodyB64);
+	if (!res) {
+		return new Response(
+			'Lifo VM is not connected. Keep the playground tab open (it hosts the virtual machine), then reload.',
+			{ status: 503, headers: { 'content-type': 'text/plain' } },
+		);
+	}
+	const headers = {};
+	let contentType = '';
+	for (const [k, v] of Object.entries(res.headers || {})) {
+		if (STRIP_HEADERS.has(k.toLowerCase())) continue;
+		headers[k] = v;
+		if (k.toLowerCase() === 'content-type') contentType = String(v).toLowerCase();
+	}
+
+	// The body arrives as a transferred ArrayBuffer (bodyBuffer) — zero-copy,
+	// binary-safe. Older bridges may still send base64 `body`.
+	let bodyBuf = res.bodyBuffer instanceof ArrayBuffer
+		? new Uint8Array(res.bodyBuffer)
+		: (res.body ? b64ToBuf(res.body) : null);
+
+	// Inject the WebSocket shim into HTML documents so the app's HMR socket
+	// (and any same-origin WebSocket) tunnels through the SW. The app on disk
+	// is never touched — this is a proxy-level seam, like the relay's byte pipe.
+	if (contentType.includes('text/html') && bodyBuf) {
+		let html = new TextDecoder().decode(bodyBuf);
+		const tag = `<script>${WS_SHIM}</script>`;
+		const headIdx = html.indexOf('<head>');
+		html = headIdx !== -1
+			? html.slice(0, headIdx + 6) + tag + html.slice(headIdx + 6)
+			: tag + html;
+		delete headers['Content-Length'];
+		delete headers['content-length'];
+		return new Response(html, { status: res.statusCode || 200, headers });
+	}
+
+	return new Response(bodyBuf, { status: res.statusCode || 200, headers });
+}
+
+async function portForRequest(event) {
+	// Subresources: the requesting client determines the app.
+	if (event.clientId) {
+		if (clientPorts.has(event.clientId)) return clientPorts.get(event.clientId);
+		// SW may have restarted and lost the map — re-derive from the client URL.
+		const client = await self.clients.get(event.clientId);
+		if (client) {
+			const m = new URL(client.url).pathname.match(SW_PREFIX);
+			if (m) {
+				const port = parseInt(m[1], 10);
+				clientPorts.set(event.clientId, port);
+				return port;
+			}
+		}
+		return null;
+	}
+	// Navigations carry no clientId — resolve via the referrer.
+	if (event.request.mode === 'navigate' && event.request.referrer) {
+		let ref;
+		try { ref = new URL(event.request.referrer); } catch { return null; }
+		if (ref.origin !== self.location.origin) return null;
+		const m = ref.pathname.match(SW_PREFIX);
+		if (m) return parseInt(m[1], 10);
+		const all = await self.clients.matchAll({ type: 'window' });
+		const refClient = all.find((c) => c.url === event.request.referrer);
+		if (refClient && clientPorts.has(refClient.id)) return clientPorts.get(refClient.id);
+	}
+	return null;
+}
+
+self.addEventListener('fetch', (event) => {
+	const url = new URL(event.request.url);
+	if (url.origin !== self.location.origin) return;
+
+	// Entry point: /_sw/<port>/... → strip prefix, map the resulting document.
+	const m = url.pathname.match(SW_PREFIX);
+	if (m) {
+		const port = parseInt(m[1], 10);
+		const path = (m[2] || '/') + url.search;
+		if (event.resultingClientId) clientPorts.set(event.resultingClientId, port);
+		event.respondWith(serveFromVm(event, port, path));
+		return;
+	}
+
+	// Client-based routing: app clients get the VM, everyone else the network.
+	event.respondWith((async () => {
+		const port = await portForRequest(event);
+		if (port == null) return fetch(event.request);
+		if (event.request.mode === 'navigate' && event.resultingClientId) {
+			clientPorts.set(event.resultingClientId, port);
+		}
+		return serveFromVm(event, port, url.pathname + url.search);
+	})());
+});

--- a/apps/playground/src/main.ts
+++ b/apps/playground/src/main.ts
@@ -12,6 +12,7 @@ declare global {
 }
 import {
 	Sandbox,
+	ServiceWorkerBridge,
 	Kernel,
 	Shell,
 	createDefaultRegistry,
@@ -374,6 +375,14 @@ $ <span class="code-fn">npx</span> <span class="code-string">lifo-sh</span> <spa
 user@lifo:/mnt/host$ <span class="code-fn">ls</span>
   package.json  src/  README.md
 
+<span class="code-comment">// Expose an in-VM server to your real browser.</span>
+<span class="code-comment">// The CLI has no service worker, so it tunnels</span>
+<span class="code-comment">// through a relay instead:</span>
+$ <span class="code-fn">npx</span> <span class="code-string">lifo-sh tunnel</span> <span class="code-string">5173</span>
+<span class="code-comment">// → serves the VM's port 5173 at http://localhost:3005</span>
+<span class="code-comment">// (in the browser playground you don't need this —</span>
+<span class="code-comment">//  the service worker serves /_sw/5173/ directly)</span>
+
 <span class="code-comment">// All changes go directly to disk</span>
 user@lifo:/mnt/host$ <span class="code-fn">echo</span> <span class="code-string">"hello"</span> > test.txt
 <span class="code-comment">// test.txt now exists on your real FS!</span>
@@ -400,46 +409,67 @@ sandbox.kernel.vfs.<span class="code-fn">mount</span>(
 
 const CODE_VITE_REACT = `\
 <span class="code-comment"># A real Vite dev server with React fast-refresh,</span>
-<span class="code-comment"># running entirely in your browser.</span>
-<span class="code-comment"># Prereq on the host: node apps/tunnel-server/server.js</span>
+<span class="code-comment"># running entirely in your browser — no host process.</span>
 
 <span class="code-fn">cd</span> react-app
 <span class="code-fn">npm</span> install          <span class="code-comment"># real npm registry, in-browser</span>
 <span class="code-fn">npm</span> run dev &        <span class="code-comment"># vite on virtual port 5173</span>
 
-<span class="code-comment"># open http://localhost:3005 in a new browser tab, then:</span>
-<span class="code-fn">sed</span> -i <span class="code-string">'s/React inside Lifo/Hello HMR/'</span> src/App.jsx
+<span class="code-comment"># the preview pane (below the terminal) is an iframe</span>
+<span class="code-comment"># pointed at /_sw/5173/ — served by a service worker</span>
+<span class="code-comment"># straight from the VM. Click "Reload" once vite is up.</span>
 
-<span class="code-comment"># the page hot-updates via react-refresh —</span>
+<span class="code-fn">sed</span> -i <span class="code-string">'s/React inside Lifo/Hello HMR/'</span> src/App.jsx
+<span class="code-comment"># the preview hot-updates via react-refresh —</span>
 <span class="code-comment"># click the counter first and watch state survive</span>`;
 
 const CODE_VITE_REACT_TS = `\
 <span class="code-comment"># Vite + React + TypeScript, same stack as the JS</span>
-<span class="code-comment"># example: tsx transforms, fast-refresh, tunnel serving.</span>
-<span class="code-comment"># Prereq on the host: node apps/tunnel-server/server.js</span>
+<span class="code-comment"># example: tsx transforms, fast-refresh, all in-browser.</span>
 
 <span class="code-fn">cd</span> react-ts-app
 <span class="code-fn">npm</span> install
 <span class="code-fn">npm</span> run dev &
 
-<span class="code-comment"># open http://localhost:3005 in a new browser tab, then:</span>
+<span class="code-comment"># preview pane → /_sw/5173/ (service-worker transport)</span>
 <span class="code-fn">sed</span> -i <span class="code-string">'s/React inside Lifo/Hello HMR/'</span> src/App.tsx`;
 
 const CODE_CREATE_VITE = `\
 <span class="code-comment"># Prove it's the real Vite: scaffold an untouched app</span>
 <span class="code-comment"># with create-vite and run it 1:1 — its own vite.config.js,</span>
 <span class="code-comment"># its own scripts, zero Lifo-specific changes.</span>
-<span class="code-comment"># Prereq on the host: node apps/tunnel-server/server.js</span>
 
 <span class="code-fn">npx</span> create-vite@7.1.3 my-app --template react
 <span class="code-fn">cd</span> my-app
 <span class="code-fn">npm</span> install
 <span class="code-fn">npm</span> run dev &
 
-<span class="code-comment"># open http://localhost:3005 — the scaffolded app served</span>
-<span class="code-comment"># by unmodified Vite from inside your browser, HMR and</span>
-<span class="code-comment"># all: the browser speaks real WebSocket frames to the</span>
-<span class="code-comment"># ws server running inside the VM.</span>`;
+<span class="code-comment"># the preview pane loads /_sw/5173/ — the scaffolded</span>
+<span class="code-comment"># app served by unmodified Vite from inside your browser,</span>
+<span class="code-comment"># HMR and all, with no host process. The service worker</span>
+<span class="code-comment"># tunnels HTTP + WebSocket frames to the in-VM server.</span>`;
+
+const CODE_TINBASE = `\
+<span class="code-comment"># Local Supabase-style dev, entirely in Lifo: tinbase</span>
+<span class="code-comment"># (tinbase.vercel.app) runs as a server IN the VM, and a</span>
+<span class="code-comment"># Vite + React + TS app talks to it via supabase-js.</span>
+
+<span class="code-fn">cd</span> tinbase-todo
+<span class="code-fn">npm</span> install
+<span class="code-fn">npm</span> run backend &   <span class="code-comment"># tinbase on :54321 (like supabase start)</span>
+<span class="code-fn">npm</span> run dev &       <span class="code-comment"># vite + react on :5173</span>
+
+<span class="code-comment"># .env — just like a real Supabase project:</span>
+<span class="code-comment">#   VITE_SUPABASE_URL=/_sw/54321</span>
+<span class="code-comment">#   VITE_SUPABASE_ANON_KEY=eyJhbGci...</span>
+
+<span class="code-keyword">const</span> supabase = <span class="code-fn">createClient</span>(url, anonKey)
+<span class="code-keyword">await</span> supabase.<span class="code-fn">from</span>(<span class="code-string">'todos'</span>).<span class="code-fn">insert</span>({ title })
+
+<span class="code-comment"># test HMR: edit the heading, keep your typed input —</span>
+<span class="code-fn">sed</span> -i <span class="code-string">'s/📝 Todos/✅ My Tasks/'</span> src/App.tsx
+<span class="code-comment"># react-refresh hot-updates the preview, state intact;</span>
+<span class="code-comment"># todos persist too (they live in the backend process).</span>`;
 
 const CODE_PGLITE = `\
 <span class="code-comment"># PostgreSQL compiled to wasm (PGlite), running in the VM</span>
@@ -472,12 +502,13 @@ const codeSnippets: Record<string, string> = {
 	'vite-react': CODE_VITE_REACT,
 	'vite-react-ts': CODE_VITE_REACT_TS,
 	'create-vite': CODE_CREATE_VITE,
+	tinbase: CODE_TINBASE,
 	pglite: CODE_PGLITE,
 };
 
 // ─── State ───
 
-type ExampleId = 'interactive' | 'headless' | 'multi' | 'http' | 'explorer' | 'git' | 'ffmpeg' | 'npm' | 'cli' | 'lifo-pkg' | 'build-pkg' | 'vite-react' | 'vite-react-ts' | 'create-vite' | 'pglite';
+type ExampleId = 'interactive' | 'headless' | 'multi' | 'http' | 'explorer' | 'git' | 'ffmpeg' | 'npm' | 'cli' | 'lifo-pkg' | 'build-pkg' | 'vite-react' | 'vite-react-ts' | 'create-vite' | 'tinbase' | 'pglite';
 
 const examples: Record<ExampleId, { booted: boolean; boot: () => Promise<void> }> = {
 	interactive: { booted: false, boot: bootInteractive },
@@ -494,6 +525,7 @@ const examples: Record<ExampleId, { booted: boolean; boot: () => Promise<void> }
 	'vite-react': { booted: false, boot: bootViteReact },
 	'vite-react-ts': { booted: false, boot: bootViteReactTs },
 	'create-vite': { booted: false, boot: bootCreateVite },
+	tinbase: { booted: false, boot: bootTinbase },
 	pglite: { booted: false, boot: bootPglite },
 };
 
@@ -2007,6 +2039,223 @@ export default function App() {
 	return files;
 }
 
+// The well-known local anon key tinbase generates with its default JWT secret
+// (fixed iat, so it's stable across boots — like Supabase's local dev anon key).
+const TINBASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRpbmJhc2UiLCJyb2xlIjoiYW5vbiIsImlhdCI6MTc4MzI3MzU0OSwiZXhwIjoyMDk4NjMzNTQ5fQ.yaaSYTyy2tRkx1myq06zU1ieZiWeJyq_hAZk2qCZEmk';
+
+/**
+ * Vite + TypeScript todo app talking to the tinbase backend
+ * (tinbase.vercel.app — a Supabase-compatible backend) via @supabase/supabase-js.
+ *
+ * This mirrors real Supabase local development: tinbase runs as an HTTP server
+ * INSIDE the Lifo VM (`npm run backend`, like `supabase start`) with Postgres
+ * (PGlite/wasm) living in the VM; the Vite app talks to it over HTTP with
+ * standard supabase-js. Because the backend is a separate process, data
+ * persists across app reloads (until the server is stopped).
+ *
+ * The browser reaches the in-VM backend through the service worker at
+ * /_sw/54321 — configured in .env, exactly where a Supabase URL normally lives.
+ */
+function tinbaseTodoAppFiles(root: string): Record<string, string> {
+	const files: Record<string, string> = {};
+
+	files[`${root}/package.json`] = JSON.stringify({
+		name: 'tinbase-todo', version: '1.0.0', type: 'module',
+		scripts: {
+			backend: 'node server.mjs',
+			dev: 'vite',
+			build: 'vite build',
+		},
+		dependencies: {
+			vite: '^7.3.1',
+			typescript: '~5.9.3',
+			react: '^18.3.1',
+			'react-dom': '^18.3.1',
+			'@vitejs/plugin-react': '^5.0.0',
+			'@types/react': '^18.3.12',
+			'@types/react-dom': '^18.3.1',
+			tinbase: '^0.1.0',
+			'@supabase/supabase-js': '^2.110.0',
+		},
+	}, null, 2);
+
+	// The backend: tinbase's fetch handler wrapped in a node http server, run
+	// inside the VM on port 54321. PGlite (Postgres/wasm) runs here in the VM,
+	// so only JSON crosses the service worker — not the ~16MB wasm.
+	files[`${root}/server.mjs`] = `import { createBackend } from 'tinbase'
+import http from 'node:http'
+
+const backend = await createBackend({
+  migrations: [{
+    name: '20240101000000_todos',
+    sql: \`create table if not exists todos (
+      id bigint generated always as identity primary key,
+      title text not null,
+      done boolean not null default false,
+      created_at timestamptz not null default now()
+    );\`,
+  }],
+})
+
+// tinbase is a (Request) => Response handler; expose it over HTTP.
+const server = http.createServer((req, res) => {
+  let body = ''
+  req.on('data', (c) => { body += c })
+  req.on('end', async () => {
+    try {
+      const url = 'http://localhost:54321' + req.url
+      const hasBody = req.method !== 'GET' && req.method !== 'HEAD' && body.length > 0
+      const request = new Request(url, { method: req.method, headers: req.headers, body: hasBody ? body : undefined })
+      const response = await backend.fetch(request)
+      const buf = new Uint8Array(await response.arrayBuffer())
+      const headers = {}
+      response.headers.forEach((v, k) => { headers[k] = v })
+      res.writeHead(response.status, headers)
+      res.end(buf)
+    } catch (e) {
+      res.writeHead(500, { 'content-type': 'text/plain' })
+      res.end('server error: ' + (e && e.message))
+    }
+  })
+})
+
+server.listen(54321, () => {
+  console.log('tinbase running on port 54321 (like supabase start)')
+  console.log('data persists while this server is running')
+})
+`;
+
+	files[`${root}/vite.config.ts`] = `import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})
+`;
+
+	files[`${root}/tsconfig.json`] = JSON.stringify({
+		compilerOptions: {
+			target: 'ES2022', module: 'ESNext', moduleResolution: 'bundler',
+			jsx: 'react-jsx',
+			strict: true, noEmit: true, lib: ['ES2022', 'DOM', 'DOM.Iterable'],
+			types: ['vite/client'],
+		},
+		include: ['src'],
+	}, null, 2);
+
+	// Standard Supabase config lives in .env — the only Lifo-specific bit is the
+	// URL path (/_sw/54321), which the service worker routes to the in-VM server.
+	files[`${root}/.env`] = `VITE_SUPABASE_URL=/_sw/54321\nVITE_SUPABASE_ANON_KEY=${TINBASE_ANON_KEY}\n`;
+
+	files[`${root}/index.html`] = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Todos · tinbase in Lifo</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 32rem; margin: 3rem auto; padding: 0 1rem; color: #1a1a2e; }
+    h1 { font-size: 1.4rem; } .sub { color: #6b7280; font-size: .85rem; margin-top: -.6rem; }
+    form { display: flex; gap: .5rem; margin: 1.25rem 0; }
+    input[type=text] { flex: 1; padding: .55rem .7rem; border: 1px solid #d1d5db; border-radius: 8px; font-size: 1rem; }
+    button { padding: .55rem .9rem; border: none; border-radius: 8px; background: #3ecf8e; color: #05291b; font-weight: 600; cursor: pointer; }
+    ul { list-style: none; padding: 0; } li { display: flex; align-items: center; gap: .6rem; padding: .5rem .2rem; border-bottom: 1px solid #eee; }
+    li.done span { text-decoration: line-through; color: #9ca3af; } li span { flex: 1; }
+    .del { background: transparent; color: #ef4444; font-weight: 700; padding: .2rem .5rem; }
+    #status { font-size: .8rem; color: #6b7280; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>`;
+
+	files[`${root}/src/supabase.ts`] = `import { createClient } from '@supabase/supabase-js'
+
+// Standard supabase-js against the tinbase server running in the Lifo VM.
+// The URL + anon key come from .env, exactly like a real Supabase project;
+// the URL is resolved to an absolute one so the service worker can route it.
+const url = new URL(import.meta.env.VITE_SUPABASE_URL, location.origin).href
+export const supabase = createClient(url, import.meta.env.VITE_SUPABASE_ANON_KEY, {
+  auth: { persistSession: false, autoRefreshToken: false },
+})
+`;
+
+	files[`${root}/src/main.tsx`] = `import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { App } from './App'
+
+createRoot(document.getElementById('root')!).render(<App />)
+`;
+
+	files[`${root}/src/App.tsx`] = `import { useEffect, useState } from 'react'
+import { supabase } from './supabase'
+
+interface Todo { id: number; title: string; done: boolean }
+
+export function App() {
+  const [todos, setTodos] = useState<Todo[]>([])
+  const [title, setTitle] = useState('')
+  const [status, setStatus] = useState('connecting…')
+
+  async function refresh() {
+    const { data, error } = await supabase.from('todos').select('*').order('id')
+    if (error) {
+      setStatus('Cannot reach backend: ' + error.message + ' — did you run "npm run backend &"?')
+      return
+    }
+    setTodos((data ?? []) as Todo[])
+    setStatus((data?.length ?? 0) + ' todo(s) · tinbase (Postgres) in the Lifo VM — persists across app reloads')
+  }
+
+  useEffect(() => { refresh() }, [])
+
+  async function add(e: React.FormEvent) {
+    e.preventDefault()
+    const t = title.trim()
+    if (!t) return
+    setTitle('')
+    await supabase.from('todos').insert({ title: t })
+    refresh()
+  }
+
+  async function toggle(todo: Todo) {
+    await supabase.from('todos').update({ done: !todo.done }).eq('id', todo.id)
+    refresh()
+  }
+
+  async function remove(todo: Todo) {
+    await supabase.from('todos').delete().eq('id', todo.id)
+    refresh()
+  }
+
+  return (
+    <>
+      <h1>📝 Todos</h1>
+      <p className="sub">Vite + React + TypeScript · supabase-js → tinbase server running in Lifo</p>
+      <form onSubmit={add}>
+        <input type="text" placeholder="What needs doing?" value={title} onChange={(e) => setTitle(e.target.value)} />
+        <button>Add</button>
+      </form>
+      <ul>
+        {todos.map((t) => (
+          <li key={t.id} className={t.done ? 'done' : ''}>
+            <input type="checkbox" checked={t.done} onChange={() => toggle(t)} />
+            <span>{t.title}</span>
+            <button className="del" onClick={() => remove(t)}>✕</button>
+          </li>
+        ))}
+      </ul>
+      <p id="status">{status}</p>
+    </>
+  )
+}
+`;
+
+	return files;
+}
+
 function pgliteFiles(root: string): Record<string, string> {
 	return {
 		[`${root}/package.json`]: JSON.stringify({
@@ -2046,39 +2295,113 @@ console.log('ALL TESTS PASSED ✅');
 	};
 }
 
-async function bootProjectExample(id: string, files: Record<string, string>, cwd: string, withTunnel: boolean): Promise<void> {
+/**
+ * A minimal browser chrome (address bar, reload, open-in-new-tab) wrapping an
+ * iframe pointed at /_sw/<port>/. The iframe is a SW-controlled client, so its
+ * requests route into the VM; HMR flows through the WebSocket shim.
+ */
+function createPreviewBrowser(port: number): HTMLElement {
+	const path = `/_sw/${port}/`;
+	const wrap = document.createElement('div');
+	wrap.className = 'flex flex-col flex-1 min-h-0 rounded-lg overflow-hidden border border-tokyo-border bg-tokyo-bg';
+
+	const bar = document.createElement('div');
+	bar.className = 'flex items-center gap-2 px-2 py-1.5 border-b border-tokyo-border bg-tokyo-bg-dark';
+
+	const reloadBtn = document.createElement('button');
+	reloadBtn.textContent = '↻';
+	reloadBtn.title = 'Reload preview';
+	reloadBtn.className = 'shrink-0 w-6 h-6 rounded bg-tokyo-hover text-tokyo-muted hover:text-tokyo-fg-bright border-none cursor-pointer';
+
+	const urlBox = document.createElement('div');
+	urlBox.className = 'flex-1 px-2.5 py-1 rounded bg-tokyo-bg text-[11px] font-code text-tokyo-comment truncate';
+	urlBox.textContent = location.origin + path;
+
+	const openBtn = document.createElement('a');
+	openBtn.textContent = '⧉';
+	openBtn.title = 'Open in new tab';
+	openBtn.href = path;
+	openBtn.target = '_blank';
+	openBtn.rel = 'noopener';
+	openBtn.className = 'shrink-0 w-6 h-6 grid place-items-center rounded bg-tokyo-hover text-tokyo-muted hover:text-tokyo-fg-bright no-underline';
+
+	bar.append(reloadBtn, urlBox, openBtn);
+
+	const iframe = document.createElement('iframe');
+	iframe.className = 'flex-1 min-h-0 w-full bg-white border-none';
+	iframe.title = 'Vite preview';
+	const load = () => { iframe.src = path + '?_t=' + Date.now(); };
+	reloadBtn.addEventListener('click', load);
+	load();
+
+	wrap.append(bar, iframe);
+	return wrap;
+}
+
+interface ProjectExampleOpts {
+	id: string;
+	files: Record<string, string>;
+	cwd: string;
+	/** Virtual port to mount an iframe preview browser for (server examples). */
+	previewPort?: number;
+}
+
+async function bootProjectExample(opts: ProjectExampleOpts): Promise<void> {
+	const { id, files, cwd, previewPort } = opts;
 	const sandbox = await Sandbox.create({
 		terminal: document.getElementById(`terminal-${id}`) as HTMLElement,
 		files: {
 			...files,
-			...(withTunnel ? { '/etc/systemd/system/tunnel.service': TUNNEL_SERVICE_UNIT } : {}),
+			...(previewPort ? { '/etc/systemd/system/tunnel.service': TUNNEL_SERVICE_UNIT } : {}),
 		},
 		cwd,
 	});
-	if (withTunnel && sandbox.kernel.serviceManager) {
+	if (previewPort && sandbox.kernel.serviceManager) {
+		// The tunnel service is optional (needs a host relay); the SW preview
+		// below is the zero-setup path. Enable but don't fail if the relay is down.
 		sandbox.kernel.serviceManager.enable('tunnel');
-		try {
-			await sandbox.kernel.serviceManager.start('tunnel');
-		} catch (error) {
-			console.warn(`[${id}] tunnel service failed to start (is the relay running on :3005?)`, error);
+		sandbox.kernel.serviceManager.start('tunnel').catch(() => {});
+	}
+
+	// Service-worker transport: serve /_sw/<port>/ with no host process.
+	// Last-booted example hosts it (like the relay's last-client-wins).
+	const swBridge = new ServiceWorkerBridge(sandbox.kernel.portRegistry);
+	const swReady = await swBridge.connect();
+
+	if (previewPort) {
+		const mount = document.getElementById(`preview-${id}`);
+		if (mount) {
+			mount.replaceChildren();
+			if (swReady) {
+				mount.appendChild(createPreviewBrowser(previewPort));
+			} else {
+				const note = document.createElement('div');
+				note.className = 'flex-1 grid place-items-center text-[12px] text-tokyo-comment text-center px-4';
+				note.textContent = 'Service worker unavailable in this browser — run the tunnel relay and open http://localhost:3005 instead.';
+				mount.appendChild(note);
+			}
 		}
 	}
 }
 
 async function bootViteReact() {
-	await bootProjectExample('vite-react', viteReactAppFiles('/home/user/react-app', false), '/home/user/react-app', true);
+	await bootProjectExample({ id: 'vite-react', files: viteReactAppFiles('/home/user/react-app', false), cwd: '/home/user/react-app', previewPort: 5173 });
 }
 
 async function bootViteReactTs() {
-	await bootProjectExample('vite-react-ts', viteReactAppFiles('/home/user/react-ts-app', true), '/home/user/react-ts-app', true);
+	await bootProjectExample({ id: 'vite-react-ts', files: viteReactAppFiles('/home/user/react-ts-app', true), cwd: '/home/user/react-ts-app', previewPort: 5173 });
 }
 
 async function bootCreateVite() {
-	await bootProjectExample('create-vite', {}, '/home/user', true);
+	await bootProjectExample({ id: 'create-vite', files: {}, cwd: '/home/user', previewPort: 5173 });
+}
+
+async function bootTinbase() {
+	await bootProjectExample({ id: 'tinbase', files: tinbaseTodoAppFiles('/home/user/tinbase-todo'), cwd: '/home/user/tinbase-todo', previewPort: 5173 });
 }
 
 async function bootPglite() {
-	await bootProjectExample('pglite', pgliteFiles('/home/user/pg-demo'), '/home/user/pg-demo', false);
+	await bootProjectExample({ id: 'pglite', files: pgliteFiles('/home/user/pg-demo'), cwd: '/home/user/pg-demo' });
 }
 
 // ─── Boot ───

--- a/apps/playground/tests/ws-shim.test.ts
+++ b/apps/playground/tests/ws-shim.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Extract the WS_SHIM source string from sw.js and evaluate it against mocked
+ * browser globals. The shim can't run in a real service worker headlessly, so
+ * this exercises its decision logic (which URLs to proxy) and message wiring —
+ * the parts a MessageChannel-only bridge test can't reach.
+ */
+const swSource = readFileSync(fileURLToPath(new URL('../public/sw.js', import.meta.url)), 'utf8');
+const shimMatch = swSource.match(/const WS_SHIM = `([\s\S]*?)`;/);
+const WS_SHIM = shimMatch![1];
+
+interface MockControllerMessage { type: string; connId?: string; [k: string]: unknown }
+
+function installShim(controllerPresent = true) {
+	const posted: MockControllerMessage[] = [];
+	const swListeners: Array<(e: { data: unknown }) => void> = [];
+	const controller = controllerPresent ? { postMessage: (m: MockControllerMessage) => posted.push(m) } : null;
+
+	const sandbox = {
+		navigator: {
+			serviceWorker: {
+				controller,
+				addEventListener: (type: string, fn: (e: { data: unknown }) => void) => {
+					if (type === 'message') swListeners.push(fn);
+				},
+			},
+		},
+		location: { href: 'http://localhost:5173/_sw/5173/', host: 'localhost:5173', origin: 'http://localhost:5173' },
+		window: {} as Record<string, unknown>,
+		URL,
+		Map,
+		Math,
+		TextEncoder,
+		TextDecoder,
+		btoa,
+		atob,
+		MessageEvent: globalThis.MessageEvent ?? class { type: string; data: unknown; constructor(t: string, i: { data: unknown }) { this.type = t; this.data = i.data; } },
+		Event: globalThis.Event ?? class { type: string; constructor(t: string) { this.type = t; } },
+		CloseEvent: (globalThis as { CloseEvent?: unknown }).CloseEvent ?? class { type: string; code: number; reason: string; constructor(t: string, i: { code: number; reason: string }) { this.type = t; this.code = i.code; this.reason = i.reason; } },
+		Blob: globalThis.Blob ?? class { constructor(public parts: unknown[]) {} },
+		ArrayBuffer,
+		Uint8Array,
+		OrigWS: class NativeWS { constructor(public url: string, public protocols?: unknown) {} },
+	};
+
+	// The shim captures `var OrigWS = window.WebSocket` — seed the native impl.
+	sandbox.window.WebSocket = sandbox.OrigWS;
+
+	// eslint-disable-next-line @typescript-eslint/no-implied-eval
+	new Function('navigator', 'location', 'window', 'URL', 'Map', 'Math', 'TextEncoder', 'TextDecoder', 'btoa', 'atob', 'MessageEvent', 'Event', 'CloseEvent', 'Blob', 'ArrayBuffer', 'Uint8Array',
+		`${WS_SHIM}`,
+	)(sandbox.navigator, sandbox.location, sandbox.window, sandbox.URL, sandbox.Map, sandbox.Math, sandbox.TextEncoder, sandbox.TextDecoder, sandbox.btoa, sandbox.atob, sandbox.MessageEvent, sandbox.Event, sandbox.CloseEvent, sandbox.Blob, sandbox.ArrayBuffer, sandbox.Uint8Array);
+
+	return {
+		WebSocket: sandbox.window.WebSocket as new (url: string, protocols?: unknown) => Record<string, unknown>,
+		posted,
+		deliverFromSw: (data: unknown) => swListeners.forEach((fn) => fn({ data })),
+		OrigWS: sandbox.OrigWS,
+	};
+}
+
+describe('ws-shim (service worker WebSocket replacement)', () => {
+	let env: ReturnType<typeof installShim>;
+	beforeEach(() => { env = installShim(); });
+
+	it('proxies same-host ws:// URLs (the Vite HMR socket) — not treated as cross-origin', () => {
+		const ws = new env.WebSocket('ws://localhost:5173/?token=abc', 'vite-hmr') as Record<string, unknown> & { connId: string };
+		// Must NOT be the native fallback
+		expect(ws instanceof (env.OrigWS as never)).toBe(false);
+		const open = env.posted.find((m) => m.type === 'ws-open');
+		expect(open).toBeTruthy();
+		expect(open!.url).toBe('/?token=abc');
+		expect(open!.protocol).toBe('vite-hmr');
+	});
+
+	it('leaves cross-host WebSockets on the native implementation', () => {
+		const ws = new env.WebSocket('wss://example.com/socket');
+		expect(ws instanceof (env.OrigWS as never)).toBe(true);
+		expect(env.posted.find((m) => m.type === 'ws-open')).toBeUndefined();
+	});
+
+	it('fires onopen when the SW reports ws-opened', () => {
+		const ws = new env.WebSocket('ws://localhost:5173/') as Record<string, unknown> & { connId: string; readyState: number };
+		let opened = false;
+		(ws as { onopen: () => void }).onopen = () => { opened = true; };
+		env.deliverFromSw({ type: 'ws-opened', connId: ws.connId });
+		expect(opened).toBe(true);
+		expect(ws.readyState).toBe(1);
+	});
+
+	it('delivers text ws-message payloads to onmessage', () => {
+		const ws = new env.WebSocket('ws://localhost:5173/') as Record<string, unknown> & { connId: string };
+		let received: string | null = null;
+		(ws as { onmessage: (e: { data: string }) => void }).onmessage = (e) => { received = e.data; };
+		const payload = btoa(new TextDecoder().decode(new TextEncoder().encode(JSON.stringify({ type: 'update' }))));
+		env.deliverFromSw({ type: 'ws-message', connId: ws.connId, data: payload, binary: false });
+		expect(received).toBe(JSON.stringify({ type: 'update' }));
+	});
+
+	it('send() posts a base64 ws-send with the connId', () => {
+		const ws = new env.WebSocket('ws://localhost:5173/') as Record<string, unknown> & { connId: string; send: (d: string) => void };
+		ws.send(JSON.stringify({ type: 'ping' }));
+		const sent = env.posted.find((m) => m.type === 'ws-send');
+		expect(sent).toBeTruthy();
+		expect(sent!.connId).toBe(ws.connId);
+		expect(atob(sent!.data as string)).toBe(JSON.stringify({ type: 'ping' }));
+	});
+
+	it('falls back to native when no SW controller is present', () => {
+		const noCtrl = installShim(false);
+		// Shim bails early → window.WebSocket left as the native constructor
+		expect(noCtrl.WebSocket).toBe(noCtrl.OrigWS);
+	});
+});

--- a/packages/core/src/commands/net/curl.ts
+++ b/packages/core/src/commands/net/curl.ts
@@ -125,10 +125,14 @@ function createCurlImpl(kernel?: Kernel): Command {
 
           if (outputFile) {
             const path = resolve(ctx.cwd, outputFile);
-            ctx.vfs.writeFile(path, body);
+            // Write raw bytes when available so binary downloads (wasm, images)
+            // aren't corrupted by the text view.
+            const bytes = vRes.bodyBytes;
+            ctx.vfs.writeFile(path, bytes ?? body);
+            const len = bytes ? bytes.length : body.length;
             if (!silent) {
               ctx.stderr.write(`  % Total    % Received\n`);
-              ctx.stderr.write(`  ${body.length}    ${body.length}\n`);
+              ctx.stderr.write(`  ${len}    ${len}\n`);
             }
           } else {
             ctx.stdout.write(body);

--- a/packages/core/src/commands/system/node.ts
+++ b/packages/core/src/commands/system/node.ts
@@ -924,25 +924,30 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 				try {
 					const stat = ctx.vfs.stat(absPath);
 					if (stat.type === 'file') return { path: absPath };
-					// Directory -- try index.js
-					const indexPath = join(absPath, 'index.js');
-					if (ctx.vfs.exists(indexPath)) return { path: indexPath };
+					// Directory -- try package.json main, then index.*
+					const pkgPath = join(absPath, 'package.json');
+					if (ctx.vfs.exists(pkgPath)) {
+						try {
+							const pkg = JSON.parse(ctx.vfs.readFileString(pkgPath));
+							const main = typeof pkg.module === 'string' ? pkg.module : (typeof pkg.main === 'string' ? pkg.main : null);
+							if (main) {
+								const mainResolved = resolveVfsModule('./' + main, absPath);
+								if (mainResolved) return mainResolved;
+							}
+						} catch { /* fall through to index */ }
+					}
+					for (const ext of ['.js', '.mjs', '.cjs', '.json']) {
+						const indexPath = join(absPath, 'index' + ext);
+						if (ctx.vfs.exists(indexPath)) return { path: indexPath };
+					}
 				} catch { /* fall through */ }
 			}
 
-			// Try .js extension
-			if (!extname(absPath) && ctx.vfs.exists(absPath + '.js')) {
-				return { path: absPath + '.js' };
-			}
-
-			// Try .mjs extension
-			if (!extname(absPath) && ctx.vfs.exists(absPath + '.mjs')) {
-				return { path: absPath + '.mjs' };
-			}
-
-			// Try .json extension
-			if (!extname(absPath) && ctx.vfs.exists(absPath + '.json')) {
-				return { path: absPath + '.json' };
+			// Append extensions when the exact path doesn't resolve. Node does
+			// this regardless of dots in the specifier, so a require of
+			// './webauthn.errors' must still find 'webauthn.errors.js'.
+			for (const ext of ['.js', '.mjs', '.cjs', '.json']) {
+				if (ctx.vfs.exists(absPath + ext)) return { path: absPath + ext };
 			}
 
 			return null;

--- a/packages/core/src/commands/system/npm.ts
+++ b/packages/core/src/commands/system/npm.ts
@@ -9,6 +9,8 @@ const GLOBAL_MODULES = '/usr/lib/node_modules';
 const GLOBAL_BIN = '/usr/bin';
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
 const NPM_VERSION = '10.0.0';
+// Max simultaneous package downloads across the whole install tree.
+const INSTALL_CONCURRENCY = 10;
 
 // ─── Types ───
 
@@ -282,6 +284,28 @@ export function registerBinCommand(registry: CommandRegistry, binName: string, s
 
 // ─── Install logic ───
 
+/** Bounded-concurrency runner — caps simultaneous network operations. */
+type Limiter = <T>(task: () => Promise<T>) => Promise<T>;
+
+function createLimiter(max: number): Limiter {
+	let active = 0;
+	const queue: (() => void)[] = [];
+	const release = () => {
+		active--;
+		const next = queue.shift();
+		if (next) next();
+	};
+	return async function limit<T>(task: () => Promise<T>): Promise<T> {
+		if (active >= max) await new Promise<void>((r) => queue.push(r));
+		active++;
+		try {
+			return await task();
+		} finally {
+			release();
+		}
+	};
+}
+
 async function installSinglePackage(
 	name: string,
 	version: string | null,
@@ -294,8 +318,11 @@ async function installSinglePackage(
 	isGlobal: boolean,
 	registry: CommandRegistry,
 	seen: Set<string>,
+	limit: Limiter,
 	kernel?: Kernel,
 ): Promise<number> {
+	// Claim the name synchronously (before any await) so concurrent installs of
+	// the same dependency dedupe correctly.
 	if (seen.has(name)) return 0;
 	seen.add(name);
 
@@ -308,9 +335,12 @@ async function installSinglePackage(
 
 	stdout.write(`  ${name}${version ? '@' + version : ''}...\n`);
 
-	const info = await fetchPackageInfo(npmRegistry, name, version, signal);
-
-	await downloadAndExtract(info.dist.tarball, targetDir, vfs, signal);
+	// Fetch metadata + tarball under the concurrency limit (the slow part).
+	const info = await limit(async () => {
+		const meta = await fetchPackageInfo(npmRegistry, name, version, signal);
+		await downloadAndExtract(meta.dist.tarball, targetDir, vfs, signal);
+		return meta;
+	});
 
 	let installed = 1;
 
@@ -329,18 +359,21 @@ async function installSinglePackage(
 
 	}
 
-	// Recursively install dependencies (flat into the same targetBase)
+	// Install dependencies in parallel (flat into the same targetBase). The
+	// limiter bounds actual concurrent downloads across the whole tree.
 	if (info.dependencies) {
-		for (const [depName, depRange] of Object.entries(info.dependencies)) {
-			try {
-				installed += await installSinglePackage(
+		const results = await Promise.all(
+			Object.entries(info.dependencies).map(([depName, depRange]) =>
+				installSinglePackage(
 					depName, depRange, targetBase, vfs, npmRegistry, signal,
-					stdout, stderr, isGlobal, registry, seen, kernel,
-				);
-			} catch (e) {
-				stderr.write(`  warn: could not install ${depName}: ${e instanceof Error ? e.message : String(e)}\n`);
-			}
-		}
+					stdout, stderr, isGlobal, registry, seen, limit, kernel,
+				).catch((e) => {
+					stderr.write(`  warn: could not install ${depName}: ${e instanceof Error ? e.message : String(e)}\n`);
+					return 0;
+				}),
+			),
+		);
+		for (const n of results) installed += n;
 	}
 
 	return installed;
@@ -442,26 +475,30 @@ async function npmInstall(ctx: CommandContext, registry: CommandRegistry, kernel
 
 		ctx.stdout.write('Installing dependencies...\n');
 		const seen = new Set<string>();
-		for (const [name, range] of Object.entries(allDeps)) {
-			try {
-				installed += await installSinglePackage(
+		const limit = createLimiter(INSTALL_CONCURRENCY);
+		const results = await Promise.all(
+			Object.entries(allDeps).map(([name, range]) =>
+				installSinglePackage(
 					name, range, targetBase, ctx.vfs, npmRegistry, ctx.signal,
-					ctx.stdout, ctx.stderr, false, registry, seen, kernel,
-				);
-			} catch (e) {
-				ctx.stderr.write(`npm ERR! ${name}: ${e instanceof Error ? e.message : String(e)}\n`);
-			}
-		}
+					ctx.stdout, ctx.stderr, false, registry, seen, limit, kernel,
+				).catch((e) => {
+					ctx.stderr.write(`npm ERR! ${name}: ${e instanceof Error ? e.message : String(e)}\n`);
+					return 0;
+				}),
+			),
+		);
+		for (const n of results) installed += n;
 	} else {
 		// Install specified packages
 		ctx.stdout.write('Installing packages...\n');
 		const seen = new Set<string>();
+		const limit = createLimiter(INSTALL_CONCURRENCY);
 		for (const spec of packages) {
 			const { name, version } = parsePackageSpec(spec);
 			try {
 				installed += await installSinglePackage(
 					name, version, targetBase, ctx.vfs, npmRegistry, ctx.signal,
-					ctx.stdout, ctx.stderr, isGlobal, registry, seen,
+					ctx.stdout, ctx.stderr, isGlobal, registry, seen, limit,
 				);
 
 				// Update package.json for local installs
@@ -1007,7 +1044,7 @@ export function createNpxCommand(
 				try {
 					await installSinglePackage(
 						parsedName, version, NPX_CACHE, ctx.vfs, npmRegistry, ctx.signal,
-						ctx.stdout, ctx.stderr, false, registry, seen,
+						ctx.stdout, ctx.stderr, false, registry, seen, createLimiter(INSTALL_CONCURRENCY),
 					);
 				} catch (e) {
 					ctx.stderr.write(`npx: could not install ${parsedName}: ${e instanceof Error ? e.message : String(e)}\n`);
@@ -1056,7 +1093,7 @@ export async function npmInstallGlobal(
 	try {
 		const installed = await installSinglePackage(
 			packageName, null, GLOBAL_MODULES, ctx.vfs, npmRegistry, ctx.signal,
-			ctx.stdout, ctx.stderr, true, registry, seen, kernel,
+			ctx.stdout, ctx.stderr, true, registry, seen, createLimiter(INSTALL_CONCURRENCY), kernel,
 		);
 
 		const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -79,6 +79,7 @@ export { createHelpCommand } from './commands/system/help.js';
 export { createNodeCommand, transformEsmToCjs } from './commands/system/node.js';
 export { createCurlCommand } from './commands/net/curl.js';
 export { createTunnelCommandV2 } from './commands/net/tunnel-v2.js';
+export { ServiceWorkerBridge } from './kernel/network/ServiceWorkerBridge.js';
 export { createIfconfigCommand } from './commands/net/ifconfig.js';
 export { createRouteCommand } from './commands/net/route.js';
 export { createNetstatCommand } from './commands/net/netstat.js';

--- a/packages/core/src/kernel/index.ts
+++ b/packages/core/src/kernel/index.ts
@@ -62,7 +62,10 @@ export interface VirtualRequest {
 export interface VirtualResponse {
 	statusCode: number;
 	headers: Record<string, string>;
+	/** Text view of the body (best-effort UTF-8). Use bodyBytes for binary-safe data. */
 	body: string;
+	/** Canonical binary body. Set for all responses; transports should prefer this. */
+	bodyBytes?: Uint8Array;
 }
 
 export type VirtualRequestHandler = (req: VirtualRequest, res: VirtualResponse) => void;

--- a/packages/core/src/kernel/network/ServiceWorkerBridge.ts
+++ b/packages/core/src/kernel/network/ServiceWorkerBridge.ts
@@ -1,0 +1,403 @@
+/**
+ * ServiceWorkerBridge — page-side half of the service-worker transport.
+ *
+ * The service worker (apps/playground/public/sw.js) intercepts requests from
+ * app clients and forwards them over a MessageChannel using the same message
+ * shapes as the tunnel relay ({type:'request'} → {type:'response'}). This
+ * class answers them from the kernel's portRegistry, exactly like
+ * WebSocketTunnel does for relay traffic — it is a sibling transport for
+ * environments where a local relay process isn't available.
+ */
+
+import type { VirtualRequestHandler } from '../index.js';
+import type { VirtualResponseWithDone } from '../../node-compat/http.js';
+import { getUpgradeHandlers } from '../../node-compat/http.js';
+import { EventEmitter } from '../../node-compat/events.js';
+import { encodeFrame, FrameDecoder, OPCODE, splitHandshake } from './ws-frame.js';
+
+interface SwRequestMessage {
+	type: 'request';
+	requestId: string;
+	port: number;
+	method: string;
+	url: string;
+	headers: Record<string, string>;
+	/** base64-encoded request body ('' when absent) */
+	body: string;
+}
+
+interface SwWsOpenMessage {
+	type: 'ws-open';
+	connId: string;
+	port: number;
+	url: string;
+	protocol: string;
+}
+
+interface SwWsSendMessage {
+	type: 'ws-send';
+	connId: string;
+	/** base64 payload */
+	data: string;
+	binary: boolean;
+}
+
+interface SwWsCloseMessage {
+	type: 'ws-close';
+	connId: string;
+}
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+function randomMask(out: Uint8Array): void {
+	if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+		crypto.getRandomValues(out);
+	} else {
+		// Deterministic fallback (non-browser hosts / tests) — masking value is
+		// irrelevant to correctness, only presence of the mask bit matters.
+		for (let i = 0; i < out.length; i++) out[i] = (i * 41 + 7) & 0xff;
+	}
+}
+
+/**
+ * Socket stand-in for a browser WebSocket piped through the service worker.
+ * Same role as the tunnel's VirtualUpgradeSocket: the in-VM ws server (Vite
+ * HMR) reads/writes RFC 6455 bytes here; the bridge frames/deframes to the
+ * message-level protocol the browser shim speaks.
+ */
+class SwUpgradeSocket extends EventEmitter {
+	readable = true;
+	writable = true;
+	destroyed = false;
+	remoteAddress = '127.0.0.1';
+	_readableState = { endEmitted: false, ended: false };
+	_writableState = { finished: false, errorEmitted: false, ended: false };
+
+	constructor(private onServerBytes: (bytes: Uint8Array) => void, private onClosed: () => void) {
+		super();
+	}
+
+	write(data: string | Uint8Array, encodingOrCb?: unknown, cb?: () => void): boolean {
+		const callback = typeof encodingOrCb === 'function' ? (encodingOrCb as () => void) : cb;
+		if (!this.destroyed) {
+			this.onServerBytes(typeof data === 'string' ? textEncoder.encode(data) : data);
+		}
+		callback?.();
+		return true;
+	}
+
+	end(data?: string | Uint8Array): void {
+		if (data !== undefined && !this.destroyed) this.write(data);
+		this.destroy();
+	}
+
+	destroy(): this {
+		if (this.destroyed) return this;
+		this.destroyed = true;
+		this.readable = false;
+		this.writable = false;
+		this._readableState.endEmitted = true;
+		this._writableState.finished = true;
+		this.onClosed();
+		this.emit('close');
+		return this;
+	}
+
+	read(): null { return null; }
+	unshift(): void {}
+	setTimeout(): this { return this; }
+	setNoDelay(): this { return this; }
+	setKeepAlive(): this { return this; }
+	pause(): this { return this; }
+	resume(): this { return this; }
+	cork(): void {}
+	uncork(): void {}
+}
+
+interface WsConnection {
+	socket: SwUpgradeSocket;
+	decoder: FrameDecoder;
+	handshakeDone: boolean;
+	/** Reassembly buffer for fragmented data frames. */
+	fragments: Uint8Array[];
+	fragmentOpcode: number;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+	let bin = '';
+	for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+	return btoa(bin);
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+	const bin = atob(b64);
+	const out = new Uint8Array(bin.length);
+	for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+	return out;
+}
+
+/** The bridge that answers the SW's reconnection requests (last connect wins). */
+let activeBridge: ServiceWorkerBridge | null = null;
+let swListenerInstalled = false;
+
+export class ServiceWorkerBridge {
+	private port: MessagePort | null = null;
+	private wsConns = new Map<string, WsConnection>();
+	private registration: ServiceWorkerRegistration | null = null;
+
+	constructor(private portRegistry: Map<number, VirtualRequestHandler>) {}
+
+	/**
+	 * Register the service worker and hand it a fresh MessageChannel.
+	 *
+	 * Service workers are killed when idle (~30s), which drops the channel and
+	 * all their in-memory state. We can't detect that from here, so the SW
+	 * re-requests a host when it wakes without one ({type:'lifo-need-host'}) and
+	 * we also reconnect on controllerchange — the page re-announces on demand.
+	 */
+	async connect(swUrl = '/sw.js'): Promise<boolean> {
+		if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return false;
+		try {
+			this.registration = await navigator.serviceWorker.register(swUrl);
+			await navigator.serviceWorker.ready;
+			activeBridge = this;
+
+			if (!swListenerInstalled) {
+				swListenerInstalled = true;
+				navigator.serviceWorker.addEventListener('message', (event: MessageEvent) => {
+					if ((event.data as { type?: string })?.type === 'lifo-need-host') {
+						void activeBridge?.reconnect();
+					}
+				});
+				navigator.serviceWorker.addEventListener('controllerchange', () => {
+					void activeBridge?.reconnect();
+				});
+			}
+
+			return this.reconnect();
+		} catch (error) {
+			console.warn('[lifo-sw] service worker registration failed:', error);
+			return false;
+		}
+	}
+
+	/** (Re)establish the MessageChannel to the (possibly restarted) service worker. */
+	async reconnect(): Promise<boolean> {
+		const controller = navigator.serviceWorker.controller ?? this.registration?.active ?? null;
+		if (!controller) return false;
+		const channel = new MessageChannel();
+		this.attach(channel.port1);
+		controller.postMessage({ type: 'lifo-connect' }, [channel.port2]);
+		return true;
+	}
+
+	/** Wire a MessagePort directly (used by connect() and by tests). */
+	attach(port: MessagePort): void {
+		this.detach();
+		// A reconnect means the SW restarted; any prior WS connections are dead
+		// (their frame state lived in the old SW). Vite's client will reopen.
+		for (const conn of this.wsConns.values()) conn.socket.destroy();
+		this.wsConns.clear();
+		this.port = port;
+		port.onmessage = (event: MessageEvent) => {
+			const msg = event.data as { type?: string };
+			if (!msg) return;
+			switch (msg.type) {
+				case 'request': void this.handleRequest(msg as SwRequestMessage); break;
+				case 'ws-open': this.handleWsOpen(msg as unknown as SwWsOpenMessage); break;
+				case 'ws-send': this.handleWsSend(msg as unknown as SwWsSendMessage); break;
+				case 'ws-close': this.handleWsClose(msg as unknown as SwWsCloseMessage); break;
+			}
+		};
+		if (typeof port.start === 'function') port.start();
+	}
+
+	detach(): void {
+		if (this.port) {
+			try { this.port.close(); } catch { /* already closed */ }
+			this.port = null;
+		}
+	}
+
+	private respondText(requestId: string, statusCode: number, headers: Record<string, string>, text: string): void {
+		this.respond(requestId, statusCode, headers, textEncoder.encode(text));
+	}
+
+	private respond(requestId: string, statusCode: number, headers: Record<string, string>, bytes: Uint8Array): void {
+		// Transfer the ArrayBuffer (zero-copy) instead of base64 — critical for
+		// large binary responses like PGlite's ~12MB wasm.
+		const buf = bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength
+			? bytes.buffer
+			: bytes.slice().buffer;
+		this.port?.postMessage({ type: 'response', requestId, statusCode, headers, bodyBuffer: buf }, [buf]);
+	}
+
+	private async handleRequest(message: SwRequestMessage): Promise<void> {
+		const { requestId, port, method, url, headers, body } = message;
+
+		const handler = this.portRegistry.get(port);
+		if (!handler) {
+			this.respondText(requestId, 404, { 'content-type': 'text/plain' }, `No server listening on port ${port}`);
+			return;
+		}
+
+		const vReq = {
+			method,
+			url,
+			headers,
+			body: body ? textDecoder.decode(base64ToBytes(body)) : '',
+		};
+		const vRes: VirtualResponseWithDone = {
+			statusCode: 200,
+			headers: {} as Record<string, string>,
+			body: '',
+		};
+
+		try {
+			handler(vReq, vRes);
+			if (vRes._donePromise) {
+				const timeout = new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 25000));
+				const result = await Promise.race([vRes._donePromise.then(() => 'done' as const), timeout]);
+				if (result === 'timeout') {
+					this.respondText(requestId, 504, { 'content-type': 'text/plain' }, `Gateway timeout: server did not respond for ${url}`);
+					return;
+				}
+			}
+			// bodyBytes is binary-safe; fall back to encoding the text view.
+			const outBytes = vRes.bodyBytes ?? textEncoder.encode(vRes.body);
+			this.respond(requestId, vRes.statusCode, vRes.headers, outBytes);
+		} catch (error) {
+			const messageText = error instanceof Error ? error.message : String(error);
+			this.respondText(requestId, 500, { 'content-type': 'text/plain' }, `Internal server error: ${messageText}`);
+		}
+	}
+
+	// ─── WebSocket transport (Phase 2: HMR) ───
+
+	/**
+	 * Open a WebSocket into the in-VM ws server on behalf of a browser shim.
+	 * Fabricates the HTTP upgrade so Vite's real ws server runs its handshake,
+	 * then bridges frames ⟷ the shim's message-level protocol.
+	 */
+	private handleWsOpen(msg: SwWsOpenMessage): void {
+		const { connId, port, url, protocol } = msg;
+		const upgradeHandler = getUpgradeHandlers(this.portRegistry).get(port);
+		if (!upgradeHandler) {
+			this.port?.postMessage({ type: 'ws-close', connId });
+			return;
+		}
+
+		const conn: WsConnection = {
+			socket: null as unknown as SwUpgradeSocket,
+			decoder: new FrameDecoder(),
+			handshakeDone: false,
+			fragments: [],
+			fragmentOpcode: 0,
+		};
+
+		const socket = new SwUpgradeSocket(
+			(bytes) => this.onServerBytes(connId, bytes),
+			() => {
+				if (this.wsConns.delete(connId)) {
+					this.port?.postMessage({ type: 'ws-close', connId });
+				}
+			},
+		);
+		conn.socket = socket;
+		this.wsConns.set(connId, conn);
+
+		// A fabricated Sec-WebSocket-Key; the shim provides no Origin (the ws
+		// server validates Origin against its own host and the browser page
+		// carries the preview origin) and no Extensions (skip permessage-deflate
+		// so the bridge never has to inflate).
+		const keyBytes = new Uint8Array(16);
+		randomMask(keyBytes);
+		const headers: Record<string, string> = {
+			upgrade: 'websocket',
+			connection: 'Upgrade',
+			'sec-websocket-version': '13',
+			'sec-websocket-key': bytesToBase64(keyBytes),
+		};
+		if (protocol) headers['sec-websocket-protocol'] = protocol;
+
+		const delivered = upgradeHandler({ method: 'GET', url, headers }, socket, new Uint8Array(0));
+		if (!delivered) {
+			this.wsConns.delete(connId);
+			socket.destroy();
+		}
+	}
+
+	/** Bytes the in-VM ws server wrote toward the browser: 101 handshake, then frames. */
+	private onServerBytes(connId: string, bytes: Uint8Array): void {
+		const conn = this.wsConns.get(connId);
+		if (!conn) return;
+		let frameBytes = bytes;
+
+		if (!conn.handshakeDone) {
+			const split = splitHandshake(bytes);
+			if (!split) return; // handshake response not complete yet
+			conn.handshakeDone = true;
+			this.port?.postMessage({ type: 'ws-opened', connId });
+			if (split.rest.length === 0) return;
+			frameBytes = split.rest;
+		}
+
+		for (const frame of conn.decoder.push(frameBytes)) {
+			this.onServerFrame(connId, conn, frame);
+		}
+	}
+
+	private onServerFrame(connId: string, conn: WsConnection, frame: { opcode: number; payload: Uint8Array; fin: boolean }): void {
+		if (frame.opcode === OPCODE.ping) {
+			// Auto-pong on the shim's behalf.
+			conn.socket.emit('data', encodeFrame(OPCODE.pong, frame.payload, randomMask));
+			return;
+		}
+		if (frame.opcode === OPCODE.pong) return;
+		if (frame.opcode === OPCODE.close) {
+			conn.socket.destroy();
+			return;
+		}
+
+		// text / binary / continuation — reassemble fragments.
+		if (frame.opcode !== OPCODE.continuation) conn.fragmentOpcode = frame.opcode;
+		conn.fragments.push(frame.payload);
+		if (!frame.fin) return;
+
+		let total = 0;
+		for (const f of conn.fragments) total += f.length;
+		const full = new Uint8Array(total);
+		let off = 0;
+		for (const f of conn.fragments) { full.set(f, off); off += f.length; }
+		conn.fragments = [];
+
+		const binary = conn.fragmentOpcode === OPCODE.binary;
+		this.port?.postMessage({
+			type: 'ws-message',
+			connId,
+			data: bytesToBase64(full),
+			binary,
+		});
+	}
+
+	/** A message the browser shim sent → frame it (masked) into the ws server. */
+	private handleWsSend(msg: SwWsSendMessage): void {
+		const conn = this.wsConns.get(msg.connId);
+		if (!conn || conn.socket.destroyed) return;
+		const payload = base64ToBytes(msg.data);
+		const opcode = msg.binary ? OPCODE.binary : OPCODE.text;
+		conn.socket.emit('data', encodeFrame(opcode, payload, randomMask));
+	}
+
+	private handleWsClose(msg: SwWsCloseMessage): void {
+		const conn = this.wsConns.get(msg.connId);
+		if (!conn) return;
+		this.wsConns.delete(msg.connId);
+		// Send a WS close frame, then tear the socket down.
+		if (!conn.socket.destroyed) {
+			conn.socket.emit('data', encodeFrame(OPCODE.close, new Uint8Array(0), randomMask));
+			conn.socket.destroy();
+		}
+	}
+}

--- a/packages/core/src/kernel/network/tunnel/WebSocketTunnel.ts
+++ b/packages/core/src/kernel/network/tunnel/WebSocketTunnel.ts
@@ -449,11 +449,12 @@ export class WebSocketTunnel extends BaseTunnel {
 				}
 			}
 
-			// Send response back through WebSocket
-			this.sendResponse(requestId, vRes.statusCode, vRes.headers, vRes.body);
+			// Send response back through WebSocket (binary-safe via bodyBytes)
+			const outBytes = vRes.bodyBytes ?? new TextEncoder().encode(vRes.body);
+			this.sendResponse(requestId, vRes.statusCode, vRes.headers, outBytes);
 
 			// Update stats
-			this.updateStats(vRes.body.length, 'tx');
+			this.updateStats(outBytes.length, 'tx');
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			this.sendError(requestId, 500, `Internal server error: ${errorMessage}`);
@@ -471,7 +472,7 @@ export class WebSocketTunnel extends BaseTunnel {
 	/**
 	 * Send HTTP response through WebSocket
 	 */
-	private sendResponse(requestId: string, statusCode: number, headers: Record<string, string>, body: string): void {
+	private sendResponse(requestId: string, statusCode: number, headers: Record<string, string>, body: string | Uint8Array): void {
 		if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
 			return;
 		}

--- a/packages/core/src/kernel/network/ws-frame.ts
+++ b/packages/core/src/kernel/network/ws-frame.ts
@@ -1,0 +1,133 @@
+/**
+ * Minimal RFC 6455 WebSocket frame codec.
+ *
+ * Used by the service-worker transport: the browser-side shim can't do real
+ * WebSocket framing (there is no native socket), so the page bridge speaks
+ * frames to the in-VM `ws` server (Vite's HMR server) on its behalf. Keeping
+ * the codec here — in TypeScript — means it's unit-testable headlessly against
+ * the real ws server, unlike code that would live in the injected shim.
+ *
+ * Scope: single-purpose HMR transport, so no permessage-deflate (the bridge
+ * simply never negotiates it) and messages are assumed to fit in memory.
+ */
+
+export const OPCODE = {
+	continuation: 0x0,
+	text: 0x1,
+	binary: 0x2,
+	close: 0x8,
+	ping: 0x9,
+	pong: 0xa,
+} as const;
+
+/** Encode one client→server frame. Client frames MUST be masked (RFC 6455 §5.3). */
+export function encodeFrame(opcode: number, payload: Uint8Array, mask: (out: Uint8Array) => void): Uint8Array {
+	const len = payload.length;
+	let headerLen = 2 + 4; // fin/opcode + mask/len + 4-byte masking key
+	if (len >= 65536) headerLen += 8;
+	else if (len >= 126) headerLen += 2;
+
+	const frame = new Uint8Array(headerLen + len);
+	frame[0] = 0x80 | (opcode & 0x0f); // FIN + opcode
+	let offset = 2;
+	if (len < 126) {
+		frame[1] = 0x80 | len;
+	} else if (len < 65536) {
+		frame[1] = 0x80 | 126;
+		frame[2] = (len >> 8) & 0xff;
+		frame[3] = len & 0xff;
+		offset = 4;
+	} else {
+		frame[1] = 0x80 | 127;
+		// 64-bit length; JS payloads never exceed 2^32, so high word is 0.
+		new DataView(frame.buffer).setUint32(2, 0);
+		new DataView(frame.buffer).setUint32(6, len >>> 0);
+		offset = 10;
+	}
+
+	const key = frame.subarray(offset, offset + 4);
+	mask(key);
+	offset += 4;
+	for (let i = 0; i < len; i++) frame[offset + i] = payload[i] ^ key[i & 3];
+	return frame;
+}
+
+export interface DecodedFrame {
+	opcode: number;
+	payload: Uint8Array;
+	fin: boolean;
+}
+
+/**
+ * Streaming decoder for server→client frames. Feed arbitrary byte chunks;
+ * get back complete frames. Server frames are normally unmasked, but the
+ * decoder unmasks defensively if the mask bit is set.
+ */
+export class FrameDecoder {
+	private buf = new Uint8Array(0);
+
+	push(chunk: Uint8Array): DecodedFrame[] {
+		const merged = new Uint8Array(this.buf.length + chunk.length);
+		merged.set(this.buf);
+		merged.set(chunk, this.buf.length);
+		this.buf = merged;
+
+		const out: DecodedFrame[] = [];
+		while (true) {
+			const frame = this.tryReadFrame();
+			if (!frame) break;
+			out.push(frame);
+		}
+		return out;
+	}
+
+	private tryReadFrame(): DecodedFrame | null {
+		const b = this.buf;
+		if (b.length < 2) return null;
+		const fin = (b[0] & 0x80) !== 0;
+		const opcode = b[0] & 0x0f;
+		const masked = (b[1] & 0x80) !== 0;
+		let len = b[1] & 0x7f;
+		let offset = 2;
+
+		if (len === 126) {
+			if (b.length < 4) return null;
+			len = (b[2] << 8) | b[3];
+			offset = 4;
+		} else if (len === 127) {
+			if (b.length < 10) return null;
+			const dv = new DataView(b.buffer, b.byteOffset);
+			// Ignore the high 32 bits — payloads never exceed 2^32 here.
+			len = dv.getUint32(6);
+			offset = 10;
+		}
+
+		let maskKey: Uint8Array | null = null;
+		if (masked) {
+			if (b.length < offset + 4) return null;
+			maskKey = b.subarray(offset, offset + 4);
+			offset += 4;
+		}
+
+		if (b.length < offset + len) return null;
+
+		let payload = b.slice(offset, offset + len);
+		if (maskKey) {
+			for (let i = 0; i < len; i++) payload[i] ^= maskKey[i & 3];
+		}
+		this.buf = b.slice(offset + len);
+		return { opcode, payload, fin };
+	}
+}
+
+/** Parse the "\r\n\r\n"-terminated HTTP upgrade response prefix from a byte stream. */
+export function splitHandshake(bytes: Uint8Array): { header: string; rest: Uint8Array } | null {
+	// Search for CRLF CRLF.
+	for (let i = 3; i < bytes.length; i++) {
+		if (bytes[i - 3] === 0x0d && bytes[i - 2] === 0x0a && bytes[i - 1] === 0x0d && bytes[i] === 0x0a) {
+			const header = new TextDecoder().decode(bytes.subarray(0, i + 1));
+			return { header, rest: bytes.subarray(i + 1) };
+		}
+	}
+	return null;
+}

--- a/packages/core/src/node-compat/fs.ts
+++ b/packages/core/src/node-compat/fs.ts
@@ -553,8 +553,10 @@ export function createFs(vfs: VFS, cwd: string) {
         if (options?.encoding) {
           stream.push(decode(slice));
         } else {
-          // Push as string since our Readable works with strings
-          stream.push(decode(slice));
+          // No encoding → emit raw bytes (Buffer), like Node. Decoding to a
+          // string here corrupts binary files (wasm, images, fonts) served via
+          // fs.createReadStream (e.g. Vite/sirv static serving).
+          stream.push(Buffer.from(slice));
         }
         stream.push(null);
       } catch (e) {
@@ -571,7 +573,10 @@ export function createFs(vfs: VFS, cwd: string) {
   function createWriteStream(path: string | URL, options?: { flags?: string; encoding?: string }): Writable {
     const abs = resolvePath(cwd, path);
     const flags = options?.flags ?? 'w';
-    const chunks: string[] = [];
+    // Accumulate raw byte chunks so binary writes aren't corrupted by joining
+    // as strings.
+    const chunks: Uint8Array[] = [];
+    const toBytes = (c: string | Uint8Array): Uint8Array => (typeof c === 'string' ? encode(c) : c);
 
     if (flags.includes('w')) {
       // Truncate on open
@@ -580,13 +585,18 @@ export function createFs(vfs: VFS, cwd: string) {
 
     const stream = new Writable();
 
-    stream.write = (chunk: string, _encoding?: string, cb?: () => void): boolean => {
-      chunks.push(chunk);
+    stream.write = (chunk: string | Uint8Array, _encoding?: string, cb?: () => void): boolean => {
       try {
         if (flags.includes('a')) {
-          vfs.appendFile(abs, chunk);
+          vfs.appendFile(abs, toBytes(chunk));
         } else {
-          vfs.writeFile(abs, chunks.join(''));
+          chunks.push(toBytes(chunk));
+          let total = 0;
+          for (const c of chunks) total += c.length;
+          const all = new Uint8Array(total);
+          let off = 0;
+          for (const c of chunks) { all.set(c, off); off += c.length; }
+          vfs.writeFile(abs, all);
         }
       } catch (e) {
         stream.emit('error', e);
@@ -596,7 +606,7 @@ export function createFs(vfs: VFS, cwd: string) {
       return true;
     };
 
-    stream.end = (chunk?: string): void => {
+    stream.end = (chunk?: string | Uint8Array): void => {
       if (chunk) stream.write(chunk);
       stream.emit('finish');
       stream.emit('close');

--- a/packages/core/src/node-compat/http.ts
+++ b/packages/core/src/node-compat/http.ts
@@ -186,8 +186,10 @@ class ServerResponse extends EventEmitter {
   writableEnded = false;
   writableFinished = false;
   private _headers: Record<string, string | string[]> = {};
-  private _body = '';
-  private _vRes: { statusCode: number; headers: Record<string, string>; body: string };
+  // Accumulate raw byte chunks so binary responses (wasm, images, fonts) are
+  // preserved. A string _body would corrupt them via UTF-8 round-tripping.
+  private _chunks: Uint8Array[] = [];
+  private _vRes: { statusCode: number; headers: Record<string, string>; body: string; bodyBytes?: Uint8Array };
   // Minimal socket stub that middleware may reference
   socket: { destroy: () => void; writable: boolean; readable: boolean; remoteAddress: string } | null;
   // Promise that resolves when end() is called (for async middleware)
@@ -211,6 +213,7 @@ class ServerResponse extends EventEmitter {
           this._vRes.statusCode = this.statusCode || 500;
           this._vRes.headers = {};
           this._vRes.body = '';
+          this._vRes.bodyBytes = new Uint8Array(0);
           this.finished = true;
           this._doneResolve();
         }
@@ -279,13 +282,11 @@ class ServerResponse extends EventEmitter {
   }
 
   write(data: string | Uint8Array): boolean {
-    if (typeof data === 'string') {
-      this._body += data;
-    } else {
-      this._body += new TextDecoder().decode(data);
-    }
+    this._chunks.push(typeof data === 'string' ? this._enc.encode(data) : data);
     return true;
   }
+
+  private _enc = new TextEncoder();
 
   end(data?: string | Uint8Array | (() => void), _encoding?: string, cb?: () => void): void {
     if (typeof data === 'function') {
@@ -293,9 +294,9 @@ class ServerResponse extends EventEmitter {
       data = undefined;
     }
     if (typeof data === 'string') {
-      this._body += data;
+      this._chunks.push(this._enc.encode(data));
     } else if (data instanceof Uint8Array) {
-      this._body += new TextDecoder().decode(data);
+      this._chunks.push(data);
     }
     this.finished = true;
     this.writableEnded = true;
@@ -305,10 +306,19 @@ class ServerResponse extends EventEmitter {
     for (const [k, v] of Object.entries(this._headers)) {
       flatHeaders[k] = Array.isArray(v) ? v.join(', ') : v;
     }
-    // Flush to virtual response
+    // Concatenate the byte chunks — binary-safe.
+    let total = 0;
+    for (const c of this._chunks) total += c.length;
+    const bytes = new Uint8Array(total);
+    let off = 0;
+    for (const c of this._chunks) { bytes.set(c, off); off += c.length; }
+
+    // Flush to virtual response: bodyBytes is canonical (binary-safe);
+    // body is a best-effort text view for legacy string consumers.
     this._vRes.statusCode = this.statusCode;
     this._vRes.headers = flatHeaders;
-    this._vRes.body = this._body;
+    this._vRes.bodyBytes = bytes;
+    this._vRes.body = new TextDecoder().decode(bytes);
     this.headersSent = true;
     this.emit('finish');
     this._doneResolve();

--- a/packages/core/tests/kernel/service-worker-bridge.test.ts
+++ b/packages/core/tests/kernel/service-worker-bridge.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ServiceWorkerBridge } from '../../src/kernel/network/ServiceWorkerBridge.js';
+import type { VirtualRequestHandler } from '../../src/kernel/index.js';
+import type { VirtualResponseWithDone } from '../../src/node-compat/http.js';
+
+/** Decode a response body — bodyBuffer (transferred ArrayBuffer) or legacy base64. */
+function bodyText(res: { bodyBuffer?: ArrayBuffer; body?: string }): string {
+	if (res.bodyBuffer) return new TextDecoder().decode(new Uint8Array(res.bodyBuffer));
+	return res.body ? new TextDecoder().decode(Uint8Array.from(atob(res.body), (c) => c.charCodeAt(0))) : '';
+}
+
+describe('ServiceWorkerBridge', () => {
+	let portRegistry: Map<number, VirtualRequestHandler>;
+	let bridge: ServiceWorkerBridge;
+	let channel: MessageChannel;
+	/** Plays the service worker: send a request message, await the response. */
+	let swRequest: (msg: Record<string, unknown>) => Promise<{ requestId: string; statusCode: number; headers: Record<string, string>; body?: string; bodyBuffer?: ArrayBuffer }>;
+
+	beforeEach(() => {
+		portRegistry = new Map();
+		bridge = new ServiceWorkerBridge(portRegistry);
+		channel = new MessageChannel();
+		bridge.attach(channel.port1 as unknown as MessagePort);
+		swRequest = (msg) =>
+			new Promise((resolve) => {
+				const onMessage = (event: MessageEvent) => {
+					if (event.data?.requestId === msg.requestId) {
+						channel.port2.removeEventListener('message', onMessage as EventListener);
+						resolve(event.data);
+					}
+				};
+				channel.port2.addEventListener('message', onMessage as EventListener);
+				channel.port2.start?.();
+				channel.port2.postMessage(msg);
+			});
+	});
+
+	afterEach(() => {
+		bridge.detach();
+		channel.port2.close();
+	});
+
+	it('answers a request from the port registry', async () => {
+		portRegistry.set(8080, (vReq, vRes) => {
+			vRes.statusCode = 200;
+			vRes.headers = { 'content-type': 'text/plain' };
+			vRes.body = `hello ${vReq.method} ${vReq.url}`;
+		});
+		const res = await swRequest({ type: 'request', requestId: 'r1', port: 8080, method: 'GET', url: '/greet', headers: {}, body: '' });
+		expect(res.statusCode).toBe(200);
+		expect(res.headers['content-type']).toBe('text/plain');
+		expect(bodyText(res)).toBe('hello GET /greet');
+	});
+
+	it('awaits async handlers via _donePromise', async () => {
+		portRegistry.set(8080, (vReq, vRes) => {
+			(vRes as VirtualResponseWithDone)._donePromise = new Promise((resolve) => {
+				setTimeout(() => {
+					vRes.statusCode = 201;
+					vRes.body = 'async done';
+					resolve();
+				}, 50);
+			});
+		});
+		const res = await swRequest({ type: 'request', requestId: 'r2', port: 8080, method: 'GET', url: '/', headers: {}, body: '' });
+		expect(res.statusCode).toBe(201);
+		expect(bodyText(res)).toBe('async done');
+	});
+
+	it('decodes base64 request bodies for the handler', async () => {
+		let seenBody = '';
+		portRegistry.set(9000, (vReq, vRes) => {
+			seenBody = vReq.body;
+			vRes.body = 'ok';
+		});
+		const body = btoa('payload=42');
+		const res = await swRequest({ type: 'request', requestId: 'r3', port: 9000, method: 'POST', url: '/submit', headers: { 'content-type': 'application/x-www-form-urlencoded' }, body });
+		expect(res.statusCode).toBe(200);
+		expect(seenBody).toBe('payload=42');
+	});
+
+	it('404s for unregistered ports', async () => {
+		const res = await swRequest({ type: 'request', requestId: 'r4', port: 5555, method: 'GET', url: '/', headers: {}, body: '' });
+		expect(res.statusCode).toBe(404);
+		expect(bodyText(res)).toContain('No server listening on port 5555');
+	});
+
+	it('500s when the handler throws', async () => {
+		portRegistry.set(8081, () => {
+			throw new Error('kaboom');
+		});
+		const res = await swRequest({ type: 'request', requestId: 'r5', port: 8081, method: 'GET', url: '/', headers: {}, body: '' });
+		expect(res.statusCode).toBe(500);
+		expect(bodyText(res)).toContain('kaboom');
+	});
+});

--- a/packages/core/tests/kernel/ws-frame.test.ts
+++ b/packages/core/tests/kernel/ws-frame.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { encodeFrame, FrameDecoder, OPCODE, splitHandshake } from '../../src/kernel/network/ws-frame.js';
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+/** A deterministic mask (all-zero key → masked payload equals plaintext). */
+const zeroMask = (out: Uint8Array) => out.fill(0);
+const fixedMask = (out: Uint8Array) => { out[0] = 0x12; out[1] = 0x34; out[2] = 0x56; out[3] = 0x78; };
+
+describe('ws-frame codec', () => {
+	it('round-trips a text frame through encode → decode', () => {
+		const frame = encodeFrame(OPCODE.text, enc.encode('hello hmr'), fixedMask);
+		const frames = new FrameDecoder().push(frame);
+		expect(frames).toHaveLength(1);
+		expect(frames[0].opcode).toBe(OPCODE.text);
+		expect(frames[0].fin).toBe(true);
+		expect(dec.decode(frames[0].payload)).toBe('hello hmr');
+	});
+
+	it('client frames are always masked (bit set, key applied)', () => {
+		const frame = encodeFrame(OPCODE.text, enc.encode('x'), fixedMask);
+		expect(frame[1] & 0x80).toBe(0x80); // MASK bit
+		// payload byte = 'x'(0x78) ^ key[0](0x12)
+		expect(frame[frame.length - 1]).toBe(0x78 ^ 0x12);
+	});
+
+	it('handles 16-bit extended length (126..65535)', () => {
+		const payload = enc.encode('a'.repeat(1000));
+		const frame = encodeFrame(OPCODE.binary, payload, zeroMask);
+		expect(frame[1] & 0x7f).toBe(126);
+		const frames = new FrameDecoder().push(frame);
+		expect(frames[0].payload.length).toBe(1000);
+	});
+
+	it('handles 64-bit extended length (>= 65536)', () => {
+		const payload = enc.encode('b'.repeat(70000));
+		const frame = encodeFrame(OPCODE.binary, payload, zeroMask);
+		expect(frame[1] & 0x7f).toBe(127);
+		const frames = new FrameDecoder().push(frame);
+		expect(frames[0].payload.length).toBe(70000);
+	});
+
+	it('reassembles frames split across chunk boundaries', () => {
+		const frame = encodeFrame(OPCODE.text, enc.encode('split me'), fixedMask);
+		const decoder = new FrameDecoder();
+		expect(decoder.push(frame.subarray(0, 3))).toHaveLength(0);
+		expect(decoder.push(frame.subarray(3, 6))).toHaveLength(0);
+		const done = decoder.push(frame.subarray(6));
+		expect(done).toHaveLength(1);
+		expect(dec.decode(done[0].payload)).toBe('split me');
+	});
+
+	it('decodes multiple frames from one chunk', () => {
+		const a = encodeFrame(OPCODE.text, enc.encode('one'), zeroMask);
+		const b = encodeFrame(OPCODE.text, enc.encode('two'), zeroMask);
+		const both = new Uint8Array(a.length + b.length);
+		both.set(a); both.set(b, a.length);
+		const frames = new FrameDecoder().push(both);
+		expect(frames.map((f) => dec.decode(f.payload))).toEqual(['one', 'two']);
+	});
+
+	it('decodes unmasked server frames', () => {
+		// Server frame: FIN+text, no mask bit, 3-byte payload
+		const server = new Uint8Array([0x81, 0x03, 0x61, 0x62, 0x63]);
+		const frames = new FrameDecoder().push(server);
+		expect(dec.decode(frames[0].payload)).toBe('abc');
+	});
+
+	it('splitHandshake separates the 101 header from trailing frame bytes', () => {
+		const header = 'HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n\r\n';
+		const trailing = encodeFrame(OPCODE.text, enc.encode('after'), zeroMask);
+		const combined = new Uint8Array(enc.encode(header).length + trailing.length);
+		combined.set(enc.encode(header));
+		combined.set(trailing, enc.encode(header).length);
+		const split = splitHandshake(combined);
+		expect(split).not.toBeNull();
+		expect(split!.header).toContain('101 Switching Protocols');
+		expect(new FrameDecoder().push(split!.rest)[0]).toBeTruthy();
+	});
+
+	it('splitHandshake returns null until the terminator arrives', () => {
+		expect(splitHandshake(enc.encode('HTTP/1.1 101 Switching Protocols\r\n'))).toBeNull();
+	});
+});


### PR DESCRIPTION
## What this adds

**1. Service-worker transport — run apps with zero host setup.** A service worker serves any in-VM port at `/_sw/<port>/`, so the Vite examples now render in an **integrated iframe browser** in the playground with no relay process. It routes by *client* (not URL rewriting), so apps keep their absolute paths unmodified, and **HMR works** — the browser's WebSocket is shimmed into a message protocol that the page bridge turns into real RFC 6455 frames against the in-VM `ws` server (Vite's own). The WebSocket frame codec lives in TypeScript and is unit-tested headlessly.

**2. Local Supabase-style dev, entirely in the browser.** New **"Supabase Todo (tinbase)"** example: [tinbase](https://tinbase.vercel.app) (a Supabase-compatible backend) runs as an HTTP server *inside the VM* (`npm run backend`, like `supabase start`), and a **Vite + React + TypeScript** app talks to it via `@supabase/supabase-js`. Postgres (PGlite/wasm) lives in the VM; config is in `.env` exactly like a real project; React fast-refresh works; and because the backend is a separate process, **data persists across app reloads**.

**3. Correctness + perf fixes** (found by running the above):
- **Binary-safe HTTP**: the virtual HTTP body was a JS string, corrupting wasm/images/fonts via UTF-8 round-trip. Fixed in `ServerResponse` (byte chunks + `bodyBytes`), `createReadStream`/`createWriteStream`, and the tunnel/curl transports. This unblocks *all* binary assets, not just tinbase.
- **Module resolver**: `require('./webauthn.errors')` failed (`.errors` looked like an extension); now appends extensions Node-style and resolves directory `package.json` main.
- **Parallel npm install**: bounded-concurrency pool replaces the sequential install — 75 packages in ~2.4s vs ~10-16s.

## Validation

- Core: 282 tests green, incl. 14 new (ws-frame codec, ServiceWorkerBridge over a MessageChannel) + a ws-shim unit test (evaluates the injected shim against mocked SW globals).
- Headless E2E harnesses drove: create-vite 1:1 through the SW, React fast-refresh (`js-update` payloads), binary wasm served with intact magic bytes and exact size, and the full tinbase todo path (both servers in one VM, `.env` injection, REST insert/select via `/_sw/54321`).
- Browser-verified by @sanketsahu: SW previews, React HMR, and the tinbase todo app.

## Notes / follow-ups
- Realtime isn't wired for tinbase (the server handles HTTP only; the app refetches after writes).
- Data resets on a full *playground* reload (that reboots the VM, no IndexedDB there) — matching `supabase stop`. VM-level persistence (`persist: true` + PGlite dataDir → VFS) is a possible follow-up.
- `create-vite@latest` scaffolds Vite 8 (rolldown/native) — still out of scope; the example pins the vite-7 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)