### PR TITLE
fix(sw): base-aware, root-scoped service worker for hosted deployments

### DIFF
--- a/apps/playground/src/main.ts
+++ b/apps/playground/src/main.ts
@@ -2366,7 +2366,11 @@ async function bootProjectExample(opts: ProjectExampleOpts): Promise<void> {
 	// Service-worker transport: serve /_sw/<port>/ with no host process.
 	// Last-booted example hosts it (like the relay's last-client-wins).
 	const swBridge = new ServiceWorkerBridge(sandbox.kernel.portRegistry);
-	const swReady = await swBridge.connect();
+	// sw.js sits next to the app (root on the dev server, /playground/ on the
+	// hosted site); request root scope so /_sw/<port>/ previews are intercepted
+	// regardless of the base path. The hosted site must send
+	// `Service-Worker-Allowed: /` for /playground/sw.js.
+	const swReady = await swBridge.connect(`${import.meta.env.BASE_URL}sw.js`, '/');
 
 	if (previewPort) {
 		const mount = document.getElementById(`preview-${id}`);

--- a/apps/playground/src/vite-env.d.ts
+++ b/apps/playground/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/core/src/kernel/network/ServiceWorkerBridge.ts
+++ b/packages/core/src/kernel/network/ServiceWorkerBridge.ts
@@ -156,10 +156,21 @@ export class ServiceWorkerBridge {
 	 * re-requests a host when it wakes without one ({type:'lifo-need-host'}) and
 	 * we also reconnect on controllerchange — the page re-announces on demand.
 	 */
-	async connect(swUrl = '/sw.js'): Promise<boolean> {
+	/**
+	 * @param swUrl   Path to the worker script. When the app is served under a
+	 *                base path (e.g. /playground/), pass the base-prefixed URL
+	 *                so the file resolves.
+	 * @param scope   Desired control scope. Defaults to '/' so previews at
+	 *                /_sw/<port>/ (and the inner apps' root-absolute asset URLs)
+	 *                are intercepted even when the outer app lives under a base
+	 *                path. A worker served from a subdirectory needs the host to
+	 *                send `Service-Worker-Allowed: /` for the broader scope to
+	 *                be granted.
+	 */
+	async connect(swUrl = '/sw.js', scope = '/'): Promise<boolean> {
 		if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return false;
 		try {
-			this.registration = await navigator.serviceWorker.register(swUrl);
+			this.registration = await navigator.serviceWorker.register(swUrl, { scope });
 			await navigator.serviceWorker.ready;
 			activeBridge = this;
 


### PR DESCRIPTION
Follow-up to #18. The service-worker previews worked on the standalone dev
server (base `/`) but not when the playground is served under a base path
(`/playground/` on the website): `sw.js` lived at `/playground/sw.js` while
registration and all `/_sw/` paths assumed root, so the worker 404'd.

**Fix:** register from the base-prefixed URL (`import.meta.env.BASE_URL + 'sw.js'`)
but claim **root scope** (`'/'`). All the existing root `/_sw/<port>/` preview
paths and the inner apps' root-absolute asset URLs then stay intercepted no
matter where the outer app is mounted — no path rewriting needed.
`ServiceWorkerBridge.connect(swUrl, scope)` gains a scope argument (default `/`).

A worker served from a subdirectory needs `Service-Worker-Allowed: /` from the
host for the broader scope to be granted — the website adds that header for
`/playground/sw.js` (separate website PR).

- Dev server (base `/`): `register('/sw.js', { scope: '/' })` — unchanged behavior.
- Website (base `/playground/`): `register('/playground/sw.js', { scope: '/' })` + the header.

Bridge tests pass; playground typechecks (added `vite-env.d.ts` for `import.meta.env`).
Needs verification on the website's preview deploy (paired with the website PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)