### PR TITLE
fix(playground): clear stale persisted tunnel enablement (interactive)

### DIFF
--- a/apps/playground/src/examples/interactive-seed.ts
+++ b/apps/playground/src/examples/interactive-seed.ts
@@ -28,6 +28,12 @@ WantedBy=multi-user.target
 	// manually, but it is NOT auto-enabled: in the browser there's no relay at
 	// ws://localhost:3005, so starting it just floods the terminal with
 	// reconnect errors. The service worker is the browser transport.
+	//
+	// This example persists its VFS (persist: true), so a returning visitor may
+	// still carry a `multi-user.target.wants/tunnel.service` entry written by a
+	// PRE-FIX build — which bootServices() would auto-start. Proactively disable
+	// it to clear any such stale enablement.
+	kernel.serviceManager?.disable('tunnel');
 
 	// Create sample Vite app for testing
 	const vfs = kernel.vfs;


### PR DESCRIPTION
## Problem
On production the interactive example still logs `tunnel: could not reach relay at ws://localhost:3005 (will retry quietly)`.

The code no longer auto-enables the tunnel, so a **fresh** VM is fine. But the interactive example uses `persist: true`, so a **returning** visitor's IndexedDB still holds the `multi-user.target.wants/tunnel.service` entry written by a pre-fix build. `bootServices()` reads that on boot and starts the tunnel — which has no relay in the browser (the service worker is the transport), so it errors.

## Fix
`seedInteractive` now calls `serviceManager.disable('tunnel')` after init, clearing any stale persisted enablement. It's a safe no-op when the tunnel isn't enabled, so fresh visitors are unaffected; users can still `systemctl start tunnel` manually if they run a relay.

## Test
- `pnpm --filter @lifo-sh/playground build` + typecheck clean
- Manual: with a persisted state that had the tunnel enabled, reload the interactive example — no more relay errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)