### PR TITLE
Expo dev server (expo start --web) with Fast Refresh in the VM

### DIFF
--- a/apps/playground/src/data/code-snippets.ts
+++ b/apps/playground/src/data/code-snippets.ts
@@ -442,18 +442,18 @@ const CODE_PGLITE = `\
 <span class="code-keyword">SELECT</span> body <span class="code-keyword">FROM</span> docs;  <span class="code-comment">-- only alice's rows</span>`;
 
 const CODE_EXPO = `\
-<span class="code-comment"># A real Expo (React Native for Web) app, bundled by</span>
-<span class="code-comment"># Metro entirely in your browser — no host process.</span>
+<span class="code-comment"># A real Expo (React Native for Web) app on a live</span>
+<span class="code-comment"># Metro dev server, running entirely in your browser.</span>
 <span class="code-comment"># Metro runs in-band (maxWorkers=1) and offline.</span>
 
 <span class="code-fn">cd</span> expo-app
 <span class="code-fn">npm</span> install          <span class="code-comment"># expo, react-native, metro, …</span>
-<span class="code-fn">npm</span> run export       <span class="code-comment"># expo export --platform web → dist/</span>
-<span class="code-fn">npm</span> run serve &      <span class="code-comment"># static server on virtual port 8081</span>
+<span class="code-fn">npm</span> run start &      <span class="code-comment"># expo start --web → Metro dev server :8081</span>
 
 <span class="code-comment"># the preview pane (below) is an iframe at /_sw/8081/,</span>
 <span class="code-comment"># served by a service worker straight from the VM.</span>
-<span class="code-comment"># edit App.js and re-run export to rebuild:</span>
+<span class="code-comment"># Fast Refresh: edit App.js and save — updates in place</span>
+<span class="code-comment"># (HMR websocket rides the same service-worker shim as Vite).</span>
 <span class="code-fn">sed</span> -i <span class="code-string">'s/Expo inside Lifo/Hello Metro/'</span> App.js`;
 
 const CODE_EXPO_ROUTER = `\

--- a/apps/playground/src/data/code-snippets.ts
+++ b/apps/playground/src/data/code-snippets.ts
@@ -457,18 +457,18 @@ const CODE_EXPO = `\
 <span class="code-fn">sed</span> -i <span class="code-string">'s/Expo inside Lifo/Hello Metro/'</span> App.js`;
 
 const CODE_EXPO_ROUTER = `\
-<span class="code-comment"># Expo Router — file-based routing — bundled by Metro</span>
-<span class="code-comment"># in your browser and exported to a static web build.</span>
+<span class="code-comment"># Expo Router — file-based routing on a live Metro dev</span>
+<span class="code-comment"># server, running entirely in your browser.</span>
 <span class="code-comment"># Routes live in app/ (app/index.js, app/about.js).</span>
 
 <span class="code-fn">cd</span> expo-router-app
 <span class="code-fn">npm</span> install          <span class="code-comment"># expo-router, react-navigation, …</span>
-<span class="code-fn">npm</span> run export       <span class="code-comment"># expo export --platform web → dist/</span>
-<span class="code-fn">npm</span> run serve &      <span class="code-comment"># static server on virtual port 8082</span>
+<span class="code-fn">npm</span> run start &      <span class="code-comment"># expo start --web → Metro dev server :8082</span>
 
 <span class="code-comment"># preview pane → /_sw/8082/ (service-worker transport).</span>
 <span class="code-comment"># click "Go to About" — client-side routing, no reload.</span>
-<span class="code-comment"># Metro hashes the router's icon assets via md5-file.</span>`;
+<span class="code-comment"># Fast Refresh: edit app/index.js and save — updates in</span>
+<span class="code-comment"># place (HMR rides the same service-worker shim as Vite).</span>`;
 
 export const codeSnippets: Record<string, string> = {
 	interactive: CODE_INTERACTIVE,

--- a/apps/playground/src/data/templates/expo-router.ts
+++ b/apps/playground/src/data/templates/expo-router.ts
@@ -4,8 +4,9 @@ export function expoRouterAppFiles(root: string): Record<string, string> {
 	files[`${root}/package.json`] = JSON.stringify({
 		name: 'expo-router-app',
 		version: '1.0.0',
-		main: 'expo-router/entry',
+		main: 'index.js',
 		scripts: {
+			start: 'node start.mjs',
 			export: 'node export.mjs',
 			serve: 'node serve.mjs',
 		},
@@ -35,6 +36,14 @@ export function expoRouterAppFiles(root: string): Record<string, string> {
 			plugins: ['expo-router'],
 		},
 	}, null, 2);
+
+	// Fast Refresh requires the react-refresh runtime (installed by
+	// @expo/metro-runtime) to load BEFORE any component module — Metro only
+	// registers a module's components if global.__ReactRefresh exists when the
+	// module executes. So it must be the first import of the entry file.
+	files[`${root}/index.js`] = `import '@expo/metro-runtime';
+import 'expo-router/entry';
+`;
 
 	files[`${root}/babel.config.js`] = `module.exports = function (api) {
   api.cache(true);
@@ -97,6 +106,33 @@ const styles = StyleSheet.create({
   body: { fontSize: 15, color: '#9aa5ce', marginBottom: 20, textAlign: 'center' },
   link: { fontSize: 16, color: '#7aa2f7', fontWeight: '600' },
 });
+`;
+
+	// Boot the Expo web dev server (Metro) non-interactively, with Fast Refresh.
+	files[`${root}/start.mjs`] = `process.env.NODE_ENV = 'development';
+process.env.EXPO_OFFLINE = '1';
+// NOTE: do NOT set CI — Expo is already non-interactive here (isInteractive() is
+// !CI && stdout.isTTY, and the VM's stdout isn't a TTY), and CI=1 makes Metro
+// disable file watching, which kills Fast Refresh.
+process.env.BROWSER = 'none';    // don't try to open a system browser
+process.env.EXPO_NO_TELEMETRY = '1';
+process.env.EXPO_NO_DEPENDENCY_VALIDATION = '1'; // skip the version doctor check
+
+// Metro's efficient recursive watcher (fs.watch(root, { recursive: true })) is
+// gated to macOS; the VM reports platform 'lifo', so Metro would fall back to a
+// per-directory walker-based watcher that doesn't observe VFS writes (no Fast
+// Refresh). Lifo's fs.watch supports { recursive: true }, so force the native
+// watcher — this is what makes editing a file rebuild + hot-reload.
+try {
+  const nw = await import('metro-file-map/src/watchers/NativeWatcher.js');
+  const NativeWatcher = nw.default ?? nw;
+  NativeWatcher.isSupported = () => true;
+} catch (e) { console.warn('[lifo] NativeWatcher patch failed (no Fast Refresh):', e && e.message); }
+
+const { expoStart } = await import('@expo/cli/build/src/start/index.js');
+await expoStart([process.cwd(), '--web', '--port', '8082']);
+console.log('\\nMetro dev server on http://localhost:8082 — open the preview and edit app/index.js.');
+await new Promise(() => {}); // keep the dev server alive
 `;
 
 	files[`${root}/export.mjs`] = `process.env.NODE_ENV = 'production';

--- a/apps/playground/src/data/templates/expo.ts
+++ b/apps/playground/src/data/templates/expo.ts
@@ -73,6 +73,7 @@ process.env.EXPO_OFFLINE = '1';
 process.env.CI = '1';            // non-interactive: skip keypress UI + prompts
 process.env.BROWSER = 'none';    // don't try to open a system browser
 process.env.EXPO_NO_TELEMETRY = '1';
+process.env.EXPO_NO_DEPENDENCY_VALIDATION = '1'; // skip the semver doctor check
 
 const { expoStart } = await import('@expo/cli/build/src/start/index.js');
 await expoStart([process.cwd(), '--web', '--port', '8081']);

--- a/apps/playground/src/data/templates/expo.ts
+++ b/apps/playground/src/data/templates/expo.ts
@@ -6,6 +6,7 @@ export function expoAppFiles(root: string): Record<string, string> {
 		version: '1.0.0',
 		main: 'expo/AppEntry.js',
 		scripts: {
+			start: 'node start.mjs',
 			export: 'node export.mjs',
 			serve: 'node serve.mjs',
 		},
@@ -35,8 +36,8 @@ export default function App() {
     <View style={styles.container}>
       <Text style={styles.title}>Expo inside Lifo 🚀</Text>
       <Text style={styles.subtitle}>
-        This React Native app was bundled by Metro running in your browser,
-        then exported to a static web build.
+        This React Native app is served by a Metro dev server running in your
+        browser. Edit this text and save — Fast Refresh updates it in place.
       </Text>
     </View>
   );
@@ -63,7 +64,23 @@ config.resolver.useWatchman = false;
 module.exports = config;
 `;
 
-	// The `expo export` CLI doesn't await its async command, so run it directly.
+	// Boot the Expo web dev server (Metro) non-interactively. Unlike \`expo export\`
+	// (a one-shot static build), this stays alive serving bundles + a Fast Refresh
+	// HMR websocket — which rides the same service-worker WebSocket shim the Vite
+	// HMR example uses, so edits update the preview in place.
+	files[`${root}/start.mjs`] = `process.env.NODE_ENV = 'development';
+process.env.EXPO_OFFLINE = '1';
+process.env.CI = '1';            // non-interactive: skip keypress UI + prompts
+process.env.BROWSER = 'none';    // don't try to open a system browser
+process.env.EXPO_NO_TELEMETRY = '1';
+
+const { expoStart } = await import('@expo/cli/build/src/start/index.js');
+await expoStart([process.cwd(), '--web', '--port', '8081']);
+console.log('\\nMetro dev server on http://localhost:8081 — open the preview and edit App.js.');
+await new Promise(() => {}); // keep the dev server alive
+`;
+
+	// The \`expo export\` CLI doesn't await its async command, so run it directly.
 	files[`${root}/export.mjs`] = `process.env.NODE_ENV = 'production';
 process.env.EXPO_OFFLINE = '1';
 const { expoExport } = await import('@expo/cli/build/src/export/index.js');

--- a/apps/playground/src/data/templates/expo.ts
+++ b/apps/playground/src/data/templates/expo.ts
@@ -4,7 +4,7 @@ export function expoAppFiles(root: string): Record<string, string> {
 	files[`${root}/package.json`] = JSON.stringify({
 		name: 'expo-app',
 		version: '1.0.0',
-		main: 'expo/AppEntry.js',
+		main: 'index.js',
 		scripts: {
 			start: 'node start.mjs',
 			export: 'node export.mjs',
@@ -29,16 +29,40 @@ export function expoAppFiles(root: string): Record<string, string> {
 		},
 	}, null, 2);
 
-	files[`${root}/App.js`] = `import { StyleSheet, Text, View } from 'react-native';
+	// Fast Refresh requires the react-refresh runtime to be installed BEFORE any
+	// component module executes — Metro registers a module's components only if
+	// global.__ReactRefresh exists when the module loads. So @expo/metro-runtime
+	// must be the first import of the ENTRY file (the standard Expo web pattern),
+	// not of App.js: importing it inside App.js runs too late, leaving the initial
+	// App unregistered → every edit "invalidates" the boundary → full reload.
+	files[`${root}/index.js`] = `import '@expo/metro-runtime';
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);
+`;
+
+	files[`${root}/App.js`] = `import { useState } from 'react';
+import { StyleSheet, Text, View, Pressable } from 'react-native';
 
 export default function App() {
+  const [count, setCount] = useState(0);
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Expo inside Lifo 🚀</Text>
       <Text style={styles.subtitle}>
-        This React Native app is served by a Metro dev server running in your
-        browser. Edit this text and save — Fast Refresh updates it in place.
+        Served by a Metro dev server running in your browser. Edit App.js and
+        save — Fast Refresh updates it in place, keeping the counter value.
       </Text>
+      <View style={styles.row}>
+        <Pressable style={styles.btn} onPress={() => setCount((c) => c - 1)}>
+          <Text style={styles.btnText}>–</Text>
+        </Pressable>
+        <Text style={styles.count}>{count}</Text>
+        <Pressable style={styles.btn} onPress={() => setCount((c) => c + 1)}>
+          <Text style={styles.btnText}>+</Text>
+        </Pressable>
+      </View>
     </View>
   );
 }
@@ -46,7 +70,11 @@ export default function App() {
 const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#1a1b26', padding: 24 },
   title: { fontSize: 28, fontWeight: '700', color: '#c0caf5', marginBottom: 12 },
-  subtitle: { fontSize: 15, color: '#9aa5ce', textAlign: 'center', maxWidth: 420, lineHeight: 22 },
+  subtitle: { fontSize: 15, color: '#9aa5ce', textAlign: 'center', maxWidth: 420, lineHeight: 22, marginBottom: 24 },
+  row: { flexDirection: 'row', alignItems: 'center', gap: 20 },
+  btn: { width: 44, height: 44, borderRadius: 22, backgroundColor: '#7aa2f7', alignItems: 'center', justifyContent: 'center' },
+  btnText: { fontSize: 24, fontWeight: '700', color: '#1a1b26' },
+  count: { fontSize: 28, fontWeight: '700', color: '#c0caf5', minWidth: 48, textAlign: 'center' },
 });
 `;
 
@@ -70,37 +98,23 @@ module.exports = config;
 	// HMR example uses, so edits update the preview in place.
 	files[`${root}/start.mjs`] = `process.env.NODE_ENV = 'development';
 process.env.EXPO_OFFLINE = '1';
-process.env.CI = '1';            // non-interactive: skip keypress UI + prompts
+// NOTE: do NOT set CI — Expo is already non-interactive here (isInteractive() is
+// !CI && stdout.isTTY, and the VM's stdout isn't a TTY), and CI=1 makes Metro
+// disable file watching, which kills Fast Refresh.
 process.env.BROWSER = 'none';    // don't try to open a system browser
 process.env.EXPO_NO_TELEMETRY = '1';
-process.env.EXPO_NO_DEPENDENCY_VALIDATION = '1'; // skip the semver doctor check
+process.env.EXPO_NO_DEPENDENCY_VALIDATION = '1'; // skip the version doctor check
 
-// Run Metro's bundle handler (processRequest) ahead of Expo's SPA fallback.
-// Inside Lifo's VM the .bundle request was falling through to the history
-// fallback (index.html), so the bundle never got built. Wrapping
-// createConnectMiddleware lets Metro handle .bundle/.map/assets first and only
-// falls back for real page routes. The [lifo-expo] logs confirm the routing.
-const metroMod = await import('metro');
-const metro = metroMod.default ?? metroMod;
-const origCreateConnectMiddleware = metro.createConnectMiddleware;
-metro.createConnectMiddleware = async function (config, options) {
-  const result = await origCreateConnectMiddleware.call(this, config, options);
-  const processRequest = result.metroServer.processRequest.bind(result.metroServer);
-  const fallback = result.middleware;
-  const wrapped = (req, res, next) => {
-    const isBundle = /\\.(bundle|map)(\\?|$)/.test(req.url || '');
-    if (isBundle) console.log('[lifo-expo] bundle request →', req.url);
-    processRequest(req, res, (err) => {
-      if (isBundle) console.log('[lifo-expo] processRequest fell through for', req.url, err ? 'err=' + err.message : '(no match)');
-      if (err) return next ? next(err) : res.end();
-      return fallback(req, res, next);
-    });
-  };
-  wrapped.use = (...a) => { fallback.use(...a); return wrapped; };
-  Object.defineProperty(wrapped, 'stack', { get: () => fallback.stack, set: (v) => { fallback.stack = v; } });
-  result.middleware = wrapped;
-  return result;
-};
+// Metro's efficient recursive watcher (fs.watch(root, { recursive: true })) is
+// gated to macOS; the VM reports platform 'lifo', so Metro would fall back to a
+// per-directory walker-based watcher that doesn't observe VFS writes (no Fast
+// Refresh). Lifo's fs.watch supports { recursive: true }, so force the native
+// watcher — this is what makes editing a file rebuild + hot-reload.
+try {
+  const nw = await import('metro-file-map/src/watchers/NativeWatcher.js');
+  const NativeWatcher = nw.default ?? nw;
+  NativeWatcher.isSupported = () => true;
+} catch (e) { console.warn('[lifo] NativeWatcher patch failed (no Fast Refresh):', e && e.message); }
 
 const { expoStart } = await import('@expo/cli/build/src/start/index.js');
 await expoStart([process.cwd(), '--web', '--port', '8081']);

--- a/apps/playground/src/data/templates/expo.ts
+++ b/apps/playground/src/data/templates/expo.ts
@@ -75,6 +75,33 @@ process.env.BROWSER = 'none';    // don't try to open a system browser
 process.env.EXPO_NO_TELEMETRY = '1';
 process.env.EXPO_NO_DEPENDENCY_VALIDATION = '1'; // skip the semver doctor check
 
+// Run Metro's bundle handler (processRequest) ahead of Expo's SPA fallback.
+// Inside Lifo's VM the .bundle request was falling through to the history
+// fallback (index.html), so the bundle never got built. Wrapping
+// createConnectMiddleware lets Metro handle .bundle/.map/assets first and only
+// falls back for real page routes. The [lifo-expo] logs confirm the routing.
+const metroMod = await import('metro');
+const metro = metroMod.default ?? metroMod;
+const origCreateConnectMiddleware = metro.createConnectMiddleware;
+metro.createConnectMiddleware = async function (config, options) {
+  const result = await origCreateConnectMiddleware.call(this, config, options);
+  const processRequest = result.metroServer.processRequest.bind(result.metroServer);
+  const fallback = result.middleware;
+  const wrapped = (req, res, next) => {
+    const isBundle = /\\.(bundle|map)(\\?|$)/.test(req.url || '');
+    if (isBundle) console.log('[lifo-expo] bundle request →', req.url);
+    processRequest(req, res, (err) => {
+      if (isBundle) console.log('[lifo-expo] processRequest fell through for', req.url, err ? 'err=' + err.message : '(no match)');
+      if (err) return next ? next(err) : res.end();
+      return fallback(req, res, next);
+    });
+  };
+  wrapped.use = (...a) => { fallback.use(...a); return wrapped; };
+  Object.defineProperty(wrapped, 'stack', { get: () => fallback.stack, set: (v) => { fallback.stack = v; } });
+  result.middleware = wrapped;
+  return result;
+};
+
 const { expoStart } = await import('@expo/cli/build/src/start/index.js');
 await expoStart([process.cwd(), '--web', '--port', '8081']);
 console.log('\\nMetro dev server on http://localhost:8081 — open the preview and edit App.js.');

--- a/apps/playground/src/examples/expo-router.tsx
+++ b/apps/playground/src/examples/expo-router.tsx
@@ -7,8 +7,8 @@ export default function ExpoRouterExample() {
       title="Expo Router"
       subtitle={
         <>
-          File-based routing with Expo Router, exported to a static web build — <code>npm install</code>,
-          then <code>npx expo export --platform web</code>.
+          File-based routing with Expo Router on a live Metro dev server — <code>npm install</code>,
+          then <code>npm run start</code>. Edit <code>app/index.js</code> and save for Fast Refresh.
         </>
       }
       files={expoRouterAppFiles('/home/user/expo-router-app')}

--- a/apps/playground/src/examples/expo.tsx
+++ b/apps/playground/src/examples/expo.tsx
@@ -7,8 +7,9 @@ export default function ExpoExample() {
       title="Expo (React Native Web)"
       subtitle={
         <>
-          A React Native app built for the web with Metro — <code>npm install</code>, then{' '}
-          <code>npx expo export --platform web</code> and preview the exported build.
+          A React Native app on a live Metro dev server in your browser —{' '}
+          <code>npm install</code>, then <code>npm run start</code>. Edit <code>App.js</code> and
+          save for Fast Refresh in the preview.
         </>
       }
       files={expoAppFiles('/home/user/expo-app')}

--- a/packages/core/src/commands/system/node.ts
+++ b/packages/core/src/commands/system/node.ts
@@ -796,7 +796,9 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 		const nodeCtx: NodeContext = {
 			vfs: ctx.vfs,
 			cwd: ctx.cwd,
-			env: ctx.env,
+			// Copy the shell env once so the node run has its own process.env
+			// (isolated from the shell) that is then shared across all its modules.
+			env: { ...ctx.env },
 			stdout: ctx.stdout,
 			stderr: ctx.stderr,
 			argv: [filename, ...scriptArgs],

--- a/packages/core/src/kernel/network/ServiceWorkerBridge.ts
+++ b/packages/core/src/kernel/network/ServiceWorkerBridge.ts
@@ -13,6 +13,7 @@ import type { VirtualRequestHandler } from '../index.js';
 import type { VirtualResponseWithDone } from '../../node-compat/http.js';
 import { getUpgradeHandlers } from '../../node-compat/http.js';
 import { EventEmitter } from '../../node-compat/events.js';
+import { Buffer } from '../../node-compat/buffer.js';
 import { encodeFrame, FrameDecoder, OPCODE, splitHandshake } from './ws-frame.js';
 
 interface SwRequestMessage {
@@ -398,7 +399,10 @@ export class ServiceWorkerBridge {
 		if (!conn || conn.socket.destroyed) return;
 		const payload = base64ToBytes(msg.data);
 		const opcode = msg.binary ? OPCODE.binary : OPCODE.text;
-		conn.socket.emit('data', encodeFrame(opcode, payload, randomMask));
+		// Emit a Buffer (not a raw Uint8Array): in-VM ws servers (e.g. Metro's HMR
+		// server via the `ws` package) parse frames with Buffer methods like
+		// readUInt16BE, which a plain Uint8Array lacks.
+		conn.socket.emit('data', Buffer.from(encodeFrame(opcode, payload, randomMask)));
 	}
 
 	private handleWsClose(msg: SwWsCloseMessage): void {
@@ -407,7 +411,7 @@ export class ServiceWorkerBridge {
 		this.wsConns.delete(msg.connId);
 		// Send a WS close frame, then tear the socket down.
 		if (!conn.socket.destroyed) {
-			conn.socket.emit('data', encodeFrame(OPCODE.close, new Uint8Array(0), randomMask));
+			conn.socket.emit('data', Buffer.from(encodeFrame(OPCODE.close, new Uint8Array(0), randomMask)));
 			conn.socket.destroy();
 		}
 	}

--- a/packages/core/src/node-compat/buffer.ts
+++ b/packages/core/src/node-compat/buffer.ts
@@ -52,6 +52,14 @@ export class Buffer extends Uint8Array {
     return new Buffer(size);
   }
 
+  // Node pools allocUnsafe but not allocUnsafeSlow; for us they're identical.
+  // safe-buffer only uses the real Buffer when from/alloc/allocUnsafe AND
+  // allocUnsafeSlow all exist — otherwise it wraps it and drops static methods
+  // like isBuffer (non-enumerable, so its for..in copy misses them).
+  static allocUnsafeSlow(size: number): Buffer {
+    return new Buffer(size);
+  }
+
   static isBuffer(obj: unknown): obj is Buffer {
     return obj instanceof Buffer;
   }

--- a/packages/core/src/node-compat/child_process.ts
+++ b/packages/core/src/node-compat/child_process.ts
@@ -40,8 +40,40 @@ export function createChildProcess(executeCapture?: ExecuteCapture) {
     throw new Error('child_process.execSync() is not supported in Lifo');
   }
 
-  function spawn(): never {
-    throw new Error('child_process.spawn() is not supported in Lifo');
+  function spawn(): EventEmitter {
+    // No real subprocesses in the VM. Rather than throw (which crashes tools
+    // that spawn optional helpers — e.g. `open` launching a browser, which is
+    // meaningless here since the preview iframe IS the browser), return a
+    // benign child that immediately exits 0 with empty output streams.
+    const child = new EventEmitter() as EventEmitter & Record<string, unknown>;
+    const mkStream = () => {
+      const s = new EventEmitter() as EventEmitter & Record<string, unknown>;
+      s.pipe = (dest: unknown) => dest;
+      s.setEncoding = () => s;
+      s.destroy = () => s;
+      s.read = () => null;
+      s.resume = () => s;
+      s.pause = () => s;
+      return s;
+    };
+    const stdin = new EventEmitter() as EventEmitter & Record<string, unknown>;
+    stdin.write = () => true;
+    stdin.end = () => {};
+    child.stdout = mkStream();
+    child.stderr = mkStream();
+    child.stdin = stdin;
+    child.pid = 0;
+    child.kill = () => true;
+    child.unref = () => child;
+    child.ref = () => child;
+    queueMicrotask(() => {
+      (child.stdout as EventEmitter).emit('end');
+      (child.stderr as EventEmitter).emit('end');
+      child.emit('spawn');
+      child.emit('close', 0, null);
+      child.emit('exit', 0, null);
+    });
+    return child;
   }
 
   function fork(): never {

--- a/packages/core/src/node-compat/http.ts
+++ b/packages/core/src/node-compat/http.ts
@@ -399,7 +399,13 @@ class Server extends EventEmitter {
 
     // Register the handler in portRegistry
     const handler: VirtualRequestHandler = (vReq, vRes) => {
-      const req = new IncomingMessage(0, '', vReq.headers);
+      // Browser requests reach us via fetch/service-worker, which strips the
+      // forbidden `Host` header. Servers rely on it (Metro builds its bundle URL
+      // from `req.headers.host`, and a missing host yields a malformed URL), so
+      // default it to this server's own authority.
+      const headers = { ...vReq.headers };
+      if (!headers.host && !headers.Host) headers.host = `localhost:${port}`;
+      const req = new IncomingMessage(0, '', headers);
       req.method = vReq.method;
       req.url = vReq.url;
 

--- a/packages/core/src/node-compat/index.ts
+++ b/packages/core/src/node-compat/index.ts
@@ -25,6 +25,37 @@ import * as asyncHooksModule from './async_hooks.js';
 import { createRimraf } from './rimraf.js';
 import { createEsbuild } from './esbuild.js';
 
+// Fake ephemeral port source for net/tls Server stubs (no real TCP in the VM).
+let __fakeEphemeralPort = 49152;
+
+/**
+ * Wire up a fake net.Server EventEmitter. Node's `listen` has many overloads
+ * (`listen(port, cb)`, `listen(port, host, cb)`, `listen(options, cb)`,
+ * `listen(cb)`) and callers may await the `'listening'` event instead of a
+ * callback — the previous stub only handled the 3-arg form, so port probes
+ * (e.g. Expo's `freeport-async` calling `listen(0, cb)`) hung forever.
+ */
+function applyFakeServer(s: EventEmitter): void {
+  let boundPort = 0;
+  const rec = s as unknown as Record<string, unknown>;
+  rec.listen = (...args: unknown[]) => {
+    const cb = args.find((a) => typeof a === 'function') as (() => void) | undefined;
+    let port = args.find((a) => typeof a === 'number') as number | undefined;
+    if (port === undefined) {
+      const opts = args.find((a) => a && typeof a === 'object') as { port?: number } | undefined;
+      port = opts?.port;
+    }
+    boundPort = port && port > 0 ? port : __fakeEphemeralPort++;
+    queueMicrotask(() => { s.emit('listening'); cb?.(); });
+    return s;
+  };
+  rec.close = (cb?: () => void) => { queueMicrotask(() => { s.emit('close'); cb?.(); }); return s; };
+  rec.address = () => ({ port: boundPort, family: 'IPv4', address: '127.0.0.1' });
+  rec.getConnections = (cb?: (err: Error | null, count: number) => void) => { cb?.(null, 0); return s; };
+  rec.unref = () => s;
+  rec.ref = () => s;
+}
+
 export interface NodeContext {
   vfs: VFS;
   cwd: string;
@@ -233,13 +264,11 @@ export function createModuleMap(ctx: NodeContext): Record<string, () => unknown>
     }),
     // net — stub (vite imports it but only uses it for actual TCP in server mode)
     net: () => ({
-      createServer: () => {
+      createServer: (...cargs: unknown[]) => {
         const s = new EventEmitter() as unknown as Record<string, unknown>;
-        s.listen = (_port: unknown, _host: unknown, cb?: () => void) => { cb?.(); return s; };
-        s.close = (cb?: () => void) => { cb?.(); return s; };
-        s.address = () => ({ port: 0, family: 'IPv4', address: '127.0.0.1' });
-        s.unref = () => s;
-        s.ref = () => s;
+        const connCb = cargs.find((a) => typeof a === 'function') as (() => void) | undefined;
+        if (connCb) (s as unknown as EventEmitter).on('connection', connCb);
+        applyFakeServer(s as unknown as EventEmitter);
         return s;
       },
       createConnection: () => {
@@ -282,11 +311,7 @@ export function createModuleMap(ctx: NodeContext): Record<string, () => unknown>
         setKeepAlive() { return this; }
       },
       Server: class Server extends EventEmitter {
-        listen(_port: unknown, _host: unknown, cb?: () => void) { cb?.(); return this; }
-        close(cb?: () => void) { cb?.(); return this; }
-        address() { return { port: 0, family: 'IPv4', address: '127.0.0.1' }; }
-        unref() { return this; }
-        ref() { return this; }
+        constructor() { super(); applyFakeServer(this); }
       },
       isIP: (s: string) => /^\d+\.\d+\.\d+\.\d+$/.test(s) ? 4 : /^[0-9a-f:]+$/i.test(s) ? 6 : 0,
       isIPv4: (s: string) => /^\d+\.\d+\.\d+\.\d+$/.test(s),
@@ -294,11 +319,11 @@ export function createModuleMap(ctx: NodeContext): Record<string, () => unknown>
     }),
     // tls — stub
     tls: () => ({
-      createServer: () => {
+      createServer: (...cargs: unknown[]) => {
         const s = new EventEmitter() as unknown as Record<string, unknown>;
-        s.listen = (_port: unknown, _host: unknown, cb?: () => void) => { cb?.(); return s; };
-        s.close = (cb?: () => void) => { cb?.(); return s; };
-        s.address = () => ({ port: 0, family: 'IPv4', address: '127.0.0.1' });
+        const connCb = cargs.find((a) => typeof a === 'function') as (() => void) | undefined;
+        if (connCb) (s as unknown as EventEmitter).on('secureConnection', connCb);
+        applyFakeServer(s as unknown as EventEmitter);
         return s;
       },
       connect: () => {

--- a/packages/core/src/node-compat/process.ts
+++ b/packages/core/src/node-compat/process.ts
@@ -24,7 +24,12 @@ export function createProcess(opts: ProcessOptions) {
   const proc = {
     argv: ['/usr/bin/node', ...opts.argv],
     argv0: 'node',
-    env: { ...opts.env },
+    // Share the env object by reference — Node has a single process.env across
+    // all modules in a process. (The node command copies the shell env once, so
+    // this shares within the run without leaking back to the shell.) Copying
+    // here would isolate each module, so `process.env.X = ...` set in an entry
+    // script wouldn't be visible to required modules.
+    env: opts.env,
     cwd: () => opts.cwd,
     chdir: (_dir: string) => { throw new Error('process.chdir() is not supported in Lifo'); },
     exit: (code = 0) => {

--- a/packages/core/src/node-compat/timers.ts
+++ b/packages/core/src/node-compat/timers.ts
@@ -1,21 +1,81 @@
-export const _setTimeout = globalThis.setTimeout;
-export const _setInterval = globalThis.setInterval;
-export const _clearTimeout = globalThis.clearTimeout;
-export const _clearInterval = globalThis.clearInterval;
+// Node's `timers` module returns Timeout/Immediate objects with .ref()/.unref()/
+// .refresh(), not the bare numeric id the browser's setTimeout returns. Code that
+// does `require('timers').setTimeout(...).unref()` / `.refresh()` (e.g. Metro's
+// metro-file-map DiskCacheManager) needs those methods, so wrap the global timers.
+const g = globalThis;
 
-export function setImmediate(fn: (...args: unknown[]) => void, ...args: unknown[]): ReturnType<typeof setTimeout> {
-  return _setTimeout(() => fn(...args), 0);
+export const _setTimeout = g.setTimeout;
+export const _setInterval = g.setInterval;
+export const _clearTimeout = g.clearTimeout;
+export const _clearInterval = g.clearInterval;
+
+class Timer {
+  private _id: ReturnType<typeof g.setTimeout> | null;
+  private readonly _fn: (...args: unknown[]) => void;
+  private readonly _ms: number;
+  private readonly _args: unknown[];
+  private readonly _interval: boolean;
+
+  constructor(fn: (...args: unknown[]) => void, ms: number, args: unknown[], interval: boolean) {
+    this._fn = fn;
+    this._ms = ms;
+    this._args = args;
+    this._interval = interval;
+    this._id = interval ? g.setInterval(() => fn(...args), ms) : g.setTimeout(() => fn(...args), ms);
+  }
+
+  ref(): this { return this; }
+  unref(): this { return this; }
+  hasRef(): boolean { return true; }
+
+  refresh(): this {
+    this.close();
+    this._id = this._interval
+      ? g.setInterval(() => this._fn(...this._args), this._ms)
+      : g.setTimeout(() => this._fn(...this._args), this._ms);
+    return this;
+  }
+
+  close(): void {
+    if (this._id != null) {
+      if (this._interval) g.clearInterval(this._id);
+      else g.clearTimeout(this._id);
+    }
+    this._id = null;
+  }
+
+  /** Number coercion returns the underlying id (Node parity for `+timeout`). */
+  [Symbol.toPrimitive](): number {
+    return this._id as unknown as number;
+  }
 }
 
-export function clearImmediate(id: ReturnType<typeof setTimeout>): void {
-  _clearTimeout(id);
+export function setTimeout(fn: (...args: unknown[]) => void, ms = 0, ...args: unknown[]): Timer {
+  return new Timer(fn, ms, args, false);
 }
 
-export default {
-  setTimeout: _setTimeout,
-  setInterval: _setInterval,
-  clearTimeout: _clearTimeout,
-  clearInterval: _clearInterval,
-  setImmediate,
-  clearImmediate,
-};
+export function setInterval(fn: (...args: unknown[]) => void, ms = 0, ...args: unknown[]): Timer {
+  return new Timer(fn, ms, args, true);
+}
+
+export function clearTimeout(t: Timer | number | undefined | null): void {
+  if (t == null) return;
+  if (t instanceof Timer) t.close();
+  else g.clearTimeout(t);
+}
+
+export function clearInterval(t: Timer | number | undefined | null): void {
+  if (t == null) return;
+  if (t instanceof Timer) t.close();
+  else g.clearInterval(t);
+}
+
+export function setImmediate(fn: (...args: unknown[]) => void, ...args: unknown[]): Timer {
+  return new Timer(fn, 0, args, false);
+}
+
+export function clearImmediate(t: Timer | number | undefined | null): void {
+  clearTimeout(t);
+}
+
+export default { setTimeout, setInterval, clearTimeout, clearInterval, setImmediate, clearImmediate };

--- a/packages/core/src/node-compat/url.ts
+++ b/packages/core/src/node-compat/url.ts
@@ -90,7 +90,12 @@ export function format(urlObj: {
     (!!urlObj.protocol && /^(?:https?|ftp|gopher|file|wss?):?$/i.test(urlObj.protocol));
   if (wantsSlashes) result += '//';
   if (host) result += host;
-  if (urlObj.pathname) result += urlObj.pathname;
+  if (urlObj.pathname) {
+    // Node prepends '/' to a pathname that doesn't start with one when the URL
+    // has an authority — otherwise host and path fuse (e.g. Metro HMR building
+    // "http://host" + "App.bundle" → "http://hostApp.bundle", an empty-path URL).
+    result += wantsSlashes && !urlObj.pathname.startsWith('/') ? '/' + urlObj.pathname : urlObj.pathname;
+  }
   if (urlObj.search) {
     result += urlObj.search.startsWith('?') ? urlObj.search : '?' + urlObj.search;
   } else if (urlObj.query && typeof urlObj.query === 'object') {

--- a/packages/core/src/node-compat/url.ts
+++ b/packages/core/src/node-compat/url.ts
@@ -4,7 +4,10 @@ const _URLSearchParams = globalThis.URLSearchParams;
 
 export { _URL as URL, _URLSearchParams as URLSearchParams };
 
-export function parse(urlString: string): {
+export function parse(
+  urlString: string,
+  parseQueryString = false,
+): {
   protocol: string | null;
   hostname: string | null;
   port: string | null;
@@ -14,46 +17,89 @@ export function parse(urlString: string): {
   host: string | null;
   href: string;
   path: string;
-  query: string | null;
+  query: string | Record<string, string> | null;
 } {
+  // Server req.url values are relative ("/a/b?c=1"); `new URL` throws on those,
+  // so parse against a dummy base and null out the origin fields (matching
+  // Node's url.parse). Getting this right is essential: Metro detects bundles
+  // via `pathname.endsWith('.bundle')`, which breaks if the query leaks into
+  // pathname. `parseQueryString` returns `query` as an object (Node semantics).
+  let u: URL;
+  let isRelative = false;
   try {
-    const u = new URL(urlString);
-    return {
-      protocol: u.protocol,
-      hostname: u.hostname,
-      port: u.port || null,
-      pathname: u.pathname,
-      search: u.search || null,
-      hash: u.hash || null,
-      host: u.host,
-      href: u.href,
-      path: u.pathname + (u.search || ''),
-      query: u.search ? u.search.slice(1) : null,
-    };
+    u = new URL(urlString);
   } catch {
-    return {
-      protocol: null,
-      hostname: null,
-      port: null,
-      pathname: urlString,
-      search: null,
-      hash: null,
-      host: null,
-      href: urlString,
-      path: urlString,
-      query: null,
-    };
+    try {
+      u = new URL(urlString, 'http://lifo.local');
+      isRelative = true;
+    } catch {
+      return {
+        protocol: null, hostname: null, port: null,
+        pathname: urlString, search: null, hash: null, host: null,
+        href: urlString, path: urlString,
+        query: parseQueryString ? {} : null,
+      };
+    }
   }
+
+  const query: string | Record<string, string> | null = parseQueryString
+    ? Object.fromEntries(u.searchParams.entries())
+    : u.search ? u.search.slice(1) : null;
+
+  return {
+    protocol: isRelative ? null : u.protocol,
+    hostname: isRelative ? null : u.hostname,
+    port: isRelative ? null : (u.port || null),
+    pathname: u.pathname,
+    search: u.search || null,
+    hash: u.hash || null,
+    host: isRelative ? null : u.host,
+    href: isRelative ? u.pathname + u.search + u.hash : u.href,
+    path: u.pathname + (u.search || ''),
+    query,
+  };
 }
 
-export function format(urlObj: { protocol?: string; hostname?: string; port?: string | number; pathname?: string; search?: string; hash?: string }): string {
+export function format(urlObj: {
+  protocol?: string | null;
+  slashes?: boolean;
+  hostname?: string | null;
+  host?: string | null;
+  port?: string | number | null;
+  pathname?: string | null;
+  search?: string | null;
+  query?: string | Record<string, string> | null;
+  hash?: string | null;
+}): string {
   let result = '';
-  if (urlObj.protocol) result += urlObj.protocol + '//';
-  if (urlObj.hostname) result += urlObj.hostname;
-  if (urlObj.port) result += ':' + urlObj.port;
+  if (urlObj.protocol) {
+    // Node stores protocol with a trailing ':', but callers (e.g. Metro's
+    // `url.format({...urlObj, protocol: "http"})`) may omit it. Without the
+    // colon, `protocol + "//"` yields "http//" and the whole URL is malformed.
+    result += urlObj.protocol.endsWith(':') ? urlObj.protocol : urlObj.protocol + ':';
+  }
+  // Prefer `host` (host:port together) — Metro sets this; fall back to hostname[:port].
+  const host = urlObj.host
+    ? urlObj.host
+    : urlObj.hostname
+      ? urlObj.hostname + (urlObj.port != null && urlObj.port !== '' ? ':' + urlObj.port : '')
+      : '';
+  const wantsSlashes =
+    urlObj.slashes === true ||
+    !!host ||
+    (!!urlObj.protocol && /^(?:https?|ftp|gopher|file|wss?):?$/i.test(urlObj.protocol));
+  if (wantsSlashes) result += '//';
+  if (host) result += host;
   if (urlObj.pathname) result += urlObj.pathname;
-  if (urlObj.search) result += urlObj.search;
-  if (urlObj.hash) result += urlObj.hash;
+  if (urlObj.search) {
+    result += urlObj.search.startsWith('?') ? urlObj.search : '?' + urlObj.search;
+  } else if (urlObj.query && typeof urlObj.query === 'object') {
+    const qs = new _URLSearchParams(urlObj.query as Record<string, string>).toString();
+    if (qs) result += '?' + qs;
+  }
+  if (urlObj.hash) {
+    result += urlObj.hash.startsWith('#') ? urlObj.hash : '#' + urlObj.hash;
+  }
   return result;
 }
 

--- a/packages/core/src/node-compat/util.ts
+++ b/packages/core/src/node-compat/util.ts
@@ -27,6 +27,16 @@ export function format(fmt: string, ...args: unknown[]): string {
   return result;
 }
 
+/**
+ * Like `format`, but the first argument is an inspect-options object (Node's
+ * `util.formatWithOptions(inspectOptions, format, ...args)`). We don't thread
+ * the options into inspect (colors/depth are cosmetic), so just delegate — the
+ * `debug` package relies on this existing.
+ */
+export function formatWithOptions(_inspectOptions: unknown, fmt: string, ...args: unknown[]): string {
+  return format(fmt, ...args);
+}
+
 export function inspect(obj: unknown, opts?: { depth?: number; colors?: boolean }): string {
   const depth = opts?.depth ?? 2;
   return formatValue(obj, depth);
@@ -201,4 +211,4 @@ export const debug = debuglog;
 export const TextDecoder = globalThis.TextDecoder;
 export const TextEncoder = globalThis.TextEncoder;
 
-export default { format, inspect, promisify, inherits, deprecate, types, styleText, stripVTControlCharacters, debuglog, debug, TextDecoder, TextEncoder };
+export default { format, formatWithOptions, inspect, promisify, inherits, deprecate, types, styleText, stripVTControlCharacters, debuglog, debug, TextDecoder, TextEncoder };


### PR DESCRIPTION
## Summary
`expo start --web` — the real Metro dev server, unmodified — now runs end-to-end inside the Lifo VM: `npm install` → `npm run start` → bundle served over the service worker → file watching → rebuild on save → **Fast Refresh** (in-place, state-preserving) over the `/hot` HMR WebSocket through the SW shim. No bundler-layer changes; everything was fixed at the node-compat/OS-shim level, per Lifo's design.

## node-compat fixes (each unblocks a real Metro/Expo code path)
- `util.formatWithOptions` (the `debug` package requires it)
- `net`/`tls` Server stubs: handle every `listen()` overload + emit `'listening'` (Expo's port probing via `freeport-async` hung forever)
- `child_process.spawn`: return a benign exited child instead of throwing (Expo's browser-open step crashed startup)
- `Buffer.allocUnsafeSlow` (without it `safe-buffer` wraps Buffer and drops `isBuffer`, breaking the `compression` middleware)
- `url.parse`: support relative URLs + `parseQueryString` (query leaked into `pathname`, so Metro never matched `.bundle` requests)
- `url.format`: protocol colon, `host` field, and authority path slash (malformed bundle + HMR-delta URLs)
- Default `Host` header for in-VM servers (fetch/SW strips it; Metro builds URLs from it)
- `timers`: Node-style `Timeout` objects with `ref/unref/refresh` (metro-file-map's DiskCacheManager)
- Shared `process.env` across a node run's modules (env set in an entry script now reaches required modules)
- ServiceWorkerBridge: ws frames delivered as `Buffer` (Metro's `ws`-based HMR server parses with `readUInt16BE`)

## Playground templates
- **Expo** + **Expo Router** examples now run a live dev server (`npm run start`) with a stateful counter demonstrating Fast Refresh.
- Root-cause subtleties encoded in the templates:
  - `index.js` entry imports `@expo/metro-runtime` **first** — Metro only registers components with react-refresh if `__ReactRefresh` exists when a module executes; importing it later means every edit "invalidates" the boundary → full reload.
  - `start.mjs` forces Metro's recursive NativeWatcher (gated to darwin upstream; the fallback walker never sees VFS writes) and must **not** set `CI` (disables Metro watch mode).

## Test plan
- Verified live in-browser: install, start, preview render, edit `App.js` → Fast Refresh applies in place with counter state preserved (confirmed via instrumented `/hot` traffic + react-refresh runtime tracing, since removed).
- `pnpm --filter @lifo-sh/playground build` clean; playground tsc clean. (Core has pre-existing type errors in curl/npm/systemctl/main unrelated to this branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)