### PR TITLE
Expo Router sub-path routing, dynamic Expo configs, portable templates

### DIFF
--- a/apps/playground/src/components/preview-browser.tsx
+++ b/apps/playground/src/components/preview-browser.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 interface PreviewBrowserProps {
   /** In-VM virtual port; the iframe loads /_sw/<port>/ through the service worker. */
@@ -13,22 +13,57 @@ interface PreviewBrowserProps {
 export function PreviewBrowser({ port }: PreviewBrowserProps) {
   const path = `/_sw/${port}/`;
   const [nonce, setNonce] = useState(0);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [currentUrl, setCurrentUrl] = useState(location.origin + path);
+
+  // The preview is same-origin, so its live URL is readable — but client-side
+  // routing (history.pushState, e.g. Expo Router / react-router) fires no event
+  // in the parent, so poll. Keeps the address bar and open-in-new-tab honest.
+  useEffect(() => {
+    const timer = setInterval(() => {
+      try {
+        const href = iframeRef.current?.contentWindow?.location.href;
+        if (href && href !== 'about:blank') setCurrentUrl(href);
+      } catch {
+        // Not ready or (unexpectedly) cross-origin — keep the last known URL.
+      }
+    }, 500);
+    return () => clearInterval(timer);
+  }, []);
+
+  const displayUrl = currentUrl.replace(/[?&]_t=\d+/, '');
+  let openHref = path;
+  try {
+    const u = new URL(currentUrl);
+    openHref = u.pathname + u.search.replace(/[?&]_t=\d+/, '');
+  } catch {
+    // keep the root path
+  }
+
+  const reload = () => {
+    try {
+      // Reload in place so the current route survives (deep links keep working).
+      iframeRef.current?.contentWindow?.location.reload();
+    } catch {
+      setNonce((n) => n + 1);
+    }
+  };
 
   return (
     <div className="flex flex-col h-full w-full min-h-0 rounded-lg overflow-hidden border border-tokyo-border bg-tokyo-bg">
       <div className="flex items-center gap-2 px-2 py-1.5 border-b border-tokyo-border bg-tokyo-bg-dark">
         <button
-          onClick={() => setNonce((n) => n + 1)}
+          onClick={reload}
           title="Reload preview"
           className="shrink-0 w-6 h-6 rounded bg-tokyo-hover text-tokyo-muted hover:text-tokyo-fg-bright border-none cursor-pointer"
         >
           ↻
         </button>
         <div className="flex-1 px-2.5 py-1 rounded bg-tokyo-bg text-[11px] font-code text-tokyo-comment truncate">
-          {location.origin + path}
+          {displayUrl}
         </div>
         <a
-          href={path}
+          href={openHref}
           target="_blank"
           rel="noopener"
           title="Open in new tab"
@@ -38,6 +73,7 @@ export function PreviewBrowser({ port }: PreviewBrowserProps) {
         </a>
       </div>
       <iframe
+        ref={iframeRef}
         key={nonce}
         src={`${path}?_t=${nonce}`}
         title="Preview"

--- a/apps/playground/src/data/templates/expo-router.ts
+++ b/apps/playground/src/data/templates/expo-router.ts
@@ -37,6 +37,22 @@ export function expoRouterAppFiles(root: string): Record<string, string> {
 		},
 	}, null, 2);
 
+	// Conditional config (standard Expo mechanism): under Lifo the preview iframe
+	// serves the app at /_sw/8082/, so set Expo's first-class sub-path option,
+	// experiments.baseUrl — inlined as EXPO_BASE_URL at transform time, it makes
+	// Expo Router match routes and generate hrefs/pushState under the prefix.
+	// Outside Lifo (real machine, dev server at the domain root) it's a no-op.
+	files[`${root}/app.config.js`] = `const isLifo = require('os').platform() === 'lifo';
+
+module.exports = ({ config }) => ({
+  ...config,
+  experiments: {
+    ...config.experiments,
+    ...(isLifo ? { baseUrl: '/_sw/8082' } : {}),
+  },
+});
+`;
+
 	// Fast Refresh requires the react-refresh runtime (installed by
 	// @expo/metro-runtime) to load BEFORE any component module — Metro only
 	// registers a module's components if global.__ReactRefresh exists when the
@@ -53,8 +69,24 @@ import 'expo-router/entry';
 
 	files[`${root}/metro.config.js`] = `const { getDefaultConfig } = require('expo/metro-config');
 const config = getDefaultConfig(__dirname);
-config.maxWorkers = 1;
-config.resolver.useWatchman = false;
+
+if (require('os').platform() === 'lifo') {
+  // In-band Metro (no worker forks), no Watchman binary.
+  config.maxWorkers = 1;
+  config.resolver.useWatchman = false;
+
+  // With experiments.baseUrl (see app.config.js), the page's script src is
+  // /_sw/8082/index.bundle and the HMR client registers that full URL as its
+  // entry point. Metro resolves entries against the server root, so strip the
+  // prefix from incoming URLs (Metro applies rewriteRequestUrl to both HTTP
+  // and HMR-registration URLs).
+  const prevRewrite = config.server.rewriteRequestUrl;
+  config.server.rewriteRequestUrl = (url) => {
+    const stripped = url.replace(/^(https?:\\/\\/[^/]+)?\\/_sw\\/\\d+/, '$1');
+    return prevRewrite ? prevRewrite(stripped) : stripped;
+  };
+}
+
 module.exports = config;
 `;
 
@@ -108,26 +140,53 @@ const styles = StyleSheet.create({
 });
 `;
 
-	// Boot the Expo web dev server (Metro) non-interactively, with Fast Refresh.
-	files[`${root}/start.mjs`] = `process.env.NODE_ENV = 'development';
-process.env.EXPO_OFFLINE = '1';
-// NOTE: do NOT set CI — Expo is already non-interactive here (isInteractive() is
-// !CI && stdout.isTTY, and the VM's stdout isn't a TTY), and CI=1 makes Metro
-// disable file watching, which kills Fast Refresh.
-process.env.BROWSER = 'none';    // don't try to open a system browser
-process.env.EXPO_NO_TELEMETRY = '1';
-process.env.EXPO_NO_DEPENDENCY_VALIDATION = '1'; // skip the version doctor check
+	// Boot the Expo web dev server (Metro) with Fast Refresh. Portable: on a real
+	// machine this is equivalent to \`expo start --web\`; the Lifo-specific
+	// adaptations only apply when os.platform() === 'lifo'.
+	files[`${root}/start.mjs`] = `import os from 'os';
+const isLifo = os.platform() === 'lifo';
 
-// Metro's efficient recursive watcher (fs.watch(root, { recursive: true })) is
-// gated to macOS; the VM reports platform 'lifo', so Metro would fall back to a
-// per-directory walker-based watcher that doesn't observe VFS writes (no Fast
-// Refresh). Lifo's fs.watch supports { recursive: true }, so force the native
-// watcher — this is what makes editing a file rebuild + hot-reload.
-try {
-  const nw = await import('metro-file-map/src/watchers/NativeWatcher.js');
-  const NativeWatcher = nw.default ?? nw;
-  NativeWatcher.isSupported = () => true;
-} catch (e) { console.warn('[lifo] NativeWatcher patch failed (no Fast Refresh):', e && e.message); }
+process.env.NODE_ENV = 'development';
+process.env.EXPO_NO_TELEMETRY = '1';
+// NOTE: do NOT set CI — Expo is non-interactive without a TTY anyway, and CI=1
+// makes Metro disable file watching, which kills Fast Refresh.
+
+if (isLifo) {
+  process.env.EXPO_OFFLINE = '1';
+  process.env.BROWSER = 'none';    // the preview iframe IS the browser
+  process.env.EXPO_NO_DEPENDENCY_VALIDATION = '1'; // skip the version doctor check
+
+  // Metro's efficient recursive watcher (fs.watch(root, { recursive: true })) is
+  // gated to macOS; the VM reports platform 'lifo', so Metro would fall back to
+  // a per-directory walker-based watcher that doesn't observe VFS writes (no
+  // Fast Refresh). Lifo's fs.watch supports { recursive: true }, so force the
+  // native watcher — this is what makes editing a file rebuild + hot-reload.
+  try {
+    const nw = await import('metro-file-map/src/watchers/NativeWatcher.js');
+    const NativeWatcher = nw.default ?? nw;
+    NativeWatcher.isSupported = () => true;
+  } catch (e) { console.warn('[lifo] NativeWatcher patch failed (no Fast Refresh):', e && e.message); }
+
+  // expo-router hard-disables baseUrl handling in development (stripBaseUrl /
+  // appendBaseUrl are gated on NODE_ENV !== 'development'), assuming the dev
+  // server is always at the domain root. Under Lifo the app legitimately serves
+  // at /_sw/8082 (experiments.baseUrl, see app.config.js), so remove the gate —
+  // otherwise the router sees pathname /_sw/8082/ and shows "Unmatched Route".
+  // Patched at the source so Metro bundles the corrected code.
+  try {
+    const fs = await import('fs');
+    const gate = "= process.env.EXPO_BASE_URL) {\\n    if (process.env.NODE_ENV !== 'development') {";
+    const opened = "= process.env.EXPO_BASE_URL) {\\n    if (true) { // lifo: baseUrl applies in dev too (served under /_sw/<port>)";
+    for (const f of [
+      'node_modules/expo-router/build/fork/getStateFromPath-forks.js',
+      'node_modules/expo-router/build/fork/getPathFromState-forks.js',
+      'node_modules/expo-router/build/fork/getPathFromState.js',
+    ]) {
+      const src = fs.readFileSync(f, 'utf8');
+      if (src.includes(gate)) fs.writeFileSync(f, src.replace(gate, opened));
+    }
+  } catch (e) { console.warn('[lifo] expo-router baseUrl patch failed:', e && e.message); }
+}
 
 const { expoStart } = await import('@expo/cli/build/src/start/index.js');
 await expoStart([process.cwd(), '--web', '--port', '8082']);

--- a/apps/playground/src/data/templates/expo.ts
+++ b/apps/playground/src/data/templates/expo.ts
@@ -84,37 +84,45 @@ const styles = StyleSheet.create({
 };
 `;
 
-	// In-band Metro (no worker forks), no Watchman binary.
 	files[`${root}/metro.config.js`] = `const { getDefaultConfig } = require('expo/metro-config');
 const config = getDefaultConfig(__dirname);
-config.maxWorkers = 1;
-config.resolver.useWatchman = false;
+
+if (require('os').platform() === 'lifo') {
+  // In-band Metro (no worker forks), no Watchman binary.
+  config.maxWorkers = 1;
+  config.resolver.useWatchman = false;
+}
+
 module.exports = config;
 `;
 
-	// Boot the Expo web dev server (Metro) non-interactively. Unlike \`expo export\`
-	// (a one-shot static build), this stays alive serving bundles + a Fast Refresh
-	// HMR websocket — which rides the same service-worker WebSocket shim the Vite
-	// HMR example uses, so edits update the preview in place.
-	files[`${root}/start.mjs`] = `process.env.NODE_ENV = 'development';
-process.env.EXPO_OFFLINE = '1';
-// NOTE: do NOT set CI — Expo is already non-interactive here (isInteractive() is
-// !CI && stdout.isTTY, and the VM's stdout isn't a TTY), and CI=1 makes Metro
-// disable file watching, which kills Fast Refresh.
-process.env.BROWSER = 'none';    // don't try to open a system browser
-process.env.EXPO_NO_TELEMETRY = '1';
-process.env.EXPO_NO_DEPENDENCY_VALIDATION = '1'; // skip the version doctor check
+	// Boot the Expo web dev server (Metro) with Fast Refresh. Portable: on a real
+	// machine this is equivalent to \`expo start --web\`; the Lifo-specific
+	// adaptations only apply when os.platform() === 'lifo'.
+	files[`${root}/start.mjs`] = `import os from 'os';
+const isLifo = os.platform() === 'lifo';
 
-// Metro's efficient recursive watcher (fs.watch(root, { recursive: true })) is
-// gated to macOS; the VM reports platform 'lifo', so Metro would fall back to a
-// per-directory walker-based watcher that doesn't observe VFS writes (no Fast
-// Refresh). Lifo's fs.watch supports { recursive: true }, so force the native
-// watcher — this is what makes editing a file rebuild + hot-reload.
-try {
-  const nw = await import('metro-file-map/src/watchers/NativeWatcher.js');
-  const NativeWatcher = nw.default ?? nw;
-  NativeWatcher.isSupported = () => true;
-} catch (e) { console.warn('[lifo] NativeWatcher patch failed (no Fast Refresh):', e && e.message); }
+process.env.NODE_ENV = 'development';
+process.env.EXPO_NO_TELEMETRY = '1';
+// NOTE: do NOT set CI — Expo is non-interactive without a TTY anyway, and CI=1
+// makes Metro disable file watching, which kills Fast Refresh.
+
+if (isLifo) {
+  process.env.EXPO_OFFLINE = '1';
+  process.env.BROWSER = 'none';    // the preview iframe IS the browser
+  process.env.EXPO_NO_DEPENDENCY_VALIDATION = '1'; // skip the version doctor check
+
+  // Metro's efficient recursive watcher (fs.watch(root, { recursive: true })) is
+  // gated to macOS; the VM reports platform 'lifo', so Metro would fall back to
+  // a per-directory walker-based watcher that doesn't observe VFS writes (no
+  // Fast Refresh). Lifo's fs.watch supports { recursive: true }, so force the
+  // native watcher — this is what makes editing a file rebuild + hot-reload.
+  try {
+    const nw = await import('metro-file-map/src/watchers/NativeWatcher.js');
+    const NativeWatcher = nw.default ?? nw;
+    NativeWatcher.isSupported = () => true;
+  } catch (e) { console.warn('[lifo] NativeWatcher patch failed (no Fast Refresh):', e && e.message); }
+}
 
 const { expoStart } = await import('@expo/cli/build/src/start/index.js');
 await expoStart([process.cwd(), '--web', '--port', '8081']);

--- a/packages/core/src/commands/system/node.ts
+++ b/packages/core/src/commands/system/node.ts
@@ -3,6 +3,7 @@ import { resolve, dirname, join, extname } from '../../utils/path.js';
 import { createModuleMap, ProcessExitError } from '../../node-compat/index.js';
 import type { NodeContext } from '../../node-compat/index.js';
 import { createProcess } from '../../node-compat/process.js';
+import { createModuleClass } from '../../node-compat/module.js';
 import { createConsole } from '../../node-compat/console.js';
 import { Buffer } from '../../node-compat/buffer.js';
 import { VFSError } from '../../kernel/vfs/index.js';
@@ -808,6 +809,12 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 			portRegistry,
 		};
 
+		// Back require('module')'s Module#_compile with the real module executor
+		// (require-from-string constructs a Module and compiles source directly —
+		// e.g. @expo/config evaluating app.config.js). executeModule is declared
+		// below in this scope; the arrow defers the reference until call time.
+		nodeCtx.executeCjs = (code, fname) => executeModule(code, fname);
+
 		const moduleMap = createModuleMap(nodeCtx);
 		const moduleCache = new Map<string, unknown>();
 
@@ -992,15 +999,24 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 		);
 		(nodeRequire as unknown as { cache: unknown }).cache = Object.create(null);
 
-		// Override module shim so createRequire returns nodeRequire (resolves VFS + node_modules)
+		// Override module shim so createRequire returns nodeRequire (resolves VFS +
+		// node_modules). Must stay a constructable Module class with a working
+		// _compile: require-from-string does `new (require('module'))(...)` +
+		// `m._compile(code)` (e.g. @expo/config evaluating app.config.js).
 		moduleMap.module = () => {
-			const createRequire = (_filename: string | URL) => nodeRequire;
 			const builtinNames = Object.keys(moduleMap);
-			const isBuiltin = (s: string) => {
-				const n = s.startsWith('node:') ? s.slice(5) : s;
-				return builtinNames.includes(n);
-			};
-			return { createRequire, builtinModules: builtinNames, isBuiltin, ...moduleResolveExtras(dir), default: { createRequire } };
+			return createModuleClass(
+				{ executeCjs: nodeCtx.executeCjs },
+				{
+					createRequire: (_filename: string | URL) => nodeRequire,
+					builtinModules: builtinNames,
+					isBuiltin: (s: string) => {
+						const n = s.startsWith('node:') ? s.slice(5) : s;
+						return builtinNames.includes(n);
+					},
+					...moduleResolveExtras(dir),
+				},
+			);
 		};
 
 		function resolveVfsModule(name: string, fromDir: string): { path: string } | null {
@@ -1354,14 +1370,22 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 			(modRequire as unknown as { cache: unknown }).cache = Object.create(null);
 
 			// Override module shim so createRequire returns modRequire (resolves VFS + node_modules too)
+			// Same as the main map's override: a constructable Module class whose
+			// createRequire is this module's scoped require.
 			modModuleMap.module = () => {
-				const createRequire = (_filename: string | URL) => modRequire;
 				const builtinNames = Object.keys(modModuleMap);
-				const isBuiltin = (s: string) => {
-					const n = s.startsWith('node:') ? s.slice(5) : s;
-					return builtinNames.includes(n);
-				};
-				return { createRequire, builtinModules: builtinNames, isBuiltin, ...moduleResolveExtras(modDir), default: { createRequire } };
+				return createModuleClass(
+					{ executeCjs: nodeCtx.executeCjs },
+					{
+						createRequire: (_filename: string | URL) => modRequire,
+						builtinModules: builtinNames,
+						isBuiltin: (s: string) => {
+							const n = s.startsWith('node:') ? s.slice(5) : s;
+							return builtinNames.includes(n);
+						},
+						...moduleResolveExtras(modDir),
+					},
+				);
 			};
 
 			let cleanSource = stripShebang(modSource);

--- a/packages/core/src/node-compat/index.ts
+++ b/packages/core/src/node-compat/index.ts
@@ -68,6 +68,12 @@ export interface NodeContext {
   signal: AbortSignal;
   executeCapture?: (input: string) => Promise<string>;
   portRegistry?: Map<number, VirtualRequestHandler>;
+  /**
+   * Execute CJS source in the VM's module system and return its module.exports.
+   * Set by the node command; backs `require('module')`'s Module#_compile (used
+   * by require-from-string, e.g. @expo/config evaluating app.config.js).
+   */
+  executeCjs?: (code: string, filename: string) => unknown;
 }
 
 export function createModuleMap(ctx: NodeContext): Record<string, () => unknown> {
@@ -400,8 +406,9 @@ export function createModuleMap(ctx: NodeContext): Record<string, () => unknown>
     }),
   };
 
-  // module shim needs access to the map itself for createRequire
-  map.module = () => createModuleShim(map);
+  // module shim needs access to the map itself for createRequire, and to the
+  // context for Module#_compile (CJS execution via the node command).
+  map.module = () => createModuleShim(map, ctx);
 
   // npm package shims
   map.rimraf = () => createRimraf(ctx.vfs, ctx.cwd);

--- a/packages/core/src/node-compat/module.ts
+++ b/packages/core/src/node-compat/module.ts
@@ -95,6 +95,12 @@ export function makeCreateRequire(
 /**
  * Minimal Module class matching the shape code typically expects.
  */
+
+/** Context hooks the node command wires in so Module instances can execute code. */
+interface ModuleShimHooks {
+  executeCjs?: (code: string, filename: string) => unknown;
+}
+
 export class Module {
   id: string;
   filename: string;
@@ -118,10 +124,44 @@ export class Module {
     throw new Error('Module.require() is not supported — use createRequire() instead');
   }
 
+  /**
+   * Compile + execute CJS source as this module's body (Node semantics), via
+   * the node command's module executor. Packages like require-from-string
+   * (used by @expo/config to evaluate app.config.js) construct a Module and
+   * call this directly.
+   */
+  _compile(code: string, filename: string): unknown {
+    const ctor = this.constructor as typeof Module;
+    const exec = ctor._hooks?.executeCjs ?? Module._hooks?.executeCjs;
+    if (!exec) {
+      throw new Error('module._compile is unavailable outside the node command');
+    }
+    this.exports = exec(code, filename || this.filename);
+    this.loaded = true;
+    return this.exports;
+  }
+
   static builtinModules = builtinModules;
   static isBuiltin = isBuiltin;
   // createRequire is attached dynamically in createModuleShim()
   static createRequire: (filename: string | URL) => RequireFunction;
+  /** Runtime hooks (CJS executor) — attached by createModuleShim. */
+  static _hooks: ModuleShimHooks | undefined;
+
+  /** Node's node_modules lookup chain for a directory (posix walk-up). */
+  static _nodeModulePaths(from: string): string[] {
+    const paths: string[] = [];
+    let dir = (from || '/').replace(/\/+$/, '') || '/';
+    for (;;) {
+      if (!dir.endsWith('/node_modules')) {
+        paths.push(dir === '/' ? '/node_modules' : dir + '/node_modules');
+      }
+      const parent = dir.slice(0, dir.lastIndexOf('/')) || '/';
+      if (parent === dir) break;
+      dir = parent;
+    }
+    return paths;
+  }
 
   static _resolveFilename(request: string): string {
     return request;
@@ -131,18 +171,42 @@ export class Module {
 }
 
 /**
- * Create the full module shim object with createRequire bound to a module map.
+ * Create the module shim with createRequire bound to a module map. Returns the
+ * Module class itself — in Node, `require('module')` IS the Module constructor
+ * (require-from-string does `new (require('module'))(...)`) — with the named
+ * APIs attached as statics.
  */
-export function createModuleShim(moduleMap: Record<string, () => unknown>) {
-  const createRequire = makeCreateRequire(moduleMap);
+export function createModuleShim(
+  moduleMap: Record<string, () => unknown>,
+  hooks?: ModuleShimHooks,
+) {
+  Module.createRequire = makeCreateRequire(moduleMap);
+  if (hooks) Module._hooks = hooks;
 
-  Module.createRequire = createRequire;
-
-  return {
-    Module,
-    builtinModules,
-    isBuiltin,
-    createRequire,
-    default: Module,
+  const M = Module as typeof Module & {
+    Module: typeof Module;
+    default: typeof Module;
   };
+  M.Module = Module;
+  M.default = Module;
+  return M;
+}
+
+/**
+ * Create a fresh, constructable Module class with its own static overrides —
+ * used by the node command, whose `require('module')` must expose its scoped
+ * require (VFS + node_modules resolution) while staying `new`-able with a
+ * working #_compile (require-from-string, @expo/config dynamic configs).
+ */
+export function createModuleClass(
+  hooks: ModuleShimHooks | undefined,
+  statics: Record<string, unknown>,
+): typeof Module {
+  class NodeModule extends Module {}
+  const M = NodeModule as typeof Module & Record<string, unknown>;
+  M._hooks = hooks;
+  Object.assign(M, statics);
+  M.Module = M;
+  M.default = M;
+  return M;
 }


### PR DESCRIPTION
## Summary
Follow-up to #23. Fixes Expo Router route matching under the service-worker transport, makes dynamic Expo configs (`app.config.js`) work in the VM, makes the Expo templates portable (run unchanged with or without Lifo), and gives the preview chrome a live address bar.

## Expo Router under /_sw/8082 (was: "Unmatched Route")
The app serves at `/_sw/8082/` but the router matched against `/`. Solved with Expo's own mechanisms — no `window.location` patching (it's non-configurable anyway):
- **`app.config.js`** sets `experiments.baseUrl: '/_sw/8082'` **only under Lifo** — the router then matches routes and generates hrefs/`pushState` under the prefix (URL bar shows `/_sw/8082/about`; deep-link reloads work).
- **`metro.config.js`** strips the `/_sw/<port>` prefix via `server.rewriteRequestUrl` (applied to both HTTP and HMR entry-registration URLs), keeping Fast Refresh working with baseUrl.
- **`start.mjs`** opens expo-router's baseUrl dev gate: upstream hard-disables `stripBaseUrl`/`appendBaseUrl` when `NODE_ENV=development`, assuming dev servers always sit at the domain root. (Upstream-PR candidate.)

## node-compat: constructable `Module` with working `_compile`
`require('module')` now returns the Module class itself (Node semantics) in every context. `require-from-string` — how `@expo/config` evaluates `app.config.js`/`.ts` — does `new (require('module'))(file)` + `m._compile(code)`, which previously crashed with *"Module is not a constructor"*. `_compile` executes through the node command's real module executor (new `NodeContext.executeCjs` hook), and `Module._nodeModulePaths` implements Node's walk-up. This unblocks **all dynamic Expo configs** in the VM, not just our template.

## Portable templates ("works with or without Lifo, unchanged")
Every Lifo-specific adaptation (watcher force, env skips, baseUrl, rewriteRequestUrl, router gate) is now conditional on `os.platform() === 'lifo'`. On a real machine the projects behave as stock `expo start --web`.

## PreviewBrowser
Address bar tracks the iframe's live URL (same-origin poll — `pushState` fires no parent event), open-in-new-tab targets the current route, reload reloads in place so the route survives.

## Test plan
- Verified live in-browser through the session: router root matches at `/_sw/8082/`, About navigates with URL bar updating, Fast Refresh applies in place (counter state preserved).
- `pnpm --filter @lifo-sh/playground build` + playground tsc clean; core tsc introduces no new errors (pre-existing ones unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)