### PR TITLE
Playground polish: README tab, ROADMAP + bench harness, and prompt-return fix for raw-mode CLIs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,7 +49,29 @@ Reproducible numbers behind the claims, so "~0 ms boot, $0 infra" is backed by d
 - [ ] Dev-server cold-start (Vite) measured end to end.
 - [ ] Publish a report + keep the harness in CI so regressions show up.
 
-### 2. A single distributable binary for host VMs — *exploring*
+### 2. The `lifo` CLI — *planned*
+
+A `lifo` command-line tool to run a box straight from your terminal — the on-ramp to server-side use before the standalone binary lands. Bonus: it gives Windows a consistent POSIX shell + coreutils build environment (npm scripts like `rm -rf dist && NODE_ENV=production …` just work, same paths and semantics as macOS/Linux) without WSL or Docker — for pure-JS toolchains. Native compilation stays out of scope, so it complements WSL/Docker rather than replacing them; the host-fs mount (phase 3) is what makes it useful for building a local project.
+
+- [ ] `lifo` — boot a box and drop into its interactive shell.
+- [ ] `lifo run <script.js>` — run a script in a fresh box and exit with its code.
+- [ ] `--mount <hostDir>:<vmPath>` — map a host directory into the VM (see phase 3).
+- [ ] `--expose <port>` — forward an in-VM port to localhost.
+- [ ] Config/flags for env, cwd, and which filesystem backend to use.
+- [ ] Cross-platform build parity: verify common POSIX-assuming npm scripts run on Windows in a box.
+
+### 3. Filesystem persistence & durability — *planned*
+
+Today the VFS is in-memory with IndexedDB persistence in the browser and whole-disk snapshots. Make the backing store pluggable and durable per environment.
+
+- [ ] Backend interface: one VFS, swappable persistence layers.
+- [ ] Browser persistent layer — IndexedDB today; evaluate OPFS for larger/faster disks.
+- [ ] Host filesystem backend — back a box's disk with a real directory when running via the CLI.
+- [ ] Volatile in-memory backend — throwaway sandboxes with no persistence.
+- [ ] Snapshot & restore (have it) → export/import a box image across environments.
+- [ ] Write-ahead log (WAL) for crash-consistent, incremental persistence (vs. snapshot-only).
+
+### 4. A single distributable binary for host VMs — *exploring*
 
 Lifo already runs in Node. Next: a single `lifo` binary (no Node install required) that runs **isolated VM instances per use case** — per-agent, per-project, per-request — so you can spin up and tear down disposable sandboxes on a server without Docker.
 
@@ -57,17 +79,38 @@ Lifo already runs in Node. Next: a single `lifo` binary (no Node install require
 - [ ] Isolation boundary + lifecycle API for many concurrent VMs in one host process.
 - [ ] Resource limits (cpu/mem/fs quotas) per VM.
 
-### 3. Tunnelling & a Docker-free dev sandbox — *planned*
+### 5. Tunnelling & network — *planned*
 
-- [ ] Expose an in-VM port to a public URL through a tunnel.
+- [ ] Expose an in-VM port to a public URL through a tunnel (self-hosted relay or hosted proxy).
+- [ ] Harden the WebSocket tunnel + relay (`apps/tunnel-server`): auth, reconnect, multiplexing.
+- [ ] Cloud/host proxy for hosts without a same-origin service worker.
 - [ ] Document using Lifo in place of Docker for local dev and CI sandboxes — honestly, for the cases where it fits.
 
-### 4. Package manager & WASM runtimes — *planned*
+### 6. Host escape hatches (opt-in) — *exploring*
+
+A deliberate, permissioned way to step outside the sandbox and talk to the host. These are powerful and risky by design — off by default, gated behind explicit per-capability permissions, and never enabled implicitly.
+
+- [ ] Host command execution (CLI/Node): run real host-machine commands from inside a box — e.g. `osascript`/AppleScript on macOS, or a whitelisted shell.
+- [ ] Browser API bridge: call Web APIs (clipboard, notifications, geolocation, …) from in-VM code, through a mediated channel.
+- [ ] A capability/permission model: opt-in per hatch, auditable, revocable; clear docs on the risks.
+- [ ] Sensible defaults: everything disabled unless the embedder explicitly grants it.
+
+### 7. Embeddable UI (terminal & browser) — *in progress*
+
+Turn the playground's building blocks into reusable components so anyone can embed a Lifo UI. Shipped in `@lifo-sh/ui` (framework-agnostic).
+
+- [x] Terminal component — a themeable terminal bound to a box's shell (core).
+- [x] Preview browser component — an iframe view bound to an in-VM port (core), with back/forward/reload + a friendly address bar.
+- [x] Package + document the components with a from-scratch integration example (see the Embeddable UI doc).
+- [ ] Browser chrome — tabs, history (*low priority*, after the core views).
+- [ ] Migrate the playground to consume the packaged components (dogfood).
+
+### 8. Package manager & WASM runtimes — *planned*
 
 - [ ] First-class package manager for VM tools.
 - [ ] Pluggable WASM runtimes so more binaries (ffmpeg, Python, native CLIs) run inside the VM.
 
-### 5. Broader Node & serverless coverage — *planned*
+### 9. Broader Node & serverless coverage — *planned*
 
 - [ ] Extend the Node compatibility layer toward serverless handlers.
 - [ ] Cover more of the ecosystem unmodified.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,77 @@
+# Lifo roadmap
+
+## North star
+
+**A developer can run agent code, dev servers, and real stacks in a sandbox that boots instantly — in the browser and in Node today, and as a single Docker-free binary you can drop on any host tomorrow.**
+
+The measure of success isn't a feature checklist; it's: take a real project, point your tools at Lifo, and it just runs — the same VM whether it's a browser tab or a server-side process.
+
+## Scope: what Lifo is (and isn't)
+
+Lifo is a **tiny Linux-like VM** — a kernel with a virtual filesystem, a bash-like shell, 60+ coreutils, a Node.js compatibility layer, and a package manager — that runs **in a browser tab** or **in Node**.
+
+**In scope**
+
+- A believable POSIX-ish environment: FS, shell, processes, ports, a virtual network.
+- Enough Node.js compatibility that real CLIs and dev servers run unmodified.
+- Running real stacks (create-expo-app, Vite, Expo Router, Supabase via tinbase).
+- Sandboxing agent-generated code safely, client-side or server-side.
+
+**Out of scope**
+
+- Being a full Linux kernel / running arbitrary native ELF binaries.
+- A hosted cloud product. Lifo is a library and (soon) a binary you run yourself.
+
+## Current state
+
+Runs in the browser and in Node today — the same VM, client-side or server-side. Already shipped:
+
+- [x] Kernel: virtual filesystem (IndexedDB-persisted in the browser), bash-like shell, process registry, virtual network + ports.
+- [x] 60+ coreutils (ls, grep, sed, awk, find, tar, curl, …) and Git in every shell.
+- [x] Node.js compatibility layer (http, fs, net, child_process, streams, crypto, readline, …).
+- [x] Real npm & npx from the registry.
+- [x] Real stacks unmodified: create-expo-app (SDK 54 & 57), Vite + React, Expo Router, Supabase (tinbase).
+- [x] Live previews — in-VM ports served over a service worker with HMR.
+- [x] Snapshot & restore a box's disk state.
+- [x] Per-box process manager (list, kill, stop, restart).
+- [x] Same-origin CORS proxy so the VM reaches api.expo.dev with no relay.
+
+## Phases (ordered by real impact)
+
+Each item ships independently and keeps the test suite green.
+
+### 1. Benchmarks for browser & Node — *in progress*
+
+Reproducible numbers behind the claims, so "~0 ms boot, $0 infra" is backed by data.
+
+- [ ] Node harness: boot time, command throughput, FS read/write, memory (`bench/`).
+- [ ] Browser harness: same metrics in a headless Chrome page.
+- [ ] Dev-server cold-start (Vite) measured end to end.
+- [ ] Publish a report + keep the harness in CI so regressions show up.
+
+### 2. A single distributable binary for host VMs — *exploring*
+
+Lifo already runs in Node. Next: a single `lifo` binary (no Node install required) that runs **isolated VM instances per use case** — per-agent, per-project, per-request — so you can spin up and tear down disposable sandboxes on a server without Docker.
+
+- [ ] Bundle the runtime into a self-contained executable.
+- [ ] Isolation boundary + lifecycle API for many concurrent VMs in one host process.
+- [ ] Resource limits (cpu/mem/fs quotas) per VM.
+
+### 3. Tunnelling & a Docker-free dev sandbox — *planned*
+
+- [ ] Expose an in-VM port to a public URL through a tunnel.
+- [ ] Document using Lifo in place of Docker for local dev and CI sandboxes — honestly, for the cases where it fits.
+
+### 4. Package manager & WASM runtimes — *planned*
+
+- [ ] First-class package manager for VM tools.
+- [ ] Pluggable WASM runtimes so more binaries (ffmpeg, Python, native CLIs) run inside the VM.
+
+### 5. Broader Node & serverless coverage — *planned*
+
+- [ ] Extend the Node compatibility layer toward serverless handlers.
+- [ ] Cover more of the ecosystem unmodified.
+
+---
+
+Priorities shift with real usage. Have a use case? Open an issue.

--- a/apps/playground/src/app.css
+++ b/apps/playground/src/app.css
@@ -72,7 +72,7 @@
   --tk-bg-darker: #121218;
   --tk-fg: #a9b1d6;
   --tk-fg-bright: #c0caf5;
-  --tk-border: #2f3146;
+  --tk-border: #262838;
   --tk-comment: #565f89;
   --tk-blue: #7aa2f7;
   --tk-blue-bright: #89b4fa;
@@ -120,7 +120,7 @@
   --tk-bg-darker: #cccfda;
   --tk-fg: #3760bf;
   --tk-fg-bright: #343b58;
-  --tk-border: #b3b7cd;
+  --tk-border: #c6c9d6;
   --tk-comment: #7a82a8;
   --tk-blue: #2e7de9;
   --tk-blue-bright: #2e7de9;

--- a/apps/playground/src/components/app-shell.tsx
+++ b/apps/playground/src/components/app-shell.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Menu } from 'lucide-react';
+import { Menu, PanelLeft } from 'lucide-react';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { Sheet, SheetContent, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { SidebarNav } from '@/components/sidebar-nav';
@@ -21,10 +21,13 @@ export function App() {
   const showCode = !active.hideCode;
 
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  // Desktop: collapse the examples sidebar to give the output full width.
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const select = (id: string) => {
     setActiveId(id);
     setSidebarOpen(false);
   };
+  const showSidebar = !isMobile && !sidebarCollapsed;
 
   return (
     <div className="flex flex-col h-full w-full">
@@ -42,14 +45,26 @@ export function App() {
         </Sheet>
       </header>
 
-      <div className="relative flex-1 min-h-0">
-        <ResizablePanelGroup direction="horizontal" autoSaveId="pg-cols-v3" className="h-full w-full">
-          {!isMobile && (
+      <div className="relative flex-1 min-h-0 flex">
+        {/* Collapsed rail — a thin strip with a button to reopen the sidebar */}
+        {!isMobile && sidebarCollapsed && (
+          <div className="w-9 shrink-0 flex flex-col items-center pt-3 bg-tokyo-bg-dark border-r border-tokyo-border">
+            <button
+              onClick={() => setSidebarCollapsed(false)}
+              title="Show sidebar"
+              className="w-7 h-7 grid place-items-center rounded-md bg-transparent border-none text-tokyo-comment hover:text-tokyo-fg-bright hover:bg-tokyo-hover cursor-pointer"
+            >
+              <PanelLeft size={15} />
+            </button>
+          </div>
+        )}
+        <ResizablePanelGroup direction="horizontal" autoSaveId="pg-cols-v3" className="h-full flex-1 min-w-0">
+          {showSidebar && (
             <ResizablePanel key="sidebar" id="sidebar" order={1} defaultSize={17} minSize={13} maxSize={26}>
-              <SidebarNav activeId={activeId} onSelect={select} />
+              <SidebarNav activeId={activeId} onSelect={select} onCollapse={() => setSidebarCollapsed(true)} />
             </ResizablePanel>
           )}
-          {!isMobile && <ResizableHandle key="h1" />}
+          {showSidebar && <ResizableHandle key="h1" />}
           <ResizablePanel key="output" id="output" order={2} defaultSize={83} minSize={40}>
             <OutputChromeProvider value={{ snippet: showCode ? snippetFor(activeId) : undefined }}>
               <div className="relative h-full w-full overflow-hidden flex flex-col min-h-0">

--- a/apps/playground/src/components/app-shell.tsx
+++ b/apps/playground/src/components/app-shell.tsx
@@ -1,69 +1,24 @@
-import { useCallback, useEffect, useState } from 'react';
-import { Menu, X } from 'lucide-react';
+import { useState } from 'react';
+import { Menu } from 'lucide-react';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { Sheet, SheetContent, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { SidebarNav } from '@/components/sidebar-nav';
-import { CodeColumn } from '@/components/code-column';
 import { ExampleHost } from '@/components/example-host';
 import { OutputChromeProvider } from '@/components/output-chrome';
 import { findExample, snippetFor } from '@/examples/registry';
 import { useIsMobile } from '@/hooks/use-is-mobile';
-import { cn } from '@/lib/utils';
-
-/** Code snippet as a drawer that slides over the output from its left edge. */
-function CodeDrawer({ open, snippet, onClose }: { open: boolean; snippet?: string; onClose: () => void }) {
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
-  }, [open, onClose]);
-
-  return (
-    <div
-      className={cn(
-        'absolute inset-y-0 left-0 z-30 w-full sm:w-[52%] sm:max-w-[560px] flex flex-col bg-tokyo-bg-dark border-r border-tokyo-border shadow-2xl transition-transform duration-200 ease-out',
-        open ? 'translate-x-0' : '-translate-x-full pointer-events-none',
-      )}
-      aria-hidden={!open}
-    >
-      <div className="flex items-center justify-between h-9 px-3 border-b border-tokyo-border shrink-0">
-        <span className="text-[10px] font-semibold uppercase tracking-widest text-tokyo-comment">Code</span>
-        <button
-          onClick={onClose}
-          title="Close code (Esc)"
-          className="w-6 h-6 grid place-items-center rounded bg-transparent border-none text-tokyo-comment hover:text-tokyo-fg-bright hover:bg-tokyo-hover cursor-pointer"
-        >
-          <X size={14} />
-        </button>
-      </div>
-      <div className="flex-1 min-h-0">
-        <CodeColumn snippet={snippet} />
-      </div>
-    </div>
-  );
-}
 
 /**
- * Layout: Sidebar | Output. The example's Code snippet lives in a drawer that
- * slides over the output from the left (toggled by the navbar ⟨⟩ / mobile Menu),
- * so the terminal + preview get the full width by default. ExampleHost keeps
- * every example's kernel/terminal mounted across switches.
+ * Layout: Sidebar | Output. The example's code sample is surfaced as a
+ * "README.md" tab inside the terminal area (see TerminalArea); the active
+ * example's snippet is handed down via OutputChrome. ExampleHost keeps every
+ * example's kernel/terminal mounted across switches.
  */
 export function App() {
   const [activeId, setActiveId] = useState('interactive');
   const isMobile = useIsMobile();
   const active = findExample(activeId);
   const showCode = !active.hideCode;
-
-  const [codeOpen, setCodeOpen] = useState(false);
-  const toggleCode = useCallback(() => setCodeOpen((v) => !v), []);
-  // An example with no code can't have the drawer open.
-  useEffect(() => {
-    if (!showCode) setCodeOpen(false);
-  }, [showCode, activeId]);
 
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const select = (id: string) => {
@@ -96,12 +51,9 @@ export function App() {
           )}
           {!isMobile && <ResizableHandle key="h1" />}
           <ResizablePanel key="output" id="output" order={2} defaultSize={83} minSize={40}>
-            <OutputChromeProvider value={{ canToggleCode: showCode, codeOpen, toggleCode }}>
+            <OutputChromeProvider value={{ snippet: showCode ? snippetFor(activeId) : undefined }}>
               <div className="relative h-full w-full overflow-hidden flex flex-col min-h-0">
                 <ExampleHost activeId={activeId} />
-                {showCode && (
-                  <CodeDrawer open={codeOpen} snippet={snippetFor(activeId)} onClose={() => setCodeOpen(false)} />
-                )}
               </div>
             </OutputChromeProvider>
           </ResizablePanel>

--- a/apps/playground/src/components/example-panel.tsx
+++ b/apps/playground/src/components/example-panel.tsx
@@ -1,6 +1,5 @@
 import { type ReactNode, useState } from 'react';
-import { Info, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
-import { useOutputChrome } from '@/components/output-chrome';
+import { Info } from 'lucide-react';
 
 interface ExamplePanelProps {
   title: string;
@@ -11,26 +10,16 @@ interface ExamplePanelProps {
 /**
  * Compact output-panel chrome (VS Code-like): a full-width navbar with the
  * example body flush beneath it. The description is collapsed by default
- * (info toggle).
+ * (info toggle). The example's code sample shows up as a "README.md" tab in
+ * the terminal area, not here.
  */
 export function ExamplePanel({ title, subtitle, children }: ExamplePanelProps) {
-  const chrome = useOutputChrome();
   const [showDesc, setShowDesc] = useState(false);
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
       {/* Navbar — end to end. */}
-      <div className="flex items-center gap-1.5 h-9 px-2 border-b border-tokyo-border bg-tokyo-bg-dark shrink-0">
-        {chrome?.canToggleCode && (
-          <button
-            onClick={chrome.toggleCode}
-            title={chrome.codeOpen ? 'Hide the commands to run' : 'Show the commands to run'}
-            className="flex items-center gap-1.5 h-6 px-2 rounded border border-tokyo-border bg-transparent text-[11px] font-medium text-tokyo-comment hover:text-tokyo-fg-bright hover:bg-tokyo-hover cursor-pointer shrink-0"
-          >
-            {chrome.codeOpen ? <PanelLeftClose size={13} /> : <PanelLeftOpen size={13} />}
-            {chrome.codeOpen ? 'Hide commands' : 'Show commands'}
-          </button>
-        )}
+      <div className="flex items-center gap-1.5 h-9 px-3 border-b border-tokyo-border bg-tokyo-bg-dark shrink-0">
         <span className="text-[13px] font-semibold text-tokyo-fg-bright truncate">{title}</span>
         {subtitle && (
           <button

--- a/apps/playground/src/components/example-panel.tsx
+++ b/apps/playground/src/components/example-panel.tsx
@@ -24,10 +24,11 @@ export function ExamplePanel({ title, subtitle, children }: ExamplePanelProps) {
         {chrome?.canToggleCode && (
           <button
             onClick={chrome.toggleCode}
-            title={chrome.codeOpen ? 'Hide code panel' : 'Show code panel'}
-            className="w-6 h-6 grid place-items-center rounded bg-transparent border-none text-tokyo-comment hover:text-tokyo-fg-bright hover:bg-tokyo-hover cursor-pointer shrink-0"
+            title={chrome.codeOpen ? 'Hide the commands to run' : 'Show the commands to run'}
+            className="flex items-center gap-1.5 h-6 px-2 rounded border border-tokyo-border bg-transparent text-[11px] font-medium text-tokyo-comment hover:text-tokyo-fg-bright hover:bg-tokyo-hover cursor-pointer shrink-0"
           >
-            {chrome.codeOpen ? <PanelLeftClose size={14} /> : <PanelLeftOpen size={14} />}
+            {chrome.codeOpen ? <PanelLeftClose size={13} /> : <PanelLeftOpen size={13} />}
+            {chrome.codeOpen ? 'Hide commands' : 'Show commands'}
           </button>
         )}
         <span className="text-[13px] font-semibold text-tokyo-fg-bright truncate">{title}</span>

--- a/apps/playground/src/components/logo.tsx
+++ b/apps/playground/src/components/logo.tsx
@@ -1,0 +1,17 @@
+/** Lifo mark — a terminal prompt: a green chevron + a green cursor block. */
+export function LifoLogo({ className = 'size-6' }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} aria-hidden="true">
+      <rect width="24" height="24" rx="6" fill="#16161e" stroke="#292e42" />
+      <path
+        d="M6.5 8.5 L10 12 L6.5 15.5"
+        fill="none"
+        stroke="#9ece6a"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <rect x="12.5" y="13.8" width="5.5" height="2.2" rx="1" fill="#9ece6a" />
+    </svg>
+  );
+}

--- a/apps/playground/src/components/output-chrome.tsx
+++ b/apps/playground/src/components/output-chrome.tsx
@@ -1,17 +1,13 @@
 import { createContext, useContext } from 'react';
 
 /**
- * Lets the per-example header (ExamplePanel) drive app-shell chrome it doesn't
- * own — namely collapsing/expanding the Code column — without threading props
- * through every example. The provider lives in app-shell; ExamplePanel reads it.
+ * Carries the active example's pre-highlighted code snippet down to the
+ * terminal area, which renders it as a "README.md" tab. Provided by app-shell
+ * so examples don't have to thread it through.
  */
 export interface OutputChrome {
-  /** True when there's a Code column that can be toggled (desktop, code example). */
-  canToggleCode: boolean;
-  /** Whether the Code column is currently open. */
-  codeOpen: boolean;
-  /** Toggle the Code column. */
-  toggleCode: () => void;
+  /** Pre-highlighted HTML for the example's code sample (undefined = none). */
+  snippet?: string;
 }
 
 const OutputChromeContext = createContext<OutputChrome | null>(null);

--- a/apps/playground/src/components/sidebar-nav.tsx
+++ b/apps/playground/src/components/sidebar-nav.tsx
@@ -1,4 +1,4 @@
-import { Moon, Sun } from 'lucide-react';
+import { Moon, Sun, PanelLeftClose } from 'lucide-react';
 import { examples, exampleGroups } from '@/examples/registry';
 import { cn } from '@/lib/utils';
 import { useTheme } from '@/lib/theme';
@@ -7,9 +7,11 @@ import { LifoLogo } from '@/components/logo';
 interface SidebarNavProps {
   activeId: string;
   onSelect: (id: string) => void;
+  /** When provided, shows a collapse button in the header (desktop only). */
+  onCollapse?: () => void;
 }
 
-export function SidebarNav({ activeId, onSelect }: SidebarNavProps) {
+export function SidebarNav({ activeId, onSelect, onCollapse }: SidebarNavProps) {
   const { mode, toggle } = useTheme();
   return (
     <nav className="h-full flex flex-col overflow-y-auto bg-tokyo-bg-dark">
@@ -17,13 +19,24 @@ export function SidebarNav({ activeId, onSelect }: SidebarNavProps) {
         <div className="flex items-center gap-2">
           <LifoLogo className="size-[22px] shrink-0" />
           <h1 className="text-lg font-bold text-tokyo-fg-bright tracking-tight">Lifo</h1>
-          <button
-            onClick={toggle}
-            title={mode === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
-            className="ml-auto w-7 h-7 grid place-items-center rounded-md bg-transparent border-none text-tokyo-comment hover:text-tokyo-fg-bright hover:bg-tokyo-hover cursor-pointer"
-          >
-            {mode === 'dark' ? <Sun size={15} /> : <Moon size={15} />}
-          </button>
+          <div className="ml-auto flex items-center gap-0.5">
+            <button
+              onClick={toggle}
+              title={mode === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+              className="w-7 h-7 grid place-items-center rounded-md bg-transparent border-none text-tokyo-comment hover:text-tokyo-fg-bright hover:bg-tokyo-hover cursor-pointer"
+            >
+              {mode === 'dark' ? <Sun size={15} /> : <Moon size={15} />}
+            </button>
+            {onCollapse && (
+              <button
+                onClick={onCollapse}
+                title="Collapse sidebar"
+                className="w-7 h-7 grid place-items-center rounded-md bg-transparent border-none text-tokyo-comment hover:text-tokyo-fg-bright hover:bg-tokyo-hover cursor-pointer"
+              >
+                <PanelLeftClose size={15} />
+              </button>
+            )}
+          </div>
         </div>
         <p className="text-[11px] text-tokyo-comment mt-1">Sandbox Examples</p>
       </div>

--- a/apps/playground/src/components/sidebar-nav.tsx
+++ b/apps/playground/src/components/sidebar-nav.tsx
@@ -2,6 +2,7 @@ import { Moon, Sun } from 'lucide-react';
 import { examples, exampleGroups } from '@/examples/registry';
 import { cn } from '@/lib/utils';
 import { useTheme } from '@/lib/theme';
+import { LifoLogo } from '@/components/logo';
 
 interface SidebarNavProps {
   activeId: string;
@@ -14,13 +15,7 @@ export function SidebarNav({ activeId, onSelect }: SidebarNavProps) {
     <nav className="h-full flex flex-col overflow-y-auto bg-tokyo-bg-dark">
       <div className="p-4 pb-3 border-b border-tokyo-border shrink-0">
         <div className="flex items-center gap-2">
-          <img
-            src={`${import.meta.env.BASE_URL}logo.png`}
-            alt="Lifo"
-            width={22}
-            height={22}
-            className="rounded-[5px] shrink-0"
-          />
+          <LifoLogo className="size-[22px] shrink-0" />
           <h1 className="text-lg font-bold text-tokyo-fg-bright tracking-tight">Lifo</h1>
           <button
             onClick={toggle}

--- a/apps/playground/src/components/terminal-area.tsx
+++ b/apps/playground/src/components/terminal-area.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { Terminal } from '@lifo-sh/ui';
-import { MoreVertical, Plus, Activity, Square, RotateCcw, Download, Upload, X, FileText } from 'lucide-react';
+import { MoreVertical, Plus, Activity, Square, RotateCcw, Download, Upload, X, FileText, PanelTopClose } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { TerminalView } from '@/components/terminal-view';
 import { ProcessPanel } from '@/components/process-panel';
@@ -24,6 +24,8 @@ interface TerminalAreaProps {
   onRestart?: () => void;
   onSnapshot?: () => void;
   onRestore?: () => void;
+  /** When provided, shows a button to fold the terminal panel (preview examples). */
+  onFold?: () => void;
 }
 
 type Tab =
@@ -39,7 +41,7 @@ const README_ID = -1;
  * restart, snapshot, restore — the latter three only when handlers are given).
  * Every tab is closable; the box menu reopens Processes if it was closed.
  */
-export function TerminalArea({ bootTab, box, initialLabels, canAdd = true, onRestart, onSnapshot, onRestore }: TerminalAreaProps) {
+export function TerminalArea({ bootTab, box, initialLabels, canAdd = true, onRestart, onSnapshot, onRestore, onFold }: TerminalAreaProps) {
   const labels = initialLabels?.length ? initialLabels : ['Terminal 1'];
   // The example's code sample, captured at mount, shown as a README.md tab.
   const chrome = useOutputChrome();
@@ -219,6 +221,15 @@ export function TerminalArea({ bootTab, box, initialLabels, canAdd = true, onRes
           )}
         </div>
         {busy && <span className="text-[10px] text-tokyo-comment px-2 self-center">{busy}</span>}
+        {onFold && (
+          <button
+            onClick={onFold}
+            title="Collapse terminal"
+            className="px-2.5 grid place-items-center bg-transparent border-none text-tokyo-comment hover:text-tokyo-fg-bright hover:bg-tokyo-hover cursor-pointer"
+          >
+            <PanelTopClose size={16} />
+          </button>
+        )}
         <div className="relative flex items-stretch" ref={menuRef}>
           <button
             onClick={() => setMenuOpen((v) => !v)}

--- a/apps/playground/src/components/terminal-area.tsx
+++ b/apps/playground/src/components/terminal-area.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import type { Terminal } from '@lifo-sh/ui';
-import { MoreVertical, Plus, Activity, Square, RotateCcw, Download, Upload, X } from 'lucide-react';
+import { MoreVertical, Plus, Activity, Square, RotateCcw, Download, Upload, X, FileText } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { TerminalView } from '@/components/terminal-view';
 import { ProcessPanel } from '@/components/process-panel';
+import { CodeColumn } from '@/components/code-column';
+import { useOutputChrome } from '@/components/output-chrome';
 import { listProcesses, killProcess, type InspectableBox } from '@/lib/process-inspector';
 
 interface TerminalAreaProps {
@@ -26,7 +28,10 @@ interface TerminalAreaProps {
 
 type Tab =
   | { id: number; kind: 'terminal'; label: string }
-  | { id: number; kind: 'process'; label: string };
+  | { id: number; kind: 'process'; label: string }
+  | { id: number; kind: 'readme'; label: string };
+
+const README_ID = -1;
 
 /**
  * Shared terminal chrome (VS Code-like): flat tabbed terminals over one kernel,
@@ -36,11 +41,18 @@ type Tab =
  */
 export function TerminalArea({ bootTab, box, initialLabels, canAdd = true, onRestart, onSnapshot, onRestore }: TerminalAreaProps) {
   const labels = initialLabels?.length ? initialLabels : ['Terminal 1'];
+  // The example's code sample, captured at mount, shown as a README.md tab.
+  const chrome = useOutputChrome();
+  const snippetRef = useRef(chrome?.snippet);
+  const hasReadme = !!snippetRef.current;
+
   const [tabs, setTabs] = useState<Tab[]>(() => [
+    ...(hasReadme ? [{ id: README_ID, kind: 'readme' as const, label: 'README.md' }] : []),
     ...labels.map((label, i) => ({ id: i, kind: 'terminal' as const, label })),
     { id: labels.length, kind: 'process' as const, label: 'Processes' },
   ]);
-  const [active, setActive] = useState(0);
+  // Default to the first terminal (README is present but not selected).
+  const [active, setActive] = useState(hasReadme ? 1 : 0);
   const [menuOpen, setMenuOpen] = useState(false);
   const [procCount, setProcCount] = useState(0);
   const [busy, setBusy] = useState<string | null>(null);
@@ -85,6 +97,7 @@ export function TerminalArea({ bootTab, box, initialLabels, canAdd = true, onRes
   const closeTab = (i: number, e?: React.MouseEvent) => {
     e?.stopPropagation();
     const closing = tabs[i];
+    if (closing?.kind === 'readme') return; // README is a permanent first tab
     if (closing?.kind === 'terminal') termsRef.current.delete(closing.id);
     setTabs((t) => t.filter((_, idx) => idx !== i));
     setActive((a) => {
@@ -174,20 +187,23 @@ export function TerminalArea({ bootTab, box, initialLabels, canAdd = true, onRes
               )}
             >
               {t.kind === 'process' && <Activity size={12} className={cn('shrink-0', running && 'text-tokyo-green')} />}
-              <span>{t.label}</span>
+              {t.kind === 'readme' && <FileText size={12} className="shrink-0 text-tokyo-blue" />}
+              <span className={cn(t.kind === 'readme' && 'pr-1.5')}>{t.label}</span>
               {running && (
                 <span className="text-[10px] tabular-nums text-tokyo-green">({procCount})</span>
               )}
-              <button
-                onClick={(e) => closeTab(i, e)}
-                title="Close tab"
-                className={cn(
-                  'grid place-items-center w-4 h-4 rounded-sm hover:bg-tokyo-active hover:text-tokyo-fg-bright shrink-0 transition-opacity',
-                  i === active ? 'opacity-70 hover:opacity-100' : 'opacity-0 group-hover:opacity-70',
-                )}
-              >
-                <X size={12} />
-              </button>
+              {t.kind !== 'readme' && (
+                <button
+                  onClick={(e) => closeTab(i, e)}
+                  title="Close tab"
+                  className={cn(
+                    'grid place-items-center w-4 h-4 rounded-sm hover:bg-tokyo-active hover:text-tokyo-fg-bright shrink-0 transition-opacity',
+                    i === active ? 'opacity-70 hover:opacity-100' : 'opacity-0 group-hover:opacity-70',
+                  )}
+                >
+                  <X size={12} />
+                </button>
+              )}
             </div>
             );
           })}
@@ -256,6 +272,10 @@ export function TerminalArea({ bootTab, box, initialLabels, canAdd = true, onRes
                       bootTab(term);
                     }}
                   />
+                </div>
+              ) : t.kind === 'readme' ? (
+                <div className="flex-1 min-h-0">
+                  <CodeColumn snippet={snippetRef.current} />
                 </div>
               ) : (
                 <div className="flex-1 min-h-0 flex flex-col">

--- a/apps/playground/src/data/code-snippets.ts
+++ b/apps/playground/src/data/code-snippets.ts
@@ -365,7 +365,6 @@ const CODE_VITE_REACT = `\
 <span class="code-comment"># A real Vite dev server with React fast-refresh,</span>
 <span class="code-comment"># running entirely in your browser — no host process.</span>
 
-<span class="code-fn">cd</span> react-app
 <span class="code-fn">npm</span> install          <span class="code-comment"># real npm registry, in-browser</span>
 <span class="code-fn">npm</span> run dev &        <span class="code-comment"># vite on virtual port 5173</span>
 
@@ -381,7 +380,6 @@ const CODE_VITE_REACT_TS = `\
 <span class="code-comment"># Vite + React + TypeScript, same stack as the JS</span>
 <span class="code-comment"># example: tsx transforms, fast-refresh, all in-browser.</span>
 
-<span class="code-fn">cd</span> react-ts-app
 <span class="code-fn">npm</span> install
 <span class="code-fn">npm</span> run dev &
 
@@ -408,7 +406,6 @@ const CODE_TINBASE = `\
 <span class="code-comment"># (tinbase.vercel.app) runs as a server IN the VM, and a</span>
 <span class="code-comment"># Vite + React + TS app talks to it via supabase-js.</span>
 
-<span class="code-fn">cd</span> tinbase-todo
 <span class="code-fn">npm</span> install
 <span class="code-fn">npm</span> run backend &   <span class="code-comment"># tinbase on :54321 (like supabase start)</span>
 <span class="code-fn">npm</span> run dev &       <span class="code-comment"># vite + react on :5173</span>
@@ -446,7 +443,6 @@ const CODE_EXPO = `\
 <span class="code-comment"># Metro dev server, running entirely in your browser.</span>
 <span class="code-comment"># Metro runs in-band (maxWorkers=1) and offline.</span>
 
-<span class="code-fn">cd</span> expo-app
 <span class="code-fn">npm</span> install          <span class="code-comment"># expo, react-native, metro, …</span>
 <span class="code-fn">npm</span> run start &      <span class="code-comment"># expo start --web → Metro dev server :8081</span>
 
@@ -461,7 +457,6 @@ const CODE_EXPO_ROUTER = `\
 <span class="code-comment"># server, running entirely in your browser.</span>
 <span class="code-comment"># Routes live in app/ (app/index.js, app/about.js).</span>
 
-<span class="code-fn">cd</span> expo-router-app
 <span class="code-fn">npm</span> install          <span class="code-comment"># expo-router, react-navigation, …</span>
 <span class="code-fn">npm</span> run start &      <span class="code-comment"># expo start --web → Metro dev server :8082</span>
 
@@ -494,7 +489,6 @@ const CODE_EXPO_SUPABASE = `\
 <span class="code-comment"># Native web app (Metro + Fast Refresh) talking supabase-js</span>
 <span class="code-comment"># to a tinbase backend (pure-JS Postgres via pg-mem).</span>
 
-<span class="code-fn">cd</span> expo-supabase
 <span class="code-fn">npm</span> install
 <span class="code-fn">npm</span> run backend &   <span class="code-comment"># tinbase :54321 — prints anon +</span>
                     <span class="code-comment"># service_role keys (like supabase start)</span>

--- a/apps/playground/src/examples/interactive.tsx
+++ b/apps/playground/src/examples/interactive.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { Kernel } from '@lifo-sh/core';
 import type { Terminal } from '@lifo-sh/ui';
 import { ExamplePanel } from '@/components/example-panel';
@@ -20,8 +20,12 @@ export default function InteractiveExample() {
     return k;
   }, []);
 
+  // Show the welcome banner on the first terminal only, not every new tab.
+  const firstBoot = useRef(true);
   const bootTab = (term: Terminal) => {
-    void kernelPromise.then((k) => bootShell(term, k, { network: true }));
+    const banner = firstBoot.current;
+    firstBoot.current = false;
+    void kernelPromise.then((k) => bootShell(term, k, { network: true, banner }));
   };
 
   const box = kernel ? { kernel, env: kernel.getDefaultEnv() } : null;

--- a/apps/playground/src/examples/project-example.tsx
+++ b/apps/playground/src/examples/project-example.tsx
@@ -1,4 +1,6 @@
 import { type ReactNode, useRef, useState } from 'react';
+import { PanelTopOpen } from 'lucide-react';
+import { Panel as RawPanel, type ImperativePanelHandle } from 'react-resizable-panels';
 import { Sandbox, ServiceWorkerBridge } from '@lifo-sh/core';
 import gitCommand from 'lifo-pkg-git';
 import type { Terminal } from '@lifo-sh/ui';
@@ -48,6 +50,11 @@ export function ProjectExample({ title, subtitle, files, cwd, previewPort, previ
 
   const sandboxRef = useRef<Sandbox | null>(null);
   const bridgeRef = useRef<ServiceWorkerBridge | null>(null);
+
+  // Fold/unfold the terminal panel (preview examples). The terminal panel is
+  // *collapsed* (size 0), never unmounted, so the box/kernel/scrollback survive.
+  const termPanelRef = useRef<ImperativePanelHandle>(null);
+  const [terminalFolded, setTerminalFolded] = useState(false);
 
   // The first terminal creates the Sandbox + SW bridge; extra terminals attach
   // a shell onto the shared kernel.
@@ -111,6 +118,7 @@ export function ProjectExample({ title, subtitle, files, cwd, previewPort, previ
       onRestart={restart}
       onSnapshot={sandbox ? () => downloadSnapshot(sandbox) : undefined}
       onRestore={sandbox ? () => pickAndRestoreSnapshot(sandbox) : undefined}
+      onFold={hasPreview ? () => termPanelRef.current?.collapse() : undefined}
     />
   );
 
@@ -120,12 +128,32 @@ export function ProjectExample({ title, subtitle, files, cwd, previewPort, previ
         <ResizablePanelGroup
           direction="vertical"
           autoSaveId={`pg-project-${previewTabs[0]?.port ?? previewPort}-split`}
-          className="flex-1 min-h-0"
+          className="relative flex-1 min-h-0"
         >
-          <ResizablePanel defaultSize={45} minSize={20}>
+          <RawPanel
+            ref={termPanelRef}
+            collapsible
+            collapsedSize={0}
+            defaultSize={45}
+            minSize={20}
+            className="overflow-hidden"
+            onCollapse={() => setTerminalFolded(true)}
+            onExpand={() => setTerminalFolded(false)}
+          >
             {terminalArea}
-          </ResizablePanel>
+          </RawPanel>
           <ResizableHandle className="my-0.5" />
+          {/* When the terminal is folded, a slim bar to bring it back */}
+          {terminalFolded && (
+            <button
+              onClick={() => termPanelRef.current?.expand()}
+              title="Show terminal"
+              className="absolute top-0 left-0 right-0 z-20 flex items-center justify-center gap-1.5 h-6 text-[11px] text-tokyo-comment bg-tokyo-bg-dark border-b border-tokyo-border hover:text-tokyo-fg-bright cursor-pointer"
+            >
+              <PanelTopOpen size={13} />
+              Show terminal
+            </button>
+          )}
           <ResizablePanel defaultSize={55} minSize={20}>
             {swReady === null ? (
               <div className="flex-1 h-full grid place-items-center text-[12px] text-tokyo-comment">

--- a/apps/playground/src/lib/shell.ts
+++ b/apps/playground/src/lib/shell.ts
@@ -43,6 +43,9 @@ export interface BootShellOptions {
   env?: Record<string, string>;
   /** Initial working directory for this shell. */
   cwd?: string;
+  /** Print the welcome banner (/etc/motd — the Lifo ASCII art + tagline) before
+   *  the first prompt. Used for the interactive example's first terminal. */
+  banner?: boolean;
 }
 
 interface ShellExecCtx {
@@ -116,6 +119,14 @@ export async function bootShell(
   await shell.sourceFile(env.HOME + '/.bashrc');
   if (opts.cwd) shell.setCwd(opts.cwd);
   if (opts.services) await kernel.bootServices();
+
+  // Welcome banner (the Lifo ASCII art + tagline) before the first prompt.
+  // Sandbox.create() prints this when it owns the xterm; the playground creates
+  // its own Terminal (for tab management), so we print it here on request.
+  if (opts.banner) {
+    const motd = kernel.vfs.readFileString('/etc/motd');
+    if (motd) terminal.write(motd.replace(/\r\n/g, '\n').replace(/\n/g, '\r\n'));
+  }
   shell.start();
 
   return shell;

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,33 @@
+# Lifo benchmarks
+
+Reproducible numbers for the "browser & Node benchmarks" roadmap item — so
+claims like "boots in ~0 ms, $0 infra" are backed by data, not vibes.
+
+## Node
+
+Measures a box booting, shell-command throughput, filesystem throughput, and
+memory — running the same VM in Node.
+
+```bash
+pnpm --filter @lifo-sh/core build   # the harness imports the built dist
+node bench/node-bench.mjs           # human-readable table
+node bench/node-bench.mjs --json    # machine-readable
+```
+
+Example (M-series laptop, Node 22):
+
+```
+Boot (Sandbox.create, cold, ×20)   avg ~0.6 ms
+Shell commands (`true` ×500)       ~240k ops/s
+Filesystem (1 KiB ×500)            ~480k write / ~540k read ops/s
+Memory                             ~60 MB rss
+```
+
+Numbers vary by machine; treat them as relative, and re-run on the same box to
+catch regressions.
+
+## Browser (planned)
+
+A headless-Chrome harness that mirrors the Node metrics inside a page (boot,
+commands, FS) plus a Vite dev-server cold-start measured end to end. Tracked in
+the roadmap; wire it into CI so regressions surface on every PR.

--- a/bench/node-bench.mjs
+++ b/bench/node-bench.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Lifo Node benchmark harness.
+ *
+ * Measures the same VM that runs in the browser, here in Node: how fast a box
+ * boots, how many shell commands it runs per second, and filesystem
+ * throughput. First step of the "browser & Node benchmarks" roadmap item — a
+ * browser harness (headless Chrome) mirrors these numbers.
+ *
+ *   node bench/node-bench.mjs            # human-readable table
+ *   node bench/node-bench.mjs --json     # machine-readable
+ *
+ * Requires the core package to be built (pnpm --filter @lifo-sh/core build).
+ */
+import { performance } from 'node:perf_hooks';
+// Import the built core directly so the harness runs from the repo root with
+// plain `node` (no workspace resolution). Build first: pnpm --filter @lifo-sh/core build
+import { Sandbox } from '../packages/core/dist/index.js';
+
+const JSON_OUT = process.argv.includes('--json');
+
+function summarize(times) {
+  const s = [...times].sort((a, b) => a - b);
+  const sum = s.reduce((a, b) => a + b, 0);
+  return {
+    runs: s.length,
+    avgMs: sum / s.length,
+    p50Ms: s[Math.floor(s.length * 0.5)],
+    p95Ms: s[Math.floor(s.length * 0.95)],
+    minMs: s[0],
+    maxMs: s[s.length - 1],
+  };
+}
+
+async function benchBoot(runs) {
+  const times = [];
+  for (let i = 0; i < runs; i++) {
+    const t = performance.now();
+    const sb = await Sandbox.create({ persist: false });
+    times.push(performance.now() - t);
+    sb.destroy?.();
+  }
+  return summarize(times);
+}
+
+async function benchCommands(sb, ops) {
+  // Warm up the command path once.
+  await sb.commands.run('true');
+  const t = performance.now();
+  for (let i = 0; i < ops; i++) await sb.commands.run('true');
+  const ms = performance.now() - t;
+  return { ops, totalMs: ms, avgMs: ms / ops, opsPerSec: (ops / ms) * 1000 };
+}
+
+async function benchFs(sb, ops, sizeBytes) {
+  const data = 'x'.repeat(sizeBytes);
+  await sb.fs.writeFile('/tmp/warm', data);
+
+  let t = performance.now();
+  for (let i = 0; i < ops; i++) await sb.fs.writeFile(`/tmp/f${i}`, data);
+  const writeMs = performance.now() - t;
+
+  t = performance.now();
+  for (let i = 0; i < ops; i++) await sb.fs.readFile(`/tmp/f${i}`);
+  const readMs = performance.now() - t;
+
+  return {
+    ops,
+    sizeBytes,
+    writeOpsPerSec: (ops / writeMs) * 1000,
+    readOpsPerSec: (ops / readMs) * 1000,
+  };
+}
+
+async function main() {
+  const node = process.version;
+  const boot = await benchBoot(20);
+
+  const sb = await Sandbox.create({ persist: false });
+  const commands = await benchCommands(sb, 500);
+  const fs = await benchFs(sb, 500, 1024);
+  const mem = process.memoryUsage();
+
+  const report = {
+    node,
+    when: new Date().toISOString(),
+    boot,
+    commands,
+    fs,
+    rssMB: +(mem.rss / 1048576).toFixed(1),
+    heapUsedMB: +(mem.heapUsed / 1048576).toFixed(1),
+  };
+
+  if (JSON_OUT) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
+  const row = (k, v) => console.log(`  ${k.padEnd(26)} ${v}`);
+  console.log(`\nLifo — Node benchmark  (${node})\n`);
+  console.log('Boot (Sandbox.create, cold, ×20)');
+  row('avg', `${boot.avgMs.toFixed(2)} ms`);
+  row('p50 / p95', `${boot.p50Ms.toFixed(2)} / ${boot.p95Ms.toFixed(2)} ms`);
+  row('min / max', `${boot.minMs.toFixed(2)} / ${boot.maxMs.toFixed(2)} ms`);
+  console.log('\nShell commands (`true` ×500)');
+  row('throughput', `${commands.opsPerSec.toFixed(0)} ops/s`);
+  row('avg latency', `${commands.avgMs.toFixed(3)} ms`);
+  console.log('\nFilesystem (1 KiB ×500)');
+  row('write', `${fs.writeOpsPerSec.toFixed(0)} ops/s`);
+  row('read', `${fs.readOpsPerSec.toFixed(0)} ops/s`);
+  console.log('\nMemory');
+  row('rss', `${report.rssMB} MB`);
+  row('heap used', `${report.heapUsedMB} MB`);
+  console.log('');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/core/src/commands/system/node.ts
+++ b/packages/core/src/commands/system/node.ts
@@ -953,14 +953,35 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 			}) as F;
 		};
 
-		const nodeCtx: NodeContext = {
+			// Real process.exit() kills the process — nothing prints afterward. In the
+		// VM an event-driven exit() must RETURN rather than throw (so a caller like
+		// Expo's Ctrl+C handler, which calls process.exit() at the end of a try
+		// block, completes cleanly instead of hitting its catch — see requestExit).
+		// That means code after process.exit() keeps running. Gate all program
+		// output on this flag so anything written post-exit stays silent, matching
+		// Node. Without it, Expo's logCmdError prints a CommandError's message and
+		// then — in a fall-through path Node never reaches — re-prints it with the
+		// full stack trace. Set by requestExit() when an exit is handled.
+		let exited = false;
+		const gateStream = <S extends { write: (chunk: string) => unknown }>(s: S): S =>
+			new Proxy(s, {
+				get(target, prop, recv) {
+					if (prop === 'write') {
+						return (chunk: string) => (exited ? true : (target.write as (c: string) => unknown).call(target, chunk));
+					}
+					return Reflect.get(target, prop, recv);
+				},
+			});
+		const runStdout = gateStream(ctx.stdout);
+		const runStderr = gateStream(ctx.stderr);
+	const nodeCtx: NodeContext = {
 			vfs: ctx.vfs,
 			cwd: ctx.cwd,
 			// Copy the shell env once so the node run has its own process.env
 			// (isolated from the shell) that is then shared across all its modules.
 			env: { ...ctx.env },
-			stdout: ctx.stdout,
-			stderr: ctx.stderr,
+			stdout: runStdout,
+			stderr: runStderr,
 			argv: [filename, ...scriptArgs],
 			filename,
 			dirname: dir,
@@ -1024,6 +1045,7 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 		const requestExit = (code: number): boolean => {
 			if (!interceptExit) return false; // still in the sync script → throw as usual
 			asyncExitCode = code;
+			exited = true; // real process.exit() is now dead: silence any post-exit output
 			signalExit();
 			return true;
 		};
@@ -1535,13 +1557,13 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 				argv: nodeCtx.argv,
 				env: nodeCtx.env,
 				cwd: nodeCtx.cwd,
-				stdout: ctx.stdout,
-				stderr: ctx.stderr,
+				stdout: runStdout,
+				stderr: runStderr,
 				stdin: nodeStdin,
 				interactive,
 				onExit: requestExit,
 			});
-			const modConsole = createConsole(ctx.stdout, ctx.stderr);
+			const modConsole = createConsole(runStdout, runStderr);
 
 			function modRequire(name: string): unknown {
 				// Strip node: prefix
@@ -1779,13 +1801,13 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 			argv: nodeCtx.argv,
 			env: nodeCtx.env,
 			cwd: nodeCtx.cwd,
-			stdout: ctx.stdout,
-			stderr: ctx.stderr,
+			stdout: runStdout,
+			stderr: runStderr,
 			stdin: nodeStdin,
 			interactive,
 			onExit: requestExit,
 		});
-		const nodeConsole = createConsole(ctx.stdout, ctx.stderr);
+		const nodeConsole = createConsole(runStdout, runStderr);
 
 		const module = { exports: {} as Record<string, unknown> };
 		const exports = module.exports;

--- a/packages/core/src/commands/system/node.ts
+++ b/packages/core/src/commands/system/node.ts
@@ -1845,9 +1845,10 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 			// gracefully rather than throw. Race the main promise against
 			// exitPromise: long-running servers await forever (`new Promise(()=>{})`),
 			// so without this a graceful exit would hang on the never-resolving main.
+			let mainResolved = false;
 			if (isEsm && result && typeof result.then === 'function') {
 				interceptExit = true;
-				await Promise.race([result, exitPromise]);
+				await Promise.race([result.then(() => { mainResolved = true; }), exitPromise]);
 			}
 
 			// Graceful async process.exit() (interactive keypress, etc.) — the
@@ -1876,7 +1877,15 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 			// aborts, or things stay quiescent for ~300ms (the script finished).
 			if (!activeServers || activeServers.length === 0) {
 				let prevCacheSize = moduleCache.size;
-				let staleCount = 0;
+				let prevPending = pendingAsync;
+				let lastInputSeq = (nodeStdin as unknown as { inputSeq?: number }).inputSeq ?? 0;
+				// Track the last moment real work happened. We stop hanging once nothing
+				// meaningful has moved for a grace window. This is deliberately wall-clock
+				// based (not tick counters): a finished CLI that leaves stdin in raw mode
+				// with a stray keypress listener (e.g. create-expo-app) makes isActive()
+				// and rawMode *flicker*, which would defeat any consecutive-tick counter.
+				let lastWorkMs = 0; // ms elapsed since loop start when work last happened
+				let elapsed = 0;
 				const hardDeadline = Date.now() + 600000; // 10 min cap (long installs)
 				while (Date.now() < hardDeadline) {
 					const tick = await Promise.race([
@@ -1884,14 +1893,30 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 						exitPromise.then(() => 'exit' as const),
 					]);
 					if (tick === 'exit' || ctx.signal.aborted || pendingRejection || asyncExitCode !== null) break;
+					elapsed += 50;
 					activeServers = getActiveServers();
 					if (activeServers && activeServers.length > 0) break;
-					if (pendingAsync > 0 || nodeStdin.isActive() || moduleCache.size > prevCacheSize) {
-						staleCount = 0;
+					const seq = (nodeStdin as unknown as { inputSeq?: number }).inputSeq ?? 0;
+					// "Meaningful work": an async op in flight, a new module loading, a new
+					// async op started, or fresh stdin input (the user answering a prompt).
+					// A merely *attached* stdin consumer sitting idle is NOT work — that's the
+					// leftover-listener case we want to time out.
+					if (
+						pendingAsync > 0 ||
+						moduleCache.size > prevCacheSize ||
+						pendingAsync > prevPending ||
+						seq !== lastInputSeq
+					) {
+						lastWorkMs = elapsed;
 						prevCacheSize = moduleCache.size;
-					} else if (++staleCount >= 6) {
-						break;
+						prevPending = pendingAsync;
+						lastInputSeq = seq;
 					}
+					// Grace after the last meaningful work: short once the ESM main has
+					// resolved, longer otherwise (CJS has no such signal, so lean toward not
+					// cutting a slow-to-answer interactive prompt short).
+					const idleMs = elapsed - lastWorkMs;
+					if (idleMs >= (mainResolved ? 500 : 2500)) break;
 				}
 			}
 

--- a/packages/core/src/commands/system/node.ts
+++ b/packages/core/src/commands/system/node.ts
@@ -937,6 +937,22 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 			? kernelOrPortRegistry
 			: kernelOrPortRegistry?.portRegistry;
 
+		// Count in-flight child processes. create-expo-app shells out to `npm
+		// install` (and post-install steps like `git init`) via child_process; that
+		// work registers no fetch and may go quiet for seconds (e.g. package
+		// extraction/linking), so without tracking it the quiescence wait below
+		// would mistake a busy install for an idle run and hand the prompt back
+		// before the CLI finishes — its final "your project is ready" then prints
+		// after the shell prompt (seen with Expo SDK 57).
+		let pendingChild = 0;
+		const trackChild = <F extends ((...a: never[]) => Promise<unknown>) | undefined>(run: F): F => {
+			if (!run) return run;
+			return ((...a: Parameters<NonNullable<F>>) => {
+				pendingChild++;
+				return Promise.resolve((run as NonNullable<F>)(...a)).finally(() => { pendingChild--; });
+			}) as F;
+		};
+
 		const nodeCtx: NodeContext = {
 			vfs: ctx.vfs,
 			cwd: ctx.cwd,
@@ -952,8 +968,8 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 			portRegistry,
 			// Lets child_process (exec/spawn) shell out to other VM commands —
 			// e.g. create-expo-app running `npm pack` / `npm install`.
-			executeCapture: ctx.executeCapture,
-			executeCaptureResult: ctx.executeCaptureResult,
+			executeCapture: trackChild(ctx.executeCapture),
+			executeCaptureResult: trackChild(ctx.executeCaptureResult),
 		};
 
 		// Back require('module')'s Module#_compile with the real module executor
@@ -1897,12 +1913,13 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 					activeServers = getActiveServers();
 					if (activeServers && activeServers.length > 0) break;
 					const seq = (nodeStdin as unknown as { inputSeq?: number }).inputSeq ?? 0;
-					// "Meaningful work": an async op in flight, a new module loading, a new
-					// async op started, or fresh stdin input (the user answering a prompt).
-					// A merely *attached* stdin consumer sitting idle is NOT work — that's the
-					// leftover-listener case we want to time out.
+					// "Meaningful work": an async op in flight, a child process running, a
+					// new module loading, a new async op started, or fresh stdin input (the
+					// user answering a prompt). A merely *attached* stdin consumer sitting
+					// idle is NOT work — that's the leftover-listener case we time out.
 					if (
 						pendingAsync > 0 ||
+						pendingChild > 0 ||
 						moduleCache.size > prevCacheSize ||
 						pendingAsync > prevPending ||
 						seq !== lastInputSeq

--- a/packages/core/src/commands/system/npm.ts
+++ b/packages/core/src/commands/system/npm.ts
@@ -878,26 +878,7 @@ async function npmRun(ctx: CommandContext, shellExecute?: ShellExecuteFn, regist
 
 	// Register local bin scripts from node_modules so they're available in scripts
 	if (registry) {
-		const nmDir = join(ctx.cwd, 'node_modules');
-		ctx.stderr.write(`[npm:debug] cwd="${ctx.cwd}", nmDir="${nmDir}", exists=${ctx.vfs.exists(nmDir)}\n`);
-		if (ctx.vfs.exists(nmDir)) {
-			try {
-				const entries = ctx.vfs.readdir(nmDir);
-				ctx.stderr.write(`[npm:debug] node_modules entries (${entries.length}): ${entries.slice(0, 20).join(', ')}\n`);
-				// Check vite specifically
-				const vitePkg = join(nmDir, 'vite', 'package.json');
-				if (ctx.vfs.exists(vitePkg)) {
-					const vPkg = JSON.parse(ctx.vfs.readFileString(vitePkg));
-					ctx.stderr.write(`[npm:debug] vite pkg.bin=${JSON.stringify(vPkg.bin)}\n`);
-				} else {
-					ctx.stderr.write(`[npm:debug] vite/package.json not found at ${vitePkg}\n`);
-				}
-			} catch (e) { ctx.stderr.write(`[npm:debug] readdir error: ${e}\n`); }
-		}
-		const count = registerLocalBins(ctx.vfs, ctx.cwd, registry, kernel);
-		ctx.stderr.write(`[npm:debug] registered ${count} local bins, script="${script}"\n`);
-		const firstWord = script.trim().split(/\s+/)[0];
-		ctx.stderr.write(`[npm:debug] first command: "${firstWord}", has=${registry.has(firstWord)}\n`);
+		registerLocalBins(ctx.vfs, ctx.cwd, registry, kernel);
 	}
 
 	// For simple scripts (single command, no shell operators), invoke directly

--- a/packages/core/src/node-compat/process.ts
+++ b/packages/core/src/node-compat/process.ts
@@ -192,9 +192,6 @@ export function createProcess(opts: ProcessOptions) {
       // main script already settled), let it — returning instead of throwing
       // so a caller like Expo's Ctrl+C handler completes its try block cleanly.
       if (opts.onExit?.(code)) return undefined as never;
-      if (code !== 0) {
-        opts.stderr.write(`[process.exit] code=${code}\n`);
-      }
       throw new ProcessExitError(code);
     },
     // Report a TTY on interactive runs so CLIs that gate their interactive UI on

--- a/packages/core/src/node-compat/process.ts
+++ b/packages/core/src/node-compat/process.ts
@@ -30,6 +30,7 @@ export function createInteractiveStdin(
       const chunk = await input.read();
       if (chunk === null) { ended = true; emit('end'); break; }
       if (chunk === '') continue;
+      stdin.inputSeq++; // bump so the node runner sees stdin is actively read
       emit('data', encoding ? chunk : Buffer.from(chunk));
     }
   }
@@ -37,6 +38,9 @@ export function createInteractiveStdin(
   const stdin = {
     isTTY: interactive,
     isRaw: false,
+    /** Bumped on every input chunk; the node runner uses it to tell a
+     *  live prompt (recent input) from a leftover consumer (idle). */
+    inputSeq: 0,
     fd: 0,
     readable: true,
     setRawMode(v: boolean) { stdin.isRaw = !!v; setRawMode?.(!!v); return stdin; },

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,6 +1,10 @@
 # @lifo-sh/ui
 
-Terminal UI package for [Lifo](https://github.com/lifo-sh/lifo) -- a Linux-like OS that runs natively in the browser. Wraps xterm.js with WebGL rendering and auto-fit.
+Embeddable UI components for [Lifo](https://github.com/lifo-sh/lifo) — a tiny Linux-like VM that runs in the browser. Framework-agnostic: mount them into any DOM element.
+
+- **`Terminal`** — a themeable xterm.js terminal (WebGL, auto-fit) bound to a box's shell.
+- **`PreviewBrowser`** — an iframe view bound to an in-VM port, with optional Chrome-like chrome (back / forward / reload, a friendly address bar, open-in-new-tab).
+- **`FileExplorer`** — a file tree over the box's filesystem (optional editor).
 
 ## Install
 
@@ -10,7 +14,7 @@ npm install @lifo-sh/ui @lifo-sh/core
 
 ## Usage
 
-Create a `Terminal` and pass it to `Sandbox.create()`:
+A terminal, bound to a box's shell:
 
 ```typescript
 import { Terminal } from '@lifo-sh/ui';
@@ -20,29 +24,33 @@ const terminal = new Terminal(document.getElementById('terminal'));
 const sandbox = await Sandbox.create({ terminal });
 ```
 
-### Standalone
+A live preview of an in-VM port:
 
 ```typescript
-import { Terminal } from '@lifo-sh/ui';
+import { ServiceWorkerBridge } from '@lifo-sh/core';
+import { PreviewBrowser } from '@lifo-sh/ui';
 
-const terminal = new Terminal(document.getElementById('terminal'));
-terminal.write('Hello from Lifo!\r\n');
+const bridge = new ServiceWorkerBridge(sandbox.kernel.portRegistry);
+await bridge.connect('/sw.js', '/');
+new PreviewBrowser(document.getElementById('preview'), { bridge, port: 3000 });
 ```
 
-## What's Included
+See the [Embeddable UI docs](https://lifo.sh/docs/embeddable-ui) for a complete from-scratch example (box + terminal + preview) and the full API.
 
-- xterm.js terminal emulator
-- WebGL renderer for GPU-accelerated rendering
-- Auto-fit addon for responsive sizing
-- Implements the `ITerminal` interface from `@lifo-sh/core`
+## What's included
+
+- `Terminal` — xterm.js + WebGL + auto-fit, implements `ITerminal` from `@lifo-sh/core`.
+- `PreviewBrowser` — service-worker-backed iframe preview of an in-VM port.
+- `FileExplorer` — filesystem tree with an optional editor provider.
+- Themed with CSS variables (`--tk-*`, Tokyo Night by default) — override to reskin.
 
 ## Packages
 
 | Package | Description |
 |---|---|
 | [@lifo-sh/core](https://www.npmjs.com/package/@lifo-sh/core) | Kernel, shell, commands, sandbox API |
-| **@lifo-sh/ui** | Terminal UI (xterm.js wrapper) |
-| [lifo-sh](https://www.npmjs.com/package/lifo-sh) | CLI -- run Lifo in your terminal |
+| **@lifo-sh/ui** | Embeddable UI — terminal, preview browser, file explorer |
+| [lifo-sh](https://www.npmjs.com/package/lifo-sh) | CLI — run Lifo in your terminal |
 
 ## Links
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lifo-sh/ui",
   "version": "0.5.0",
-  "description": "Terminal UI for Lifo -- xterm.js wrapper with WebGL rendering",
+  "description": "Embeddable UI components for Lifo — terminal, preview browser, and file explorer",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -14,6 +14,9 @@
     "terminal",
     "xterm",
     "webgl",
+    "preview",
+    "iframe",
+    "file-explorer",
     "lifo"
   ],
   "type": "module",

--- a/packages/ui/src/PreviewBrowser.ts
+++ b/packages/ui/src/PreviewBrowser.ts
@@ -1,0 +1,229 @@
+import type { ServiceWorkerBridge } from '@lifo-sh/core';
+
+export interface PreviewBrowserOptions {
+  /** In-VM virtual port to preview. */
+  port: number;
+  /**
+   * The box's ServiceWorkerBridge. Its `boxId` is used to route requests
+   * (`/_sw/<boxId>/<port>/`) to the right VM. Preferred over `boxId` because it
+   * stays correct if you recreate the bridge. Connect the bridge yourself
+   * (`await bridge.connect()`) — the preview just points at it.
+   */
+  bridge?: ServiceWorkerBridge;
+  /** An explicit box id, if you manage the service worker yourself. */
+  boxId?: string;
+  /** Initial path inside the app (default `/`) — e.g. `/_/` for a studio route. */
+  path?: string;
+  /** Render the browser chrome (back / forward / reload + address bar + open-in-tab). Default `true`. */
+  chrome?: boolean;
+}
+
+const STYLES = `
+.lf-pv { display: flex; flex-direction: column; height: 100%; width: 100%; min-height: 0; overflow: hidden; background: var(--tk-bg, #1a1b26); font-family: ui-sans-serif, system-ui, sans-serif; }
+.lf-pv-bar { display: flex; align-items: center; gap: 4px; padding: 6px 8px; border-bottom: 1px solid var(--tk-border, #2f3146); background: var(--tk-bg-dark, #16161e); flex-shrink: 0; }
+.lf-pv-btn { flex-shrink: 0; width: 28px; height: 28px; display: grid; place-items: center; border-radius: 9999px; background: transparent; border: none; color: var(--tk-comment, #565f89); cursor: pointer; padding: 0; }
+.lf-pv-btn:hover { color: var(--tk-fg-bright, #c0caf5); background: var(--tk-hover, #1e2030); }
+.lf-pv-addr { flex: 1; min-width: 0; display: flex; align-items: center; gap: 8px; height: 28px; padding: 0 12px; margin: 0 4px; border-radius: 9999px; background: var(--tk-bg, #1a1b26); }
+.lf-pv-addr svg { flex-shrink: 0; color: var(--tk-comment, #565f89); }
+.lf-pv-url { font-size: 12.5px; color: var(--tk-fg, #a9b1d6); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.lf-pv-frame { flex: 1; min-height: 0; width: 100%; display: block; background: #fff; border: none; }
+.lf-pv-link { text-decoration: none; }
+`;
+
+const ICONS = {
+  back: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="M12 19l-7-7 7-7"/></svg>',
+  forward: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg>',
+  reload: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>',
+  info: '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>',
+  external: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><path d="M15 3h6v6"/><path d="M10 14L21 3"/></svg>',
+};
+
+let stylesInjected = false;
+function injectStyles(): void {
+  if (stylesInjected || typeof document === 'undefined') return;
+  const el = document.createElement('style');
+  el.dataset.lifoUi = 'preview-browser';
+  el.textContent = STYLES;
+  document.head.appendChild(el);
+  stylesInjected = true;
+}
+
+/**
+ * An embeddable preview browser: an `<iframe>` bound to an in-VM port through a
+ * `ServiceWorkerBridge`, with optional Chrome-like chrome (back / forward /
+ * reload, a friendly `localhost:<port>` address bar, and open-in-new-tab).
+ *
+ * The iframe is a service-worker-controlled client, so its requests route into
+ * the VM and HMR/WebSocket traffic flows through the bridge — a real dev server
+ * inside the box renders live here. Framework-agnostic: mount it into any element.
+ *
+ * ```ts
+ * const bridge = new ServiceWorkerBridge(sandbox.kernel.portRegistry);
+ * await bridge.connect();
+ * const preview = new PreviewBrowser(document.getElementById('preview')!, { bridge, port: 5173 });
+ * ```
+ */
+export class PreviewBrowser {
+  private root!: HTMLDivElement;
+  private iframe: HTMLIFrameElement;
+  private urlEl: HTMLSpanElement | null = null;
+  private openLink: HTMLAnchorElement | null = null;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private nonce = 0;
+
+  private boxId: string;
+  private port: number;
+  private path: string;
+  private currentUrl = '';
+
+  constructor(container: HTMLElement, options: PreviewBrowserOptions) {
+    injectStyles();
+    this.port = options.port;
+    this.boxId = options.bridge?.boxId ?? options.boxId ?? '';
+    if (!this.boxId) {
+      throw new Error('PreviewBrowser: pass a `bridge` or an explicit `boxId`.');
+    }
+    const p = options.path ?? '/';
+    this.path = p.startsWith('/') ? p : '/' + p;
+
+    const root = document.createElement('div');
+    root.className = 'lf-pv';
+
+    const showChrome = options.chrome !== false;
+    if (showChrome) root.appendChild(this.buildChrome());
+
+    this.iframe = document.createElement('iframe');
+    this.iframe.className = 'lf-pv-frame';
+    this.iframe.title = 'Preview';
+    this.iframe.src = this.route();
+    root.appendChild(this.iframe);
+
+    container.appendChild(root);
+    this.root = root;
+
+    if (showChrome) this.startPolling();
+  }
+
+  /** The absolute in-VM route the iframe points at (`/_sw/<boxId>/<port>/…`). */
+  route(): string {
+    return `/_sw/${this.boxId}/${this.port}${this.path}?_t=${this.nonce}`;
+  }
+
+  private buildChrome(): HTMLElement {
+    const bar = document.createElement('div');
+    bar.className = 'lf-pv-bar';
+
+    const mkBtn = (icon: string, title: string, onClick: () => void) => {
+      const b = document.createElement('button');
+      b.className = 'lf-pv-btn';
+      b.title = title;
+      b.innerHTML = icon;
+      b.addEventListener('click', onClick);
+      return b;
+    };
+
+    bar.appendChild(mkBtn(ICONS.back, 'Back', () => this.back()));
+    bar.appendChild(mkBtn(ICONS.forward, 'Forward', () => this.forward()));
+    bar.appendChild(mkBtn(ICONS.reload, 'Reload', () => this.reload()));
+
+    const addr = document.createElement('div');
+    addr.className = 'lf-pv-addr';
+    addr.innerHTML = ICONS.info;
+    this.urlEl = document.createElement('span');
+    this.urlEl.className = 'lf-pv-url';
+    this.urlEl.textContent = `localhost:${this.port}`;
+    addr.appendChild(this.urlEl);
+    bar.appendChild(addr);
+
+    this.openLink = document.createElement('a');
+    this.openLink.className = 'lf-pv-btn lf-pv-link';
+    this.openLink.title = 'Open in new tab';
+    this.openLink.target = '_blank';
+    this.openLink.rel = 'noopener';
+    this.openLink.innerHTML = ICONS.external;
+    this.openLink.href = this.route();
+    bar.appendChild(this.openLink);
+
+    return bar;
+  }
+
+  // The preview is same-origin, so its live URL is readable — but client-side
+  // routing (history.pushState) fires no event in the parent, so poll to keep
+  // the address bar and open-in-new-tab honest.
+  private startPolling(): void {
+    this.pollTimer = setInterval(() => {
+      try {
+        const href = this.iframe.contentWindow?.location.href;
+        if (href && href !== 'about:blank' && href !== this.currentUrl) {
+          this.currentUrl = href;
+          this.updateAddress();
+        }
+      } catch {
+        // Not ready — keep the last known URL.
+      }
+    }, 500);
+  }
+
+  private updateAddress(): void {
+    if (!this.urlEl) return;
+    let friendly = `localhost:${this.port}`;
+    let open = this.route();
+    try {
+      const u = new URL(this.currentUrl);
+      const m = u.pathname.match(/^\/_sw\/[^/]+\/(\d+)(\/.*)?$/);
+      const search = u.search.replace(/[?&]_t=\d+/, '').replace(/^\?$/, '');
+      if (m) {
+        const sub = m[2] && m[2] !== '/' ? m[2] : '';
+        friendly = `localhost:${m[1]}${sub}${search}`;
+      }
+      open = u.pathname + search;
+    } catch {
+      // keep defaults
+    }
+    this.urlEl.textContent = friendly;
+    if (this.openLink) this.openLink.href = open;
+  }
+
+  back(): void {
+    try {
+      this.iframe.contentWindow?.history.back();
+    } catch { /* not ready */ }
+  }
+
+  forward(): void {
+    try {
+      this.iframe.contentWindow?.history.forward();
+    } catch { /* not ready */ }
+  }
+
+  /** Reload in place, preserving the current in-app route where possible. */
+  reload(): void {
+    try {
+      this.iframe.contentWindow?.location.reload();
+    } catch {
+      this.nonce++;
+      this.iframe.src = this.route();
+    }
+  }
+
+  /** Navigate the preview to a new in-VM path (resets to the entry route). */
+  navigate(path: string): void {
+    this.path = path.startsWith('/') ? path : '/' + path;
+    this.nonce++;
+    this.iframe.src = this.route();
+  }
+
+  /** Point the preview at a different in-VM port. */
+  setPort(port: number): void {
+    this.port = port;
+    this.nonce++;
+    this.iframe.src = this.route();
+    this.updateAddress();
+  }
+
+  destroy(): void {
+    if (this.pollTimer) clearInterval(this.pollTimer);
+    this.pollTimer = null;
+    this.root.remove();
+  }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,7 @@
 export { Terminal } from './Terminal.js';
 export { FileExplorer } from './FileExplorer.js';
 export type { FileExplorerOptions, FileExplorerEntry, FileExplorerEvent, EditorProvider, EditorInstance } from './FileExplorer.js';
+export { PreviewBrowser } from './PreviewBrowser.js';
+export type { PreviewBrowserOptions } from './PreviewBrowser.js';
 // Re-export ITerminal type from core for convenience
 export type { ITerminal } from '@lifo-sh/core';


### PR DESCRIPTION
Follow-up work on top of the (now-merged) #26. Groups several playground/UX polish commits plus a node-compat correctness fix.

## node-compat: return to the prompt after prompt-based CLIs
`create-expo-app` and similar CLIs finish their work but leave stdin in raw mode with a stray keypress listener that's never torn down. The node runner's quiescence loop saw an "active" stdin consumer and hung until the user pressed Enter, instead of returning to the shell prompt.

The old consecutive-tick counters couldn't handle it: after the CLI finishes, `isActive()`/rawMode *flicker* (the leftover listener toggles), resetting the counters before they reached threshold. Reworked to be wall-clock based — track the last moment real work happened (async op in flight, new module loading, or fresh user input) and stop once nothing meaningful has moved for a grace window (500ms once an ESM main resolves, 2.5s otherwise so a slow-to-answer CJS prompt isn't cut short). Adds `stdin.inputSeq` to tell genuine input from a leftover listener.

Verified: create-expo-app returns to the prompt on its own (no Enter needed) and the shell accepts the next command; ESM and CJS scripts that leave a raw-mode keypress listener both exit gracefully.

## Playground UX
- Replace the "Show commands" button with a first-position, non-selected **README.md** tab in terminals (only for examples that have one).
- Drop redundant `cd <dir>` lines from README snippets where the cwd is already that directory.
- Dull the playground border lines (lower contrast).

## Docs / harness
- `ROADMAP.md` — North Star, scope, and phased roadmap (benchmarks, single distributable binary for isolated host VMs, tunnelling / Docker-free).
- `bench/` — runnable Node benchmark harness (boot, command throughput, fs, memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)