### PR TITLE
Snapshot: deep-path fix, node_modules exclude, VFS sync primitives, snapshot-on-all-examples + non-blocking dump

### DIFF
--- a/apps/playground/src/components/example-panel.tsx
+++ b/apps/playground/src/components/example-panel.tsx
@@ -5,6 +5,9 @@ interface ExamplePanelProps {
   title: string;
   subtitle?: ReactNode;
   children: ReactNode;
+  /** Optional control rendered in the header, left of the info toggle (e.g. the
+   *  terminal fold/unfold button for preview examples). */
+  headerAction?: ReactNode;
 }
 
 /**
@@ -13,7 +16,7 @@ interface ExamplePanelProps {
  * (info toggle). The example's code sample shows up as a "README.md" tab in
  * the terminal area, not here.
  */
-export function ExamplePanel({ title, subtitle, children }: ExamplePanelProps) {
+export function ExamplePanel({ title, subtitle, children, headerAction }: ExamplePanelProps) {
   const [showDesc, setShowDesc] = useState(false);
 
   return (
@@ -21,18 +24,21 @@ export function ExamplePanel({ title, subtitle, children }: ExamplePanelProps) {
       {/* Navbar — end to end. */}
       <div className="flex items-center gap-1.5 h-9 px-3 border-b border-tokyo-border bg-tokyo-bg-dark shrink-0">
         <span className="text-[13px] font-semibold text-tokyo-fg-bright truncate">{title}</span>
-        {subtitle && (
-          <button
-            onClick={() => setShowDesc((v) => !v)}
-            title="About this example"
-            className={
-              'w-6 h-6 grid place-items-center rounded bg-transparent border-none cursor-pointer shrink-0 ml-auto ' +
-              (showDesc ? 'text-tokyo-blue' : 'text-tokyo-comment hover:text-tokyo-fg-bright hover:bg-tokyo-hover')
-            }
-          >
-            <Info size={14} />
-          </button>
-        )}
+        <div className="ml-auto flex items-center gap-0.5 shrink-0">
+          {headerAction}
+          {subtitle && (
+            <button
+              onClick={() => setShowDesc((v) => !v)}
+              title="About this example"
+              className={
+                'w-6 h-6 grid place-items-center rounded bg-transparent border-none cursor-pointer ' +
+                (showDesc ? 'text-tokyo-blue' : 'text-tokyo-comment hover:text-tokyo-fg-bright hover:bg-tokyo-hover')
+              }
+            >
+              <Info size={14} />
+            </button>
+          )}
+        </div>
       </div>
       {subtitle && showDesc && (
         <div className="text-[11px] text-tokyo-comment leading-relaxed px-3 py-2 border-b border-tokyo-border bg-tokyo-bg-dark shrink-0">

--- a/apps/playground/src/components/terminal-area.tsx
+++ b/apps/playground/src/components/terminal-area.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { Terminal } from '@lifo-sh/ui';
-import { MoreVertical, Plus, Activity, Square, RotateCcw, Download, Upload, X, FileText, PanelTopClose } from 'lucide-react';
+import { MoreVertical, Plus, Activity, Square, RotateCcw, Download, Upload, X, FileText } from 'lucide-react';
+import { downloadSnapshot, pickAndRestoreSnapshot } from '@/lib/box-snapshot';
 import { cn } from '@/lib/utils';
 import { TerminalView } from '@/components/terminal-view';
 import { ProcessPanel } from '@/components/process-panel';
@@ -20,12 +21,9 @@ interface TerminalAreaProps {
   initialLabels?: string[];
   /** Show the "+" to open more terminals (default true). */
   canAdd?: boolean;
-  /** Box-menu actions — only shown when provided (project examples). */
+  /** Restart the box — only shown when provided (project examples). Snapshot &
+   *  restore are always offered whenever a box exists. */
   onRestart?: () => void;
-  onSnapshot?: () => void;
-  onRestore?: () => void;
-  /** When provided, shows a button to fold the terminal panel (preview examples). */
-  onFold?: () => void;
 }
 
 type Tab =
@@ -41,7 +39,7 @@ const README_ID = -1;
  * restart, snapshot, restore — the latter three only when handlers are given).
  * Every tab is closable; the box menu reopens Processes if it was closed.
  */
-export function TerminalArea({ bootTab, box, initialLabels, canAdd = true, onRestart, onSnapshot, onRestore, onFold }: TerminalAreaProps) {
+export function TerminalArea({ bootTab, box, initialLabels, canAdd = true, onRestart }: TerminalAreaProps) {
   const labels = initialLabels?.length ? initialLabels : ['Terminal 1'];
   // The example's code sample, captured at mount, shown as a README.md tab.
   const chrome = useOutputChrome();
@@ -165,8 +163,11 @@ export function TerminalArea({ bootTab, box, initialLabels, canAdd = true, onRes
     { label: 'Process manager', icon: Activity, onClick: openProcesses },
     { label: 'Stop all', icon: Square, onClick: () => void stopAll() },
     ...(onRestart ? [{ label: 'Restart box', icon: RotateCcw, onClick: () => { setMenuOpen(false); onRestart(); } }] : []),
-    ...(onSnapshot ? [{ label: 'Snapshot (download)', icon: Download, onClick: run('Snapshotting…', onSnapshot) }] : []),
-    ...(onRestore ? [{ label: 'Restore (upload)', icon: Upload, onClick: () => { setMenuOpen(false); onRestore(); } }] : []),
+    // Snapshot & restore work off any box's VFS, so every example gets them.
+    ...(box ? [
+      { label: 'Snapshot (download)', icon: Download, onClick: run('Snapshotting…', () => downloadSnapshot(box.kernel.vfs)) },
+      { label: 'Restore (upload)', icon: Upload, onClick: () => { setMenuOpen(false); pickAndRestoreSnapshot(box.kernel.vfs); } },
+    ] : []),
   ];
 
   return (
@@ -221,15 +222,6 @@ export function TerminalArea({ bootTab, box, initialLabels, canAdd = true, onRes
           )}
         </div>
         {busy && <span className="text-[10px] text-tokyo-comment px-2 self-center">{busy}</span>}
-        {onFold && (
-          <button
-            onClick={onFold}
-            title="Collapse terminal"
-            className="px-2.5 grid place-items-center bg-transparent border-none text-tokyo-comment hover:text-tokyo-fg-bright hover:bg-tokyo-hover cursor-pointer"
-          >
-            <PanelTopClose size={16} />
-          </button>
-        )}
         <div className="relative flex items-stretch" ref={menuRef}>
           <button
             onClick={() => setMenuOpen((v) => !v)}

--- a/apps/playground/src/examples/project-example.tsx
+++ b/apps/playground/src/examples/project-example.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useRef, useState } from 'react';
-import { PanelTopOpen } from 'lucide-react';
+import { PanelTopOpen, PanelTopClose } from 'lucide-react';
 import { Panel as RawPanel, type ImperativePanelHandle } from 'react-resizable-panels';
 import { Sandbox, ServiceWorkerBridge } from '@lifo-sh/core';
 import gitCommand from 'lifo-pkg-git';
@@ -8,7 +8,6 @@ import { ExamplePanel } from '@/components/example-panel';
 import { PreviewTabs, type PreviewTab } from '@/components/preview-tabs';
 import { TerminalArea } from '@/components/terminal-area';
 import { bootShell } from '@/lib/shell';
-import { downloadSnapshot, pickAndRestoreSnapshot } from '@/lib/box-snapshot';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
 
 export interface ProjectExampleProps {
@@ -116,14 +115,23 @@ export function ProjectExample({ title, subtitle, files, cwd, previewPort, previ
         else void bootFirstTerminal(term);
       }}
       onRestart={restart}
-      onSnapshot={sandbox ? () => downloadSnapshot(sandbox) : undefined}
-      onRestore={sandbox ? () => pickAndRestoreSnapshot(sandbox) : undefined}
-      onFold={hasPreview ? () => termPanelRef.current?.collapse() : undefined}
     />
   );
 
+  // Fold/unfold the terminal panel — lives in the example header (one button
+  // toggles the whole terminal row).
+  const foldToggle = hasPreview ? (
+    <button
+      onClick={() => (terminalFolded ? termPanelRef.current?.expand() : termPanelRef.current?.collapse())}
+      title={terminalFolded ? 'Show terminal' : 'Hide terminal'}
+      className="w-6 h-6 grid place-items-center rounded bg-transparent border-none cursor-pointer text-tokyo-comment hover:text-tokyo-fg-bright hover:bg-tokyo-hover"
+    >
+      {terminalFolded ? <PanelTopOpen size={14} /> : <PanelTopClose size={14} />}
+    </button>
+  ) : undefined;
+
   return (
-    <ExamplePanel title={title} subtitle={subtitle}>
+    <ExamplePanel title={title} subtitle={subtitle} headerAction={foldToggle}>
       {hasPreview ? (
         <ResizablePanelGroup
           direction="vertical"
@@ -142,18 +150,7 @@ export function ProjectExample({ title, subtitle, files, cwd, previewPort, previ
           >
             {terminalArea}
           </RawPanel>
-          <ResizableHandle className="my-0.5" />
-          {/* When the terminal is folded, a slim bar to bring it back */}
-          {terminalFolded && (
-            <button
-              onClick={() => termPanelRef.current?.expand()}
-              title="Show terminal"
-              className="absolute top-0 left-0 right-0 z-20 flex items-center justify-center gap-1.5 h-6 text-[11px] text-tokyo-comment bg-tokyo-bg-dark border-b border-tokyo-border hover:text-tokyo-fg-bright cursor-pointer"
-            >
-              <PanelTopOpen size={13} />
-              Show terminal
-            </button>
-          )}
+          <ResizableHandle className={terminalFolded ? 'hidden' : 'my-0.5'} />
           <ResizablePanel defaultSize={55} minSize={20}>
             {swReady === null ? (
               <div className="flex-1 h-full grid place-items-center text-[12px] text-tokyo-comment">

--- a/apps/playground/src/lib/box-snapshot.ts
+++ b/apps/playground/src/lib/box-snapshot.ts
@@ -1,12 +1,14 @@
-import type { Sandbox } from '@lifo-sh/core';
+import { exportVfsSnapshot, importVfsSnapshot } from '@lifo-sh/core';
+import type { VFS } from '@lifo-sh/core';
 
 /**
  * Download the box's disk as a .tar.gz snapshot. Processes aren't captured —
  * only the VFS — so a restored box starts with the same files but no running
- * servers (re-run the dev command after restoring).
+ * servers (re-run the dev command after restoring). Works off any box's VFS,
+ * so every example can snapshot, not just the preview ones.
  */
-export async function downloadSnapshot(sandbox: Sandbox, name = 'lifo-box'): Promise<void> {
-  const data = await sandbox.exportSnapshot();
+export async function downloadSnapshot(vfs: VFS, name = 'lifo-box'): Promise<void> {
+  const data = await exportVfsSnapshot(vfs);
   // Copy into a fresh ArrayBuffer so the Blob type is exactly BlobPart (the VFS
   // may hand back a view over a larger buffer).
   const buf = data.slice();
@@ -18,12 +20,11 @@ export async function downloadSnapshot(sandbox: Sandbox, name = 'lifo-box'): Pro
   document.body.appendChild(a);
   a.click();
   a.remove();
-  // Revoke on the next tick so the download has started.
   setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
 /** Prompt for a .tar.gz file and restore the box's disk from it. */
-export function pickAndRestoreSnapshot(sandbox: Sandbox, onDone?: (ok: boolean) => void): void {
+export function pickAndRestoreSnapshot(vfs: VFS, onDone?: (ok: boolean) => void): void {
   const input = document.createElement('input');
   input.type = 'file';
   input.accept = '.gz,.tgz,.tar,application/gzip';
@@ -35,7 +36,7 @@ export function pickAndRestoreSnapshot(sandbox: Sandbox, onDone?: (ok: boolean) 
     }
     try {
       const buf = new Uint8Array(await file.arrayBuffer());
-      await sandbox.importSnapshot(buf);
+      await importVfsSnapshot(vfs, buf);
       onDone?.(true);
     } catch {
       onDone?.(false);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export type {
 	CommandResult,
 	SandboxCommands,
 	SandboxFs,
+	SnapshotOptions,
 } from './sandbox/index.js';
 
 // Kernel
@@ -48,6 +49,18 @@ export type {
 	VFSWatchListener,
 	VFSEventType,
 } from './kernel/vfs/index.js';
+
+// VFS sync (full dump, incremental change stream, wire encoding)
+export {
+	dumpChanges,
+	applyChanges,
+	applyChange,
+	watchChanges,
+	serializeChange,
+	deserializeChange,
+	isExcluded,
+} from './kernel/vfs/sync.js';
+export type { VfsChange, SyncOptions } from './kernel/vfs/sync.js';
 
 // Blob storage & content store
 export { MemoryBlobStore, IndexedDBBlobStore, hashBytes } from './kernel/storage/index.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,6 +62,10 @@ export {
 } from './kernel/vfs/sync.js';
 export type { VfsChange, SyncOptions } from './kernel/vfs/sync.js';
 
+// VFS snapshot (tar.gz), operable on any VFS — non-blocking (yields)
+export { exportVfsSnapshot, importVfsSnapshot } from './kernel/vfs/snapshot.js';
+export type { VfsSnapshotOptions } from './kernel/vfs/snapshot.js';
+
 // Blob storage & content store
 export { MemoryBlobStore, IndexedDBBlobStore, hashBytes } from './kernel/storage/index.js';
 export { ContentStore, CHUNK_THRESHOLD, CHUNK_SIZE } from './kernel/storage/index.js';

--- a/packages/core/src/kernel/vfs/snapshot.ts
+++ b/packages/core/src/kernel/vfs/snapshot.ts
@@ -1,0 +1,75 @@
+import type { VFS } from './VFS.js';
+import { createTar, parseTar, compressGzip, decompressGzip } from '../../utils/archive.js';
+import type { TarEntry } from '../../utils/archive.js';
+import { dirname } from '../../utils/path.js';
+import { isExcluded } from './sync.js';
+
+// Synthetic provider mounts — generated on read, never snapshotted.
+const SKIP_DIRS = new Set(['/proc', '/dev']);
+// Yield to the event loop every N files so a large tree (node_modules) doesn't
+// freeze the UI while snapshotting/restoring.
+const YIELD_EVERY = 200;
+const EMPTY = new Uint8Array(0);
+const yieldToEventLoop = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+export interface VfsSnapshotOptions {
+  /** Path segments to skip, e.g. `['node_modules', '.git']`. */
+  exclude?: string[];
+}
+
+/**
+ * Export a VFS as a `tar.gz` snapshot. Non-blocking: yields to the event loop
+ * periodically so a big tree doesn't jank the UI. Long paths round-trip via the
+ * tar writer's GNU long-name headers.
+ */
+export async function exportVfsSnapshot(vfs: VFS, opts: VfsSnapshotOptions = {}): Promise<Uint8Array> {
+  const entries: TarEntry[] = [];
+  let count = 0;
+
+  const walk = async (absPath: string): Promise<void> => {
+    if (SKIP_DIRS.has(absPath) || isExcluded(absPath, opts.exclude)) return;
+    const stat = vfs.stat(absPath);
+    if (stat.type === 'directory') {
+      if (absPath !== '/') {
+        entries.push({ path: absPath, data: EMPTY, type: 'directory', mode: stat.mode, mtime: stat.mtime });
+      }
+      for (const child of vfs.readdir(absPath)) {
+        await walk(absPath === '/' ? `/${child.name}` : `${absPath}/${child.name}`);
+      }
+    } else {
+      entries.push({ path: absPath, data: vfs.readFile(absPath), type: 'file', mode: stat.mode, mtime: stat.mtime });
+      if (++count % YIELD_EVERY === 0) await yieldToEventLoop();
+    }
+  };
+
+  await walk('/');
+  const tar = createTar(entries);
+  return compressGzip(tar);
+}
+
+/**
+ * Restore a VFS from a `tar.gz` snapshot. Directories first (so parents exist),
+ * then files; skips writing a file over an existing directory so a restore can
+ * never throw mid-way. Yields periodically to stay responsive.
+ */
+export async function importVfsSnapshot(vfs: VFS, data: Uint8Array): Promise<void> {
+  const tar = await decompressGzip(data);
+  const entries = parseTar(tar);
+  const dirs = entries.filter((e) => e.type === 'directory');
+  const files = entries.filter((e) => e.type === 'file');
+
+  for (const entry of dirs) {
+    const path = entry.path.startsWith('/') ? entry.path : '/' + entry.path;
+    if (!vfs.exists(path)) vfs.mkdir(path, { recursive: true });
+  }
+
+  let count = 0;
+  for (const entry of files) {
+    const path = entry.path.startsWith('/') ? entry.path : '/' + entry.path;
+    const parent = dirname(path);
+    if (parent !== '/' && !vfs.exists(parent)) vfs.mkdir(parent, { recursive: true });
+    if (vfs.exists(path) && vfs.stat(path).type === 'directory') continue;
+    vfs.writeFile(path, entry.data);
+    if (++count % YIELD_EVERY === 0) await yieldToEventLoop();
+  }
+}

--- a/packages/core/src/kernel/vfs/sync.ts
+++ b/packages/core/src/kernel/vfs/sync.ts
@@ -1,0 +1,166 @@
+import type { VFS } from './VFS.js';
+import type { VFSWatchEvent } from './types.js';
+
+/**
+ * A single filesystem change. The building block for syncing a VFS anywhere —
+ * a full dump is just an ordered list of these, and an incremental sync is a
+ * stream of them. Transport-agnostic: serialize with `serializeChange` to send
+ * over a BroadcastChannel, a WebSocket, or into a database row.
+ */
+export type VfsChange =
+  | { op: 'put'; path: string; data: Uint8Array }
+  | { op: 'mkdir'; path: string }
+  | { op: 'delete'; path: string }
+  | { op: 'rename'; from: string; to: string };
+
+export interface SyncOptions {
+  /**
+   * Skip any path that contains one of these segments — e.g.
+   * `['node_modules', '.git']`. Applies to dumps and to the live stream.
+   */
+  exclude?: string[];
+  /**
+   * Only sync this subtree (default `/`). Useful to sync just a project dir
+   * (e.g. `/home/user/app`) instead of the whole filesystem.
+   */
+  root?: string;
+}
+
+// Synthetic provider mounts — generated on read, not writable, never synced.
+const SYSTEM_DIRS = new Set(['/proc', '/dev']);
+
+/** True if `path` contains any excluded path segment. */
+export function isExcluded(path: string, exclude?: string[]): boolean {
+  if (!exclude || exclude.length === 0) return false;
+  const segments = path.split('/');
+  return exclude.some((ex) => segments.includes(ex));
+}
+
+/**
+ * Full dump of a VFS as an ordered change list — directories before the files
+ * inside them, so `applyChanges` can replay it into an empty VFS. This is the
+ * "full sync" building block; for a live sync, pair it with `watchChanges`.
+ */
+export function dumpChanges(vfs: VFS, opts: SyncOptions = {}): VfsChange[] {
+  const out: VfsChange[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of vfs.readdir(dir)) {
+      const p = dir === '/' ? '/' + entry.name : dir + '/' + entry.name;
+      if (SYSTEM_DIRS.has(p) || isExcluded(p, opts.exclude)) continue;
+      if (entry.type === 'directory') {
+        out.push({ op: 'mkdir', path: p });
+        walk(p);
+      } else {
+        out.push({ op: 'put', path: p, data: vfs.readFile(p) });
+      }
+    }
+  };
+  walk(opts.root ?? '/');
+  return out;
+}
+
+/** Apply one change to a VFS. Idempotent: creates parents, ignores redundant
+ *  deletes, and never clobbers a directory with a file. */
+export function applyChange(vfs: VFS, change: VfsChange): void {
+  switch (change.op) {
+    case 'mkdir':
+      if (!vfs.exists(change.path)) vfs.mkdir(change.path, { recursive: true });
+      break;
+    case 'put': {
+      const slash = change.path.lastIndexOf('/');
+      const parent = slash > 0 ? change.path.slice(0, slash) : '/';
+      if (parent !== '/' && !vfs.exists(parent)) vfs.mkdir(parent, { recursive: true });
+      if (vfs.exists(change.path) && vfs.stat(change.path).type === 'directory') break;
+      vfs.writeFile(change.path, change.data);
+      break;
+    }
+    case 'delete':
+      if (vfs.exists(change.path)) {
+        if (vfs.stat(change.path).type === 'directory') vfs.rmdir(change.path);
+        else vfs.unlink(change.path);
+      }
+      break;
+    case 'rename':
+      if (vfs.exists(change.from)) vfs.rename(change.from, change.to);
+      break;
+  }
+}
+
+/** Apply an ordered list of changes (e.g. a `dumpChanges` result). */
+export function applyChanges(vfs: VFS, changes: VfsChange[]): void {
+  for (const change of changes) applyChange(vfs, change);
+}
+
+/**
+ * Subscribe to a VFS's mutations and emit a `VfsChange` for each — the
+ * incremental sync source. Feed the changes to another VFS (`applyChange`), a
+ * socket (`serializeChange`), or a per-file store. Returns an unsubscribe fn.
+ */
+export function watchChanges(
+  vfs: VFS,
+  onChange: (change: VfsChange) => void,
+  opts: SyncOptions = {},
+): () => void {
+  const read = (path: string): Uint8Array => {
+    try {
+      return vfs.readFile(path);
+    } catch {
+      return new Uint8Array(0);
+    }
+  };
+  const root = opts.root ?? '/';
+  const inScope = (p: string) => (root === '/' || p === root || p.startsWith(root + '/')) && !SYSTEM_DIRS.has(p) && !p.startsWith('/proc/') && !p.startsWith('/dev/');
+  return vfs.watch((e: VFSWatchEvent) => {
+    if (!inScope(e.path) || isExcluded(e.path, opts.exclude)) return;
+    switch (e.type) {
+      case 'create':
+        onChange(e.fileType === 'directory' ? { op: 'mkdir', path: e.path } : { op: 'put', path: e.path, data: read(e.path) });
+        break;
+      case 'modify':
+        if (e.fileType === 'file') onChange({ op: 'put', path: e.path, data: read(e.path) });
+        break;
+      case 'delete':
+        onChange({ op: 'delete', path: e.path });
+        break;
+      case 'rename':
+        if (!e.oldPath) break;
+        // If the source was excluded, the target looks brand-new to a peer.
+        if (isExcluded(e.oldPath, opts.exclude)) {
+          onChange(e.fileType === 'directory' ? { op: 'mkdir', path: e.path } : { op: 'put', path: e.path, data: read(e.path) });
+        } else {
+          onChange({ op: 'rename', from: e.oldPath, to: e.path });
+        }
+        break;
+    }
+  });
+}
+
+// ─── Wire encoding (transport-safe: JSON + base64 for the `put` payload) ───
+
+function toBase64(bytes: Uint8Array): string {
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
+
+function fromBase64(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+/** Encode a change to a string safe for a BroadcastChannel / WebSocket / DB row. */
+export function serializeChange(change: VfsChange): string {
+  if (change.op === 'put') {
+    return JSON.stringify({ op: 'put', path: change.path, data: toBase64(change.data) });
+  }
+  return JSON.stringify(change);
+}
+
+/** Decode a change produced by `serializeChange`. */
+export function deserializeChange(message: string): VfsChange {
+  const o = JSON.parse(message) as { op: string; path?: string; data?: string; from?: string; to?: string };
+  if (o.op === 'put') return { op: 'put', path: o.path!, data: fromBase64(o.data!) };
+  return o as VfsChange;
+}

--- a/packages/core/src/sandbox/Sandbox.ts
+++ b/packages/core/src/sandbox/Sandbox.ts
@@ -23,7 +23,7 @@ import type { VFS } from '../kernel/vfs/index.js';
 import { NativeFsProvider } from '../kernel/vfs/providers/NativeFsProvider.js';
 import type { NativeFsModule } from '../kernel/vfs/providers/NativeFsProvider.js';
 import type { ITerminal } from '../terminal/ITerminal.js';
-import type { SandboxOptions, SandboxCommands, SandboxFs } from './types.js';
+import type { SandboxOptions, SandboxCommands, SandboxFs, SnapshotOptions } from './types.js';
 import { SandboxFsImpl } from './SandboxFs.js';
 import { SandboxCommandsImpl } from './SandboxCommands.js';
 import { HeadlessTerminal } from './HeadlessTerminal.js';
@@ -267,10 +267,11 @@ export class Sandbox {
 	}
 
 	/**
-	 * Export the entire VFS as a tar.gz snapshot.
+	 * Export the VFS as a tar.gz snapshot. Pass `{ exclude: ['node_modules'] }`
+	 * to skip subtrees (smaller snapshot; restore then needs a reinstall).
 	 */
-	async exportSnapshot(): Promise<Uint8Array> {
-		return this.fs.exportSnapshot();
+	async exportSnapshot(options?: SnapshotOptions): Promise<Uint8Array> {
+		return this.fs.exportSnapshot(options);
 	}
 
 	/**

--- a/packages/core/src/sandbox/SandboxFs.ts
+++ b/packages/core/src/sandbox/SandboxFs.ts
@@ -3,6 +3,8 @@ import type { SandboxFs as ISandboxFs } from './types.js';
 import { resolve, dirname } from '../utils/path.js';
 import { createTar, parseTar, compressGzip, decompressGzip } from '../utils/archive.js';
 import type { TarEntry } from '../utils/archive.js';
+import { isExcluded } from '../kernel/vfs/sync.js';
+import type { SnapshotOptions } from './types.js';
 
 /**
  * Async wrapper around VFS that matches the industry-standard filesystem API.
@@ -89,11 +91,12 @@ export class SandboxFsImpl implements ISandboxFs {
   /** Directories to skip during export (virtual providers) */
   private static SKIP_DIRS = new Set(['/proc', '/dev']);
 
-  async exportSnapshot(): Promise<Uint8Array> {
+  async exportSnapshot(options: SnapshotOptions = {}): Promise<Uint8Array> {
     const entries: TarEntry[] = [];
 
     const walk = (absPath: string): void => {
       if (SandboxFsImpl.SKIP_DIRS.has(absPath)) return;
+      if (isExcluded(absPath, options.exclude)) return;
 
       const stat = this.vfs.stat(absPath);
 
@@ -153,6 +156,9 @@ export class SandboxFsImpl implements ISandboxFs {
       if (parent !== '/' && !this.vfs.exists(parent)) {
         this.vfs.mkdir(parent, { recursive: true });
       }
+      // Defensive: never write a file over an existing directory (a restore
+      // must not throw mid-way and leave the tree half-populated).
+      if (this.vfs.exists(path) && this.vfs.stat(path).type === 'directory') continue;
       this.vfs.writeFile(path, entry.data);
     }
   }

--- a/packages/core/src/sandbox/SandboxFs.ts
+++ b/packages/core/src/sandbox/SandboxFs.ts
@@ -1,9 +1,7 @@
 import type { VFS } from '../kernel/vfs/index.js';
 import type { SandboxFs as ISandboxFs } from './types.js';
-import { resolve, dirname } from '../utils/path.js';
-import { createTar, parseTar, compressGzip, decompressGzip } from '../utils/archive.js';
-import type { TarEntry } from '../utils/archive.js';
-import { isExcluded } from '../kernel/vfs/sync.js';
+import { resolve } from '../utils/path.js';
+import { exportVfsSnapshot, importVfsSnapshot } from '../kernel/vfs/snapshot.js';
 import type { SnapshotOptions } from './types.js';
 
 /**
@@ -89,77 +87,11 @@ export class SandboxFsImpl implements ISandboxFs {
   }
 
   /** Directories to skip during export (virtual providers) */
-  private static SKIP_DIRS = new Set(['/proc', '/dev']);
-
   async exportSnapshot(options: SnapshotOptions = {}): Promise<Uint8Array> {
-    const entries: TarEntry[] = [];
-
-    const walk = (absPath: string): void => {
-      if (SandboxFsImpl.SKIP_DIRS.has(absPath)) return;
-      if (isExcluded(absPath, options.exclude)) return;
-
-      const stat = this.vfs.stat(absPath);
-
-      if (stat.type === 'directory') {
-        // Add directory entry (skip root itself)
-        if (absPath !== '/') {
-          entries.push({
-            path: absPath,
-            data: new Uint8Array(0),
-            type: 'directory',
-            mode: stat.mode,
-            mtime: stat.mtime,
-          });
-        }
-
-        const children = this.vfs.readdir(absPath);
-        for (const child of children) {
-          const childPath = absPath === '/' ? `/${child.name}` : `${absPath}/${child.name}`;
-          walk(childPath);
-        }
-      } else {
-        entries.push({
-          path: absPath,
-          data: this.vfs.readFile(absPath),
-          type: 'file',
-          mode: stat.mode,
-          mtime: stat.mtime,
-        });
-      }
-    };
-
-    walk('/');
-
-    const tar = createTar(entries);
-    return compressGzip(tar);
+    return exportVfsSnapshot(this.vfs, options);
   }
 
   async importSnapshot(data: Uint8Array): Promise<void> {
-    const tar = await decompressGzip(data);
-    const entries = parseTar(tar);
-
-    // Process directories first, then files, to ensure parents exist
-    const dirs = entries.filter((e) => e.type === 'directory');
-    const files = entries.filter((e) => e.type === 'file');
-
-    for (const entry of dirs) {
-      const path = entry.path.startsWith('/') ? entry.path : '/' + entry.path;
-      if (!this.vfs.exists(path)) {
-        this.vfs.mkdir(path, { recursive: true });
-      }
-    }
-
-    for (const entry of files) {
-      const path = entry.path.startsWith('/') ? entry.path : '/' + entry.path;
-      // Ensure parent directory exists
-      const parent = dirname(path);
-      if (parent !== '/' && !this.vfs.exists(parent)) {
-        this.vfs.mkdir(parent, { recursive: true });
-      }
-      // Defensive: never write a file over an existing directory (a restore
-      // must not throw mid-way and leave the tree half-populated).
-      if (this.vfs.exists(path) && this.vfs.stat(path).type === 'directory') continue;
-      this.vfs.writeFile(path, entry.data);
-    }
+    return importVfsSnapshot(this.vfs, data);
   }
 }

--- a/packages/core/src/sandbox/index.ts
+++ b/packages/core/src/sandbox/index.ts
@@ -5,4 +5,5 @@ export type {
   CommandResult,
   SandboxCommands,
   SandboxFs,
+  SnapshotOptions,
 } from './types.js';

--- a/packages/core/src/sandbox/types.ts
+++ b/packages/core/src/sandbox/types.ts
@@ -71,6 +71,15 @@ export interface SandboxCommands {
 
 // ─── SandboxFs ───
 
+export interface SnapshotOptions {
+  /**
+   * Path segments to skip in the snapshot, e.g. `['node_modules', '.git']`.
+   * Excluding `node_modules` yields a much smaller snapshot, but the restored
+   * box must reinstall (`npm install`) before it can run.
+   */
+  exclude?: string[];
+}
+
 export interface SandboxFs {
   readFile(path: string): Promise<string>;
   readFile(path: string, encoding: null): Promise<Uint8Array>;
@@ -83,8 +92,8 @@ export interface SandboxFs {
   rename(oldPath: string, newPath: string): Promise<void>;
   cp(src: string, dest: string): Promise<void>;
   writeFiles(files: Array<{ path: string; content: string | Uint8Array }>): Promise<void>;
-  /** Export entire VFS as a tar.gz snapshot */
-  exportSnapshot(): Promise<Uint8Array>;
+  /** Export the VFS as a tar.gz snapshot (optionally excluding paths). */
+  exportSnapshot(options?: SnapshotOptions): Promise<Uint8Array>;
   /** Restore VFS from a tar.gz snapshot */
   importSnapshot(data: Uint8Array): Promise<void>;
 }

--- a/packages/core/src/utils/archive.ts
+++ b/packages/core/src/utils/archive.ts
@@ -97,18 +97,47 @@ function tarReadOctal(buf: Uint8Array, offset: number, len: number): number {
   return str ? parseInt(str, 8) : 0;
 }
 
+/**
+ * A GNU long-name header ('L') + payload, emitted before an entry whose path
+ * exceeds the 100-byte `name` field. parseTar() decodes typeflag 76 into the
+ * next entry's path, so deep trees (e.g. node_modules) round-trip instead of
+ * truncating and colliding.
+ */
+function tarLongNameBlocks(pathBytes: Uint8Array): Uint8Array[] {
+  const header = new Uint8Array(512);
+  tarWriteString(header, 0, '././@LongLink', 100);
+  tarWriteOctal(header, 100, 0, 8); // mode
+  tarWriteOctal(header, 108, 0, 8); // uid
+  tarWriteOctal(header, 116, 0, 8); // gid
+  tarWriteOctal(header, 124, pathBytes.length + 1, 12); // size = path + NUL
+  tarWriteOctal(header, 136, 0, 12); // mtime
+  header[156] = 76; // 'L'
+  tarWriteString(header, 257, 'ustar', 6);
+  tarWriteString(header, 263, '00', 2);
+  tarWriteString(header, 265, 'user', 32);
+  tarWriteString(header, 297, 'user', 32);
+  tarWriteOctal(header, 148, tarChecksum(header), 7);
+  header[155] = 0x20;
+
+  const payload = new Uint8Array(Math.ceil((pathBytes.length + 1) / 512) * 512);
+  payload.set(pathBytes, 0); // trailing NUL(s) already zero
+  return [header, payload];
+}
+
 export function createTar(entries: TarEntry[]): Uint8Array {
   const blocks: Uint8Array[] = [];
 
   for (const entry of entries) {
-    const header = new Uint8Array(512);
-
     let path = entry.path;
     if (entry.type === 'directory' && !path.endsWith('/')) path += '/';
     // Remove leading /
     if (path.startsWith('/')) path = path.slice(1);
 
-    tarWriteString(header, 0, path, 100);          // name
+    const pathBytes = encode(path);
+    if (pathBytes.length > 100) blocks.push(...tarLongNameBlocks(pathBytes));
+
+    const header = new Uint8Array(512);
+    tarWriteString(header, 0, path, 100);          // name (truncated if long; LongLink wins)
     tarWriteOctal(header, 100, entry.mode, 8);      // mode
     tarWriteOctal(header, 108, 0, 8);               // uid
     tarWriteOctal(header, 116, 0, 8);               // gid


### PR DESCRIPTION
## Snapshot round-trip bug (reported)
Snapshot after `npm install` → restore left the box broken (`npm start` failed). `createTar` truncated names > 100 bytes (no long-name headers on write); deep `node_modules` paths collided → `importSnapshot` threw `EISDIR` mid-restore. Fixed: `createTar` emits **GNU long-name headers** for long paths; restore skips writing a file over a directory.

## VFS-level, non-blocking snapshot
`exportVfsSnapshot` / `importVfsSnapshot` operate on **any VFS** and **yield to the event loop** every 200 files, so a large tree no longer freezes the UI during a dump/restore. `SandboxFs` delegates to them.

## `node_modules` exclude
`exportSnapshot({ exclude: ['node_modules'] })` — ~8 KB vs 313 KB in testing.

## VFS sync primitives (`kernel/vfs/sync.ts`)
`dumpChanges` / `applyChanges` / `watchChanges` / `serializeChange` / `deserializeChange` / `isExcluded` — transport-agnostic (tabs / socket / DB), `root`-subtree + exclude, skips `/proc`,`/dev`. Documented as recipes (website PR #30).

## Playground: snapshot on every example + header fold toggle
- **Snapshot & Restore** in the box menu for **all** examples (derived from `box.kernel.vfs`), not just previews.
- **Collapse the terminal from the example header** — one toggle replaces the in-tab-bar button and the full-width "Show terminal" bar.

## Verified (Node + browser)
npm-install → snapshot → restore → `npm start` exit 0, full byte parity; exclude; dump/apply/watch + binary wire; snapshot menu on a non-preview example; header fold collapses the terminal.

Note: a `@lifo-sh/core` 0.6.x release + playground rebuild would follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)