### PR TITLE
feat: browser-metro — a light, switchable in-VM Metro replacement

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -104,16 +104,28 @@ Turn the playground's building blocks into reusable components so anyone can emb
 - [x] Package + document the components with a from-scratch integration example (see the Embeddable UI doc).
 - [ ] Browser chrome — tabs, history (*low priority*, after the core views).
 - [ ] Migrate the playground to consume the packaged components (dogfood).
+- [ ] Example: a **Node/Express server with the preview browser** bound to its port — a full backend + live preview in one box, alongside the existing Vite/Expo examples.
 
 ### 8. Package manager & WASM runtimes — *planned*
 
 - [ ] First-class package manager for VM tools.
+- [ ] **Keep the core light.** We've been stuffing commands into `@lifo-sh/core`; move the non-essential ones out into installable packages, pulled in on demand. Core ships only the essentials; everything else is a package.
+- [ ] `vi`/`vim` editor (as an installable package). Feasibility: *medium* — build a modal input state machine (normal/insert/visual) + basic motions/operators on top of the existing full-screen infra we already have for `nano`/`less` (raw-mode input, viewport/scroll, render loop). The plumbing is done; the work is the modal command grammar. Start with a usable subset (h/j/k/l, i/a/o, x/dd/dw, :w/:q/:wq, /search).
+- [ ] `ssh` client (as an installable package). Needs a WebSocket/tunnel transport for the connection — ties into phase 5 (tunnelling & network).
 - [ ] Pluggable WASM runtimes so more binaries (ffmpeg, Python, native CLIs) run inside the VM.
 
 ### 9. Broader Node & serverless coverage — *planned*
 
 - [ ] Extend the Node compatibility layer toward serverless handlers.
 - [ ] Cover more of the ecosystem unmodified.
+
+### 10. Lighter browser bundling for mobile — *exploring*
+
+Snapshots are ~90MB, too big for phones. Two prototypes exist: `pruneExpoModules` (trim `node_modules` to Metro's read set → keeps the real toolchain, ~8-13% of `node_modules`) and a `browser-metro` engine (offloads package bundling to a hosted pre-bundler, `esm.reactnative.run` → ~2MB, no toolchain on device; switchable with real Metro).
+
+- [ ] Decide per-stack: **prune** (keep the real toolchain in a smaller snapshot) vs **hosted pre-bundle** (tiny download, no on-device toolchain).
+- [ ] Does **Vite** need a prune command like Expo, or can a Vite example fetch pre-bundled deps from `esm.reactnative.run` (or similar) to cut in-browser load? Investigate — measure a Vite example's snapshot/bundle both ways.
+- [ ] Turn prune into a one-shot pre-snapshot command per stack; document snapshot sizes.
 
 ## Known bugs
 
@@ -123,6 +135,7 @@ Turn the playground's building blocks into reusable components so anyone can emb
   - `expo export --platform web` bundles fine but **crashes after bundling** with `TypeError: this.on is not a function` (an EventEmitter/stream shim gap in the export writer), so it never writes `dist/`. Blocks producing a real web export in-VM.
   - `expo start` logs `An unknown error occurred while installing React Native DevTools … node_modules/fb-dotslash/index.js: Cannot read properties of undefined (reading 'wasm')` — a `fb-dotslash`/WASM shim gap. Non-fatal (Metro continues) but noisy.
   - Repro harnesses: `bench/prune-trace.mjs`, `bench/gen-keepset.mjs`.
+- [ ] **Full-screen commands don't react to live terminal resize.** `nano`/`less`/`fastfetch`/`sl` read `LINES`/`COLUMNS` once at launch. Fixed: the shell now mirrors the real terminal size into `LINES`/`COLUMNS` before each command (previously unset → hard-coded 24×80, so on a shorter pane scrolling kicked in ~10 lines late). Still open: if the pane is resized *while* a full-screen command is running, it won't re-fit — needs a resize signal delivered to the running command (a `SIGWINCH`-style hook on `CommandContext`).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,6 +115,15 @@ Turn the playground's building blocks into reusable components so anyone can emb
 - [ ] Extend the Node compatibility layer toward serverless handlers.
 - [ ] Cover more of the ecosystem unmodified.
 
+## Known bugs
+
+- [ ] **Expo in the Node environment (headless / CLI).** Running Expo in a box under Node (not the browser) has rough edges:
+  - `npx create-expo-app` / `npx expo …` leak the *host* cwd into the VM, so a relative project path resolves against the host and `expo start/export` fail with `Invalid project root` / `ConfigError: expected package.json … does not exist`. Workarounds today: pass an **absolute** VM path to `create-expo-app`, and invoke the installed CLI directly (`node <app>/node_modules/@expo/cli/build/bin/cli …`) with the project root as a positional, not via `npx`. Fix the npx/cwd propagation so `npx expo` works unmodified.
+  - `expo start` fatally errors on the Expo version endpoint (`CommandError: … Bad Gateway`) unless `EXPO_OFFLINE=1` is set; investigate the CORS-proxy path for `api.expo.dev` under Node.
+  - `expo export --platform web` bundles fine but **crashes after bundling** with `TypeError: this.on is not a function` (an EventEmitter/stream shim gap in the export writer), so it never writes `dist/`. Blocks producing a real web export in-VM.
+  - `expo start` logs `An unknown error occurred while installing React Native DevTools … node_modules/fb-dotslash/index.js: Cannot read properties of undefined (reading 'wasm')` — a `fb-dotslash`/WASM shim gap. Non-fatal (Metro continues) but noisy.
+  - Repro harnesses: `bench/prune-trace.mjs`, `bench/gen-keepset.mjs`.
+
 ---
 
 Priorities shift with real usage. Have a use case? Open an issue.

--- a/apps/playground/src/components/nosw-preview.tsx
+++ b/apps/playground/src/components/nosw-preview.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from 'react';
+import type { Kernel } from '@lifo-sh/core';
+import { mountNoSwPreview, type NoSwPreviewHandle } from '@/lib/preview-nosw';
+
+/**
+ * Service-worker-FREE preview: renders an in-VM dev-server app in a blob iframe,
+ * tunnelling its requests/HMR to the host over postMessage. Alternative to the
+ * SW-backed PreviewBrowser for environments where SWs are unreliable (iOS).
+ */
+export function NoSwPreview({ kernel, port }: { kernel: Kernel; port: number }) {
+  const ref = useRef<HTMLIFrameElement>(null);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+
+  useEffect(() => {
+    let handle: NoSwPreviewHandle | null = null;
+    let cancelled = false;
+    const el = ref.current;
+    if (el) {
+      setStatus('loading');
+      mountNoSwPreview(el, kernel, port)
+        .then((h) => { if (cancelled) h.destroy(); else { handle = h; setStatus('ready'); } })
+        .catch(() => { if (!cancelled) setStatus('error'); });
+    }
+    return () => { cancelled = true; handle?.destroy(); };
+  }, [kernel, port]);
+
+  return (
+    <div className="relative flex-1 h-full min-h-0">
+      {status === 'loading' && (
+        <div className="absolute inset-0 grid place-items-center text-[12px] text-tokyo-comment pointer-events-none">
+          Starting SW-free preview… (run the dev server in the terminal)
+        </div>
+      )}
+      {status === 'error' && (
+        <div className="absolute inset-0 grid place-items-center text-[12px] text-tokyo-red px-4 text-center">
+          Preview failed to start.
+        </div>
+      )}
+      <iframe
+        ref={ref}
+        className="w-full h-full border-0 bg-white"
+        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+        title="preview"
+      />
+    </div>
+  );
+}

--- a/apps/playground/src/components/terminal-area.tsx
+++ b/apps/playground/src/components/terminal-area.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { Terminal } from '@lifo-sh/ui';
-import { MoreVertical, Plus, Activity, Square, RotateCcw, Download, Upload, X, FileText } from 'lucide-react';
+import { MoreVertical, Plus, Activity, Square, RotateCcw, Download, Upload, X, FileText, Scissors } from 'lucide-react';
 import { downloadSnapshot, pickAndRestoreSnapshot } from '@/lib/box-snapshot';
 import { cn } from '@/lib/utils';
 import { TerminalView } from '@/components/terminal-view';
@@ -24,6 +24,9 @@ interface TerminalAreaProps {
   /** Restart the box — only shown when provided (project examples). Snapshot &
    *  restore are always offered whenever a box exists. */
   onRestart?: () => void;
+  /** Prune the Expo project's node_modules for a small snapshot — only shown
+   *  when provided (Expo examples). Runs before the user snapshots. */
+  onPrune?: () => Promise<void>;
 }
 
 type Tab =
@@ -39,7 +42,7 @@ const README_ID = -1;
  * restart, snapshot, restore — the latter three only when handlers are given).
  * Every tab is closable; the box menu reopens Processes if it was closed.
  */
-export function TerminalArea({ bootTab, box, initialLabels, canAdd = true, onRestart }: TerminalAreaProps) {
+export function TerminalArea({ bootTab, box, initialLabels, canAdd = true, onRestart, onPrune }: TerminalAreaProps) {
   const labels = initialLabels?.length ? initialLabels : ['Terminal 1'];
   // The example's code sample, captured at mount, shown as a README.md tab.
   const chrome = useOutputChrome();
@@ -163,6 +166,8 @@ export function TerminalArea({ bootTab, box, initialLabels, canAdd = true, onRes
     { label: 'Process manager', icon: Activity, onClick: openProcesses },
     { label: 'Stop all', icon: Square, onClick: () => void stopAll() },
     ...(onRestart ? [{ label: 'Restart box', icon: RotateCcw, onClick: () => { setMenuOpen(false); onRestart(); } }] : []),
+    // Prune node_modules (Expo examples) — shrinks the box before snapshotting.
+    ...(onPrune ? [{ label: 'Prune node_modules', icon: Scissors, onClick: run('Pruning node_modules (~15s)…', onPrune) }] : []),
     // Snapshot & restore work off any box's VFS, so every example gets them.
     ...(box ? [
       { label: 'Snapshot (download)', icon: Download, onClick: run('Snapshotting…', () => downloadSnapshot(box.kernel.vfs)) },

--- a/apps/playground/src/data/code-snippets.ts
+++ b/apps/playground/src/data/code-snippets.ts
@@ -484,6 +484,21 @@ const CODE_CREATE_EXPO_APP = `\
 <span class="code-comment"># which needs the relay as a CORS proxy:</span>
 <span class="code-comment">#   node apps/tunnel-server/server.js   (on your machine)</span>`;
 
+const CODE_BROWSER_METRO = `\
+<span class="code-comment"># browser-metro: a light Metro REPLACEMENT inside Lifo.</span>
+<span class="code-comment"># No node_modules, no real Metro/Babel in the VM — your</span>
+<span class="code-comment"># files are sucrase-transformed and npm packages come</span>
+<span class="code-comment"># pre-built from esm.reactnative.run (~2 MB bundle).</span>
+
+<span class="code-fn">browser-metro</span>            <span class="code-comment"># bundles + serves on :8081</span>
+
+<span class="code-comment"># edit App.tsx and save → the preview reloads.</span>
+<span class="code-comment"># assets become blob: URLs from the VFS; icon fonts</span>
+<span class="code-comment"># come inlined from the package server.</span>
+
+<span class="code-comment"># it's a switchable option — for full-fidelity real Metro:</span>
+<span class="code-fn">npx</span> expo start --web    <span class="code-comment"># heavier; installs node_modules</span>`;
+
 const CODE_EXPO_SUPABASE = `\
 <span class="code-comment"># Expo Router + Supabase, both entirely in the VM: a React</span>
 <span class="code-comment"># Native web app (Metro + Fast Refresh) talking supabase-js</span>
@@ -525,5 +540,6 @@ export const codeSnippets: Record<string, string> = {
 	expo: CODE_EXPO,
 	'expo-router': CODE_EXPO_ROUTER,
 	'create-expo-app': CODE_CREATE_EXPO_APP,
+	'browser-metro': CODE_BROWSER_METRO,
 	'expo-supabase': CODE_EXPO_SUPABASE,
 };

--- a/apps/playground/src/data/code-snippets.ts
+++ b/apps/playground/src/data/code-snippets.ts
@@ -486,17 +486,18 @@ const CODE_CREATE_EXPO_APP = `\
 
 const CODE_BROWSER_METRO = `\
 <span class="code-comment"># browser-metro: a light Metro REPLACEMENT inside Lifo.</span>
-<span class="code-comment"># No node_modules, no real Metro/Babel in the VM — your</span>
-<span class="code-comment"># files are sucrase-transformed and npm packages come</span>
-<span class="code-comment"># pre-built from esm.reactnative.run (~2 MB bundle).</span>
+<span class="code-comment"># Scaffold a real Expo app with NO install — no node_modules.</span>
 
+<span class="code-fn">npx</span> create-expo-app my-app --no-install
+<span class="code-fn">cd</span> my-app
 <span class="code-fn">browser-metro</span>            <span class="code-comment"># bundles + serves on :8081</span>
 
-<span class="code-comment"># edit App.tsx and save → the preview reloads.</span>
-<span class="code-comment"># assets become blob: URLs from the VFS; icon fonts</span>
-<span class="code-comment"># come inlined from the package server.</span>
+<span class="code-comment"># your files are sucrase-transformed in the VM; npm packages</span>
+<span class="code-comment"># come pre-built from esm.reactnative.run (~2 MB bundle).</span>
+<span class="code-comment"># edit a screen and save → the preview reloads.</span>
+<span class="code-comment"># images → blob: URLs from the VFS; fonts inlined from the server.</span>
 
-<span class="code-comment"># it's a switchable option — for full-fidelity real Metro:</span>
+<span class="code-comment"># switchable option — for full-fidelity real Metro instead:</span>
 <span class="code-fn">npx</span> expo start --web    <span class="code-comment"># heavier; installs node_modules</span>`;
 
 const CODE_EXPO_SUPABASE = `\

--- a/apps/playground/src/examples/browser-metro.tsx
+++ b/apps/playground/src/examples/browser-metro.tsx
@@ -1,0 +1,82 @@
+import { ProjectExample } from '@/examples/project-example';
+
+const APP = '/home/user/rn-app';
+
+// A tiny .tsx Expo web app. browser-metro JSX-transforms .tsx/.jsx (not .js),
+// so the app uses .tsx. No node_modules are installed — browser-metro fetches
+// pre-bundled packages from esm.reactnative.run at bundle time.
+const files: Record<string, string> = {
+  [`${APP}/package.json`]: JSON.stringify(
+    {
+      name: 'rn-app',
+      main: 'index.tsx',
+      dependencies: {
+        expo: '~54.0.0',
+        react: '19.1.0',
+        'react-dom': '19.1.0',
+        'react-native': '0.81.5',
+        'react-native-web': '~0.21.0',
+      },
+    },
+    null,
+    2,
+  ),
+  [`${APP}/index.tsx`]: `import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);
+`,
+  [`${APP}/App.tsx`]: `import { useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+export default function App() {
+  const [count, setCount] = useState(0);
+  return (
+    <View style={styles.container}>
+      <Text style={styles.rocket}>🚀</Text>
+      <Text style={styles.title}>browser-metro in Lifo</Text>
+      <Text style={styles.subtitle}>
+        Bundled in the VM, packages fetched pre-built from esm.reactnative.run — no node_modules.
+        Edit App.tsx and save.
+      </Text>
+      <Pressable style={styles.button} onPress={() => setCount((c) => c + 1)}>
+        <Text style={styles.buttonText}>Tapped {count} times</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#1a1b26', padding: 24, gap: 12 },
+  rocket: { fontSize: 56 },
+  title: { color: '#c0caf5', fontSize: 22, fontWeight: '700' },
+  subtitle: { color: '#565f89', fontSize: 13, textAlign: 'center', maxWidth: 320, lineHeight: 20 },
+  button: { marginTop: 12, flexDirection: 'row', alignItems: 'center', gap: 8, backgroundColor: '#7aa2f7', paddingVertical: 10, paddingHorizontal: 18, borderRadius: 10 },
+  buttonText: { color: '#1a1b26', fontSize: 15, fontWeight: '600' },
+});
+`,
+};
+
+export default function BrowserMetroExample() {
+  return (
+    <ProjectExample
+      title="browser-metro (light Metro)"
+      subtitle={
+        <>
+          A Metro <em>replacement</em> that runs inside Lifo. Instead of installing node_modules and
+          running real Metro/Babel in the VM, it sucrase-transforms your files and fetches pre-built
+          npm packages from <code>esm.reactnative.run</code> — a ~2&nbsp;MB self-contained bundle, no{' '}
+          <code>node_modules</code>. Just run <code>browser-metro</code> (it serves on port 8081).
+          <span className="block mt-1.5 text-tokyo-comment/80">
+            It&apos;s a switchable option — run <code>npx expo start --web</code> instead for real
+            Metro when you need full fidelity. Images are materialized as blob URLs from the VFS,
+            and fonts (e.g. <code>@expo/vector-icons</code>) come inlined from the package server.
+          </span>
+        </>
+      }
+      files={files}
+      cwd={APP}
+      previewPort={8081}
+    />
+  );
+}

--- a/apps/playground/src/examples/browser-metro.tsx
+++ b/apps/playground/src/examples/browser-metro.tsx
@@ -1,82 +1,36 @@
 import { ProjectExample } from '@/examples/project-example';
 
-const APP = '/home/user/rn-app';
-
-// A tiny .tsx Expo web app. browser-metro JSX-transforms .tsx/.jsx (not .js),
-// so the app uses .tsx. No node_modules are installed — browser-metro fetches
-// pre-bundled packages from esm.reactnative.run at bundle time.
-const files: Record<string, string> = {
-  [`${APP}/package.json`]: JSON.stringify(
-    {
-      name: 'rn-app',
-      main: 'index.tsx',
-      dependencies: {
-        expo: '~54.0.0',
-        react: '19.1.0',
-        'react-dom': '19.1.0',
-        'react-native': '0.81.5',
-        'react-native-web': '~0.21.0',
-      },
-    },
-    null,
-    2,
-  ),
-  [`${APP}/index.tsx`]: `import { registerRootComponent } from 'expo';
-import App from './App';
-
-registerRootComponent(App);
-`,
-  [`${APP}/App.tsx`]: `import { useState } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
-
-export default function App() {
-  const [count, setCount] = useState(0);
-  return (
-    <View style={styles.container}>
-      <Text style={styles.rocket}>🚀</Text>
-      <Text style={styles.title}>browser-metro in Lifo</Text>
-      <Text style={styles.subtitle}>
-        Bundled in the VM, packages fetched pre-built from esm.reactnative.run — no node_modules.
-        Edit App.tsx and save.
-      </Text>
-      <Pressable style={styles.button} onPress={() => setCount((c) => c + 1)}>
-        <Text style={styles.buttonText}>Tapped {count} times</Text>
-      </Pressable>
-    </View>
-  );
-}
-
-const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#1a1b26', padding: 24, gap: 12 },
-  rocket: { fontSize: 56 },
-  title: { color: '#c0caf5', fontSize: 22, fontWeight: '700' },
-  subtitle: { color: '#565f89', fontSize: 13, textAlign: 'center', maxWidth: 320, lineHeight: 20 },
-  button: { marginTop: 12, flexDirection: 'row', alignItems: 'center', gap: 8, backgroundColor: '#7aa2f7', paddingVertical: 10, paddingHorizontal: 18, borderRadius: 10 },
-  buttonText: { color: '#1a1b26', fontSize: 15, fontWeight: '600' },
-});
-`,
-};
-
 export default function BrowserMetroExample() {
   return (
     <ProjectExample
       title="browser-metro (light Metro)"
       subtitle={
         <>
-          A Metro <em>replacement</em> that runs inside Lifo. Instead of installing node_modules and
-          running real Metro/Babel in the VM, it sucrase-transforms your files and fetches pre-built
-          npm packages from <code>esm.reactnative.run</code> — a ~2&nbsp;MB self-contained bundle, no{' '}
-          <code>node_modules</code>. Just run <code>browser-metro</code> (it serves on port 8081).
+          A Metro <em>replacement</em> that runs inside Lifo. Scaffold a real Expo app with{' '}
+          <strong>no install</strong> — <code>npx create-expo-app my-app --no-install</code>,{' '}
+          <code>cd my-app</code>, then <code>browser-metro</code>. There are <em>no</em>{' '}
+          <code>node_modules</code>: your files are sucrase-transformed in the VM and npm packages
+          come pre-built from <code>esm.reactnative.run</code> — a ~2&nbsp;MB self-contained bundle
+          on port 8081. Edit a screen and save to reload.
           <span className="block mt-1.5 text-tokyo-comment/80">
             It&apos;s a switchable option — run <code>npx expo start --web</code> instead for real
-            Metro when you need full fidelity. Images are materialized as blob URLs from the VFS,
-            and fonts (e.g. <code>@expo/vector-icons</code>) come inlined from the package server.
+            Metro (installs <code>node_modules</code>) when you need full fidelity. Images are
+            materialized as blob URLs from the VFS; fonts (e.g. <code>@expo/vector-icons</code>) come
+            inlined from the package server.
           </span>
         </>
       }
-      files={files}
-      cwd={APP}
+      files={{}}
+      cwd="/home/user"
       previewPort={8081}
+      // create-expo-app downloads the template from the network (do NOT set
+      // EXPO_OFFLINE); these silence telemetry/version/dep-validation/browser
+      // calls. --no-install skips node_modules — browser-metro doesn't need them.
+      env={{
+        EXPO_NO_TELEMETRY: '1',
+        EXPO_NO_DEPENDENCY_VALIDATION: '1',
+        BROWSER: 'none',
+      }}
     />
   );
 }

--- a/apps/playground/src/examples/create-expo-app.tsx
+++ b/apps/playground/src/examples/create-expo-app.tsx
@@ -19,6 +19,7 @@ export default function CreateExpoAppExample() {
       files={{}}
       cwd="/home/user"
       previewPort={8081}
+      pruneable
       // Defaults a stock project doesn't set for itself, so `expo start` behaves
       // in the VM. NOTE: do NOT set EXPO_OFFLINE — create-expo-app needs the
       // network to download the template tarball (offline → "Could not find npm

--- a/apps/playground/src/examples/project-example.tsx
+++ b/apps/playground/src/examples/project-example.tsx
@@ -1,11 +1,12 @@
 import { type ReactNode, useRef, useState } from 'react';
 import { PanelTopOpen, PanelTopClose } from 'lucide-react';
 import { Panel as RawPanel, type ImperativePanelHandle } from 'react-resizable-panels';
-import { Sandbox, ServiceWorkerBridge } from '@lifo-sh/core';
+import { Sandbox, ServiceWorkerBridge, pruneExpoModules } from '@lifo-sh/core';
 import gitCommand from 'lifo-pkg-git';
 import type { Terminal } from '@lifo-sh/ui';
 import { ExamplePanel } from '@/components/example-panel';
 import { PreviewTabs, type PreviewTab } from '@/components/preview-tabs';
+import { NoSwPreview } from '@/components/nosw-preview';
 import { TerminalArea } from '@/components/terminal-area';
 import { bootShell } from '@/lib/shell';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
@@ -22,6 +23,9 @@ export interface ProjectExampleProps {
   previews?: PreviewTab[];
   /** Extra env for the sandbox (e.g. Expo-friendly defaults for a stock scaffold). */
   env?: Record<string, string>;
+  /** Offer "Prune node_modules" in the box menu (Expo projects) — shrinks the
+   *  box to just what Metro needs before snapshotting. */
+  pruneable?: boolean;
 }
 
 /**
@@ -30,7 +34,7 @@ export interface ProjectExampleProps {
  * preview, split by a resizable handle. The SW bridge serves /_sw/<boxId>/<port>/
  * so each example routes to its own VM.
  */
-export function ProjectExample({ title, subtitle, files, cwd, previewPort, previews, env }: ProjectExampleProps) {
+export function ProjectExample({ title, subtitle, files, cwd, previewPort, previews, env, pruneable }: ProjectExampleProps) {
   const hasPreview = !!(previews?.length || previewPort);
   // Always present the preview as Chrome-like tabs, even for a single port.
   const previewTabs: PreviewTab[] = previews?.length
@@ -54,6 +58,8 @@ export function ProjectExample({ title, subtitle, files, cwd, previewPort, previ
   // *collapsed* (size 0), never unmounted, so the box/kernel/scrollback survive.
   const termPanelRef = useRef<ImperativePanelHandle>(null);
   const [terminalFolded, setTerminalFolded] = useState(false);
+  // Preview transport: 'sw' (service worker) or 'postmessage' (SW-free blob iframe).
+  const [previewEngine, setPreviewEngine] = useState<'sw' | 'postmessage'>('sw');
 
   // The first terminal creates the Sandbox + SW bridge; extra terminals attach
   // a shell onto the shared kernel.
@@ -115,19 +121,44 @@ export function ProjectExample({ title, subtitle, files, cwd, previewPort, previ
         else void bootFirstTerminal(term);
       }}
       onRestart={restart}
+      onPrune={
+        pruneable
+          ? async () => {
+              const sb = sandboxRef.current;
+              if (!sb) return;
+              try {
+                const r = await pruneExpoModules(sb, { onLog: (s) => console.log('[prune]', s) });
+                console.log(`[prune] done — kept ${r.after}/${r.before} node_modules files (~${(r.freedBytes / 1048576).toFixed(0)} MB freed). Snapshot now.`);
+                alert(`Pruned: kept ${r.after} of ${r.before} node_modules files (~${(r.freedBytes / 1048576).toFixed(0)} MB freed). Snapshot now.`);
+              } catch (e) {
+                const msg = e instanceof Error ? e.message : String(e);
+                console.error('[prune] FAILED:', msg);
+                alert(`Prune failed: ${msg}\n\nThe snapshot will be full-size. Make sure the app's web dev server can start (expo start --web).`);
+              }
+            }
+          : undefined
+      }
     />
   );
 
-  // Fold/unfold the terminal panel — lives in the example header (one button
-  // toggles the whole terminal row).
+  // Header actions: a preview-engine switch (SW ⇄ postMessage) + the fold toggle.
   const foldToggle = hasPreview ? (
-    <button
-      onClick={() => (terminalFolded ? termPanelRef.current?.expand() : termPanelRef.current?.collapse())}
-      title={terminalFolded ? 'Show terminal' : 'Hide terminal'}
-      className="w-6 h-6 grid place-items-center rounded bg-transparent border-none cursor-pointer text-tokyo-comment hover:text-tokyo-fg-bright hover:bg-tokyo-hover"
-    >
-      {terminalFolded ? <PanelTopOpen size={14} /> : <PanelTopClose size={14} />}
-    </button>
+    <div className="flex items-center gap-2">
+      <button
+        onClick={() => setPreviewEngine((e) => (e === 'sw' ? 'postmessage' : 'sw'))}
+        title="Switch preview transport (service worker ⇄ SW-free postMessage)"
+        className="h-6 px-2 grid place-items-center rounded bg-tokyo-bg-dark border border-tokyo-border cursor-pointer text-[10px] font-mono text-tokyo-comment hover:text-tokyo-fg-bright"
+      >
+        preview: {previewEngine === 'sw' ? 'SW' : 'postMessage'}
+      </button>
+      <button
+        onClick={() => (terminalFolded ? termPanelRef.current?.expand() : termPanelRef.current?.collapse())}
+        title={terminalFolded ? 'Show terminal' : 'Hide terminal'}
+        className="w-6 h-6 grid place-items-center rounded bg-transparent border-none cursor-pointer text-tokyo-comment hover:text-tokyo-fg-bright hover:bg-tokyo-hover"
+      >
+        {terminalFolded ? <PanelTopOpen size={14} /> : <PanelTopClose size={14} />}
+      </button>
+    </div>
   ) : undefined;
 
   return (
@@ -152,7 +183,13 @@ export function ProjectExample({ title, subtitle, files, cwd, previewPort, previ
           </RawPanel>
           <ResizableHandle className={terminalFolded ? 'hidden' : 'my-0.5'} />
           <ResizablePanel defaultSize={55} minSize={20}>
-            {swReady === null ? (
+            {previewEngine === 'postmessage' ? (
+              sandbox ? (
+                <NoSwPreview kernel={sandbox.kernel} port={previewTabs[0]?.port ?? previewPort ?? 8081} />
+              ) : (
+                <div className="flex-1 h-full grid place-items-center text-[12px] text-tokyo-comment">Booting box…</div>
+              )
+            ) : swReady === null ? (
               <div className="flex-1 h-full grid place-items-center text-[12px] text-tokyo-comment">
                 Starting preview…
               </div>
@@ -160,8 +197,8 @@ export function ProjectExample({ title, subtitle, files, cwd, previewPort, previ
               <PreviewTabs boxId={boxId} tabs={previewTabs} />
             ) : (
               <div className="flex-1 h-full grid place-items-center text-[12px] text-tokyo-comment text-center px-4">
-                Service worker unavailable in this browser — run the tunnel relay and open
-                http://localhost:3005 instead.
+                Service worker unavailable in this browser — switch preview to postMessage (top-right),
+                or run the tunnel relay at http://localhost:3005.
               </div>
             )}
           </ResizablePanel>

--- a/apps/playground/src/examples/registry.tsx
+++ b/apps/playground/src/examples/registry.tsx
@@ -19,6 +19,7 @@ const PgliteExample = lazy(() => import('@/examples/pglite'));
 const ExpoExample = lazy(() => import('@/examples/expo'));
 const ExpoRouterExample = lazy(() => import('@/examples/expo-router'));
 const CreateExpoAppExample = lazy(() => import('@/examples/create-expo-app'));
+const BrowserMetroExample = lazy(() => import('@/examples/browser-metro'));
 const ExpoSupabaseExample = lazy(() => import('@/examples/expo-supabase'));
 const CliExample = lazy(() => import('@/examples/cli'));
 const LifoPkgExample = lazy(() => import('@/examples/lifo-pkg'));
@@ -53,6 +54,7 @@ export const examples: ExampleConfig[] = [
   { id: 'expo', label: 'Expo (React Native Web)', group: 'Real-World Stacks', Component: ExpoExample },
   { id: 'expo-router', label: 'Expo Router', group: 'Real-World Stacks', Component: ExpoRouterExample },
   { id: 'create-expo-app', label: 'create-expo-app (1:1)', group: 'Real-World Stacks', Component: CreateExpoAppExample },
+  { id: 'browser-metro', label: 'browser-metro (light)', group: 'Real-World Stacks', Component: BrowserMetroExample },
   { id: 'expo-supabase', label: 'Expo Router + Supabase', group: 'Real-World Stacks', Component: ExpoSupabaseExample },
   // ── Installable Packages ──
   { id: 'git', label: 'Git', group: 'Installable Packages', Component: GitExample },

--- a/apps/playground/src/lib/preview-nosw.ts
+++ b/apps/playground/src/lib/preview-nosw.ts
@@ -1,0 +1,284 @@
+/**
+ * preview-nosw.ts — service-worker-FREE preview transport.
+ *
+ * Instead of proxying the iframe's requests through a service worker, we:
+ *   1. Fetch the app's HTML + JS bundle from the in-VM dev server directly via
+ *      kernel.portRegistry (host-side, no SW).
+ *   2. Rewrite the bundle's static asset URLs (/assets/…) to blob: URLs the host
+ *      pre-fetches (blobs, not data URIs — short + fast).
+ *   3. Serve the bundle + HTML to the iframe as blob: URLs, with injected shims
+ *      (fetch/XHR/WebSocket) that tunnel the app's RUNTIME requests to the parent
+ *      via window.postMessage.
+ *   4. The parent answers those over the SAME message protocol the SW used, by
+ *      reusing ServiceWorkerBridge.attach() with a postMessage adapter port.
+ *
+ * This makes the mobile hot path work where service workers are unreliable
+ * (iOS Chrome). React Refresh (HMR) rides the WebSocket shim → parent → in-VM
+ * ws server, exactly like the SW path.
+ */
+import { ServiceWorkerBridge } from '@lifo-sh/core';
+import type { Kernel } from '@lifo-sh/core';
+
+interface VmResponse { status: number; headers: Record<string, string>; body: Uint8Array }
+
+/** Call a bound in-VM port directly (no SW) and await its full response. */
+function vmFetch(kernel: Kernel, port: number, url: string, timeoutMs = 120000): Promise<VmResponse> {
+  const handler = kernel.portRegistry.get(port);
+  if (!handler) return Promise.resolve({ status: 502, headers: {}, body: new Uint8Array() });
+  const vRes: {
+    statusCode: number; headers: Record<string, string>; body: string;
+    bodyBytes?: Uint8Array; _donePromise?: Promise<unknown>;
+  } = { statusCode: 200, headers: {}, body: '' };
+  handler({ method: 'GET', url, headers: { host: `localhost:${port}` }, body: '' }, vRes);
+  const finish = (): VmResponse => ({
+    status: vRes.statusCode,
+    headers: vRes.headers,
+    body: vRes.bodyBytes ?? new TextEncoder().encode(vRes.body || ''),
+  });
+  if (vRes._donePromise) {
+    return Promise.race([
+      vRes._donePromise.then(finish),
+      new Promise<VmResponse>((resolve) => setTimeout(() => resolve({ status: 504, headers: {}, body: new Uint8Array() }), timeoutMs)),
+    ]);
+  }
+  return Promise.resolve(finish());
+}
+
+/**
+ * Injected into the preview HTML (as a classic inline script, before the bundle)
+ * so it runs first. Tunnels the app's runtime fetch/XHR/WebSocket to the parent
+ * over window.postMessage. `__LIFO_PORT` is stamped in by the host.
+ */
+function shimScript(port: number): string {
+  return `(function(){
+  var PORT=${port};
+  var parentWin=window.parent, seq=0, pending=new Map(), wsConns=new Map();
+  function b64enc(u8){var s='';for(var i=0;i<u8.length;i++)s+=String.fromCharCode(u8[i]);return btoa(s);}
+  function b64dec(b){var s=atob(b),u=new Uint8Array(s.length);for(var i=0;i<s.length;i++)u[i]=s.charCodeAt(i);return u;}
+  window.addEventListener('message',function(e){
+    if(e.source!==parentWin)return; var m=e.data||{};
+    if(m.type==='response'){var p=pending.get(m.requestId);if(p){pending.delete(m.requestId);p(m);}}
+    else if(m.connId){var c=wsConns.get(m.connId);if(!c)return;
+      if(m.type==='ws-opened')c.__open();
+      else if(m.type==='ws-message')c.__msg(m.data,m.binary);
+      else if(m.type==='ws-close'){wsConns.delete(m.connId);c.__close(1006,'');}}
+  });
+  // Which URLs tunnel to the VM: relative, root-absolute, or our own host.
+  function tunnelable(u){ if(!u)return false; if(/^(blob:|data:)/.test(u))return false;
+    if(u[0]==='/')return true; try{var url=new URL(u); return url.host==='localhost:'+PORT||url.host===location.host;}catch(_){return u[0]==='.';} }
+  function pathOf(u){ if(u[0]==='/')return u; try{return new URL(u).pathname+new URL(u).search;}catch(_){return u;} }
+  function vmreq(method,url,headers,body){ return new Promise(function(res){ var id='r'+(seq++);
+    pending.set(id,res); parentWin.postMessage({type:'request',requestId:id,port:PORT,method:method,url:pathOf(url),headers:headers||{},body:body?b64enc(body):''},'*'); }); }
+  // --- fetch shim ---
+  var origFetch=window.fetch;
+  window.fetch=function(input,init){ var url=typeof input==='string'?input:(input&&input.url);
+    if(!tunnelable(url))return origFetch.apply(this,arguments);
+    var method=(init&&init.method)||'GET'; var body=init&&init.body; var bytes=null;
+    if(typeof body==='string')bytes=new TextEncoder().encode(body);
+    return vmreq(method,url,(init&&init.headers)||{},bytes).then(function(m){
+      var buf=m.bodyBuffer||(m.body?b64dec(m.body).buffer:new ArrayBuffer(0));
+      return new Response(buf,{status:m.statusCode||200,headers:m.headers||{}}); }); };
+  // --- image asset interceptor ---
+  // RNW builds /assets/… URLs at RENDER time; the browser would load them from
+  // the blob origin (no server, no SW) and 404. Route via the (shimmed) fetch →
+  // blob → swap the real src.
+  (function(){
+    var proto=window.HTMLImageElement&&HTMLImageElement.prototype; if(!proto)return;
+    var d=Object.getOwnPropertyDescriptor(proto,'src');
+    if(d&&d.set){ Object.defineProperty(proto,'src',{configurable:true,enumerable:d.enumerable,
+      get:function(){return d.get.call(this);},
+      set:function(v){ var img=this; if(typeof v==='string'&&tunnelable(v)){ window.fetch(v).then(function(r){return r.ok?r.blob():null;}).then(function(b){ d.set.call(img,b?URL.createObjectURL(b):v); }).catch(function(){ d.set.call(img,v); }); } else { d.set.call(this,v); } }
+    }); }
+    var os=proto.setAttribute; proto.setAttribute=function(n,val){ if(n==='src'){ this.src=val; return; } return os.call(this,n,val); };
+  })();
+  // --- font interceptor (expo-font / @expo/vector-icons) ---
+  // FontFace.load() fetches its url() with the BROWSER (bypassing our fetch
+  // shim) → 404. Fetch the bytes via the bridge and build the face from an
+  // ArrayBuffer instead.
+  (function(){
+    var Orig=window.FontFace; if(!Orig)return;
+    function Patched(family,source,desc){
+      if(typeof source==='string'){ var m=source.match(/url\\(\\s*['"]?([^'")]+)['"]?\\s*\\)/);
+        if(m&&tunnelable(m[1])){ var url=m[1]; var ff=new Orig(family,'url(about:blank)',desc||{});
+          ff.load=function(){ return window.fetch(url).then(function(r){return r.arrayBuffer();}).then(function(buf){ var real=new Orig(family,buf,desc||{}); try{document.fonts.add(real);}catch(_){}; return real.load(); }); };
+          return ff; } }
+      return new Orig(family,source,desc);
+    }
+    Patched.prototype=Orig.prototype;
+    try{ window.FontFace=Patched; }catch(_){}
+  })();
+  // --- CSS @font-face interceptor (@expo/vector-icons) ---
+  // vector-icons injects a <style> with @font-face{src:url(/assets/…ttf)} and
+  // lets the BROWSER load the url — bypassing fetch/FontFace shims → 404 → tofu.
+  // Rewrite such urls to bridge-fetched blob: URLs on the fly.
+  (function(){
+    function rewrite(styleEl){
+      try{ var css=styleEl.textContent||''; if(css.indexOf('@font-face')<0&&css.indexOf('url(')<0)return;
+        var urls=[]; css.replace(/url\\(\\s*['"]?([^'")]+)['"]?\\s*\\)/g,function(_m,u){ if(tunnelable(u)&&urls.indexOf(u)<0)urls.push(u); return _m; });
+        if(!urls.length)return; if(styleEl.__lifoRw)return; styleEl.__lifoRw=1;
+        var map={},pending=urls.length;
+        urls.forEach(function(u){ window.fetch(u).then(function(r){return r.ok?r.blob():null;}).then(function(b){ if(b)map[u]=URL.createObjectURL(b); }).catch(function(){}).then(function(){ if(--pending===0){ var out=css; Object.keys(map).forEach(function(u){ out=out.split(u).join(map[u]); }); if(styleEl.textContent!==out)styleEl.textContent=out; } }); });
+      }catch(_){}
+    }
+    var ap=Node.prototype.appendChild;
+    Node.prototype.appendChild=function(node){ var r=ap.call(this,node); try{ if(node&&node.tagName==='STYLE')rewrite(node); else if(this&&this.tagName==='STYLE')rewrite(this); }catch(_){}; return r; };
+    var ib=Node.prototype.insertBefore;
+    Node.prototype.insertBefore=function(node,ref){ var r=ib.call(this,node,ref); try{ if(node&&node.tagName==='STYLE')rewrite(node); }catch(_){}; return r; };
+  })();
+  // --- XHR shim (RN's networking uses XHR) ---
+  var OrigXHR=window.XMLHttpRequest;
+  function ShimXHR(){ this._h={}; this.readyState=0; this.status=0; this.response=''; this.responseText=''; this.onload=null; this.onreadystatechange=null; this.onerror=null; }
+  ShimXHR.prototype.open=function(m,u){ this._m=m; this._u=u; if(!tunnelable(u)){this._native=new OrigXHR();this._native.open.apply(this._native,arguments);} };
+  ShimXHR.prototype.setRequestHeader=function(k,v){ if(this._native)return this._native.setRequestHeader(k,v); this._h[k]=v; };
+  ShimXHR.prototype.send=function(body){ var self=this; if(this._native){['onload','onerror','onreadystatechange'].forEach(function(k){self._native[k]=function(){self.status=self._native.status;self.responseText=self._native.responseText;self.response=self._native.response;self.readyState=self._native.readyState;self[k]&&self[k]();};});return this._native.send(body);}
+    var bytes=typeof body==='string'?new TextEncoder().encode(body):null;
+    vmreq(this._m,this._u,this._h,bytes).then(function(m){ var buf=m.bodyBuffer||(m.body?b64dec(m.body).buffer:new ArrayBuffer(0));
+      self.status=m.statusCode||200; self.response=buf; self.responseText=new TextDecoder().decode(new Uint8Array(buf)); self.readyState=4;
+      self.onreadystatechange&&self.onreadystatechange(); self.onload&&self.onload(); }); };
+  ShimXHR.prototype.getAllResponseHeaders=function(){return '';}; ShimXHR.prototype.getResponseHeader=function(){return null;}; ShimXHR.prototype.abort=function(){};
+  window.XMLHttpRequest=ShimXHR;
+  // --- WebSocket shim (HMR / React Refresh) ---
+  var OrigWS=window.WebSocket;
+  function LifoWS(url,protocols){ var u; try{u=new URL(url,location.href);}catch(_){return new OrigWS(url,protocols);}
+    var sameHost=(u.host==='localhost:'+PORT||u.host===location.host)&&(u.protocol==='ws:'||u.protocol==='wss:');
+    if(!sameHost)return new OrigWS(url,protocols); var self=this;
+    this.url=u.href; this.readyState=0; this.bufferedAmount=0; this.protocol=Array.isArray(protocols)?(protocols[0]||''):(protocols||''); this.binaryType='blob';
+    this.onopen=null;this.onmessage=null;this.onclose=null;this.onerror=null; this._l={open:[],message:[],close:[],error:[]};
+    this.connId='ws'+(seq++); wsConns.set(this.connId,this);
+    parentWin.postMessage({type:'ws-open',connId:this.connId,port:PORT,url:u.pathname+u.search,protocol:this.protocol},'*');
+    this.__open=function(){self.readyState=1;self.__emit('open',{});};
+    this.__msg=function(b64,binary){var data;if(binary){var buf=b64dec(b64).buffer;data=self.binaryType==='arraybuffer'?buf:new Blob([buf]);}else{data=new TextDecoder().decode(b64dec(b64));}self.__emit('message',{data:data});};
+    this.__close=function(code,reason){if(self.readyState===3)return;self.readyState=3;self.__emit('close',{code:code||1000,reason:reason||'',wasClean:code===1000});};
+    this.__emit=function(type,init){var ev;try{ev=type==='message'?new MessageEvent('message',init):new (type==='close'?CloseEvent:Event)(type,init);}catch(_){ev={type:type};for(var k in init)ev[k]=init[k];}var h=self['on'+type];if(h)try{h.call(self,ev);}catch(_){}(self._l[type]||[]).forEach(function(fn){try{fn.call(self,ev);}catch(_){}});};
+  }
+  LifoWS.prototype.send=function(data){var u8;if(typeof data==='string')u8=new TextEncoder().encode(data);else if(data instanceof ArrayBuffer)u8=new Uint8Array(data);else if(ArrayBuffer.isView(data))u8=new Uint8Array(data.buffer,data.byteOffset,data.byteLength);else u8=new TextEncoder().encode(String(data));parentWin.postMessage({type:'ws-send',connId:this.connId,data:b64enc(u8),binary:typeof data!=='string'},'*');};
+  LifoWS.prototype.close=function(code,reason){if(this.readyState>=2)return;this.readyState=2;parentWin.postMessage({type:'ws-close',connId:this.connId},'*');this.__close(code||1000,reason||'');};
+  LifoWS.prototype.addEventListener=function(t,fn){if(this._l[t])this._l[t].push(fn);};
+  LifoWS.prototype.removeEventListener=function(t,fn){if(this._l[t]){var i=this._l[t].indexOf(fn);if(i>=0)this._l[t].splice(i,1);}};
+  LifoWS.prototype.dispatchEvent=function(){return true;};
+  LifoWS.CONNECTING=0;LifoWS.OPEN=1;LifoWS.CLOSING=2;LifoWS.CLOSED=3;
+  window.WebSocket=LifoWS;
+})();`;
+}
+
+/**
+ * Router shim (ported from browser-metro). blob: documents can't change
+ * location.pathname, so client routers (Expo Router / React Navigation) see the
+ * blob UUID and render "Unmatched Route". This virtualizes document.URL, the URL
+ * constructor, and the History stack, carrying the real route in location.hash
+ * so the router reads a clean "/" path. Runs before the bundle.
+ */
+function routerShim(): string {
+  return `(function() {
+  var rawHash = location.hash.slice(1) || '/';
+  var hashIdx = rawHash.indexOf('#');
+  var virtualHash = '';
+  var pathAndSearch = rawHash;
+  if (hashIdx > 0) { virtualHash = rawHash.slice(hashIdx); pathAndSearch = rawHash.slice(0, hashIdx); }
+  var searchIdx = pathAndSearch.indexOf('?');
+  var virtualPathname = searchIdx >= 0 ? pathAndSearch.slice(0, searchIdx) : pathAndSearch;
+  var virtualSearch = searchIdx >= 0 ? pathAndSearch.slice(searchIdx) : '';
+  if (virtualPathname.charAt(0) !== '/') virtualPathname = '/' + virtualPathname;
+  var virtualOrigin = location.origin || 'http://localhost';
+  var virtualHref = virtualOrigin + virtualPathname + virtualSearch + virtualHash;
+  try { Object.defineProperty(Document.prototype, 'URL', { get: function() { return virtualHref; }, configurable: true }); } catch(e) {}
+  var OrigURL = URL;
+  var _URL = function(url, base) { var u = String(url); if (u.indexOf('blob:') === 0) u = virtualHref; if (arguments.length > 1) return new OrigURL(u, base); return new OrigURL(u); };
+  _URL.prototype = OrigURL.prototype;
+  _URL.createObjectURL = OrigURL.createObjectURL; _URL.revokeObjectURL = OrigURL.revokeObjectURL; _URL.canParse = OrigURL.canParse;
+  window.URL = _URL;
+  var _realReplaceState = history.replaceState;
+  var _blobBase = location.href.split('#')[0];
+  var stack = [{ state: null, pathname: virtualPathname, search: virtualSearch, hash: virtualHash }];
+  var stackIndex = 0;
+  function currentEntry() { return stack[stackIndex]; }
+  function sync() {
+    var e = currentEntry();
+    virtualPathname = e.pathname; virtualSearch = e.search; virtualHash = e.hash;
+    virtualHref = virtualOrigin + virtualPathname + virtualSearch + virtualHash;
+    var routeHash = '#' + e.pathname + e.search;
+    window.__ROUTER_SHIM_HASH__ = routeHash;
+    var newUrl = _blobBase + routeHash;
+    if (newUrl !== location.href) { try { _realReplaceState.call(history, e.state, '', newUrl); } catch(e) {} }
+  }
+  function parseUrl(url) {
+    var s = String(url);
+    if (s.indexOf('blob:') === 0) { try { var inner = new OrigURL(s.slice(5)); s = inner.pathname + inner.search + inner.hash; } catch(e) {} }
+    try { var u = new OrigURL(s, virtualOrigin); return { pathname: u.pathname, search: u.search, hash: u.hash }; } catch(e) {}
+    var pathname = s, search = '', hash = '';
+    var hi = pathname.indexOf('#'); if (hi >= 0) { hash = pathname.slice(hi); pathname = pathname.slice(0, hi); }
+    var si = pathname.indexOf('?'); if (si >= 0) { search = pathname.slice(si); pathname = pathname.slice(0, si); }
+    if (!pathname) pathname = '/'; if (pathname.charAt(0) !== '/') pathname = '/' + pathname;
+    return { pathname: pathname, search: search, hash: hash };
+  }
+  history.pushState = function(state, title, url) { if (url != null) { var p = parseUrl(url); stack = stack.slice(0, stackIndex + 1); stack.push({ state: state, pathname: p.pathname, search: p.search, hash: '' }); stackIndex = stack.length - 1; sync(); } };
+  history.replaceState = function(state, title, url) { if (url != null) { var p = parseUrl(url); stack[stackIndex] = { state: state, pathname: p.pathname, search: p.search, hash: '' }; sync(); } };
+  history.go = function(n) { if (!n) return; var ni = stackIndex + n; if (ni < 0) ni = 0; if (ni >= stack.length) ni = stack.length - 1; if (ni === stackIndex) return; stackIndex = ni; sync(); window.dispatchEvent(new PopStateEvent('popstate', { state: currentEntry().state })); };
+  history.back = function() { history.go(-1); }; history.forward = function() { history.go(1); };
+  Object.defineProperty(history, 'state', { get: function() { return currentEntry().state; }, configurable: true });
+  sync();
+})();`;
+}
+
+export interface NoSwPreviewHandle { destroy(): void }
+
+/**
+ * Mount a service-worker-free preview of an in-VM dev server into `iframe`.
+ * Returns a handle whose destroy() revokes blob URLs and detaches the bridge.
+ */
+export async function mountNoSwPreview(iframe: HTMLIFrameElement, kernel: Kernel, port: number): Promise<NoSwPreviewHandle> {
+  const blobUrls: string[] = [];
+  const mkBlob = (bytes: Uint8Array, type: string) => { const u = URL.createObjectURL(new Blob([bytes as BlobPart], { type })); blobUrls.push(u); return u; };
+
+  // 0. Wait for the dev server to bind + serve a real page (user runs it in the
+  //    terminal). x-lifo: no-server marks "port not bound yet".
+  const deadline = Date.now() + 180000;
+  let htmlRes = await vmFetch(kernel, port, '/');
+  while ((htmlRes.status !== 200 || htmlRes.headers['x-lifo'] === 'no-server') && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 800));
+    htmlRes = await vmFetch(kernel, port, '/');
+  }
+
+  // 1. App HTML from the dev server.
+  let html = new TextDecoder().decode(htmlRes.body);
+
+  // 2. Find the bundle <script src>, fetch it, rewrite static asset URLs to blobs.
+  const scriptMatch = html.match(/<script\s+src=["']([^"']+\.bundle[^"']*)["']/i);
+  if (scriptMatch) {
+    const bundleUrl = scriptMatch[1].startsWith('/') ? scriptMatch[1] : '/' + scriptMatch[1];
+    const bundleRes = await vmFetch(kernel, port, bundleUrl);
+    // Assets are handled at RUNTIME (img.src / FontFace interceptors in the
+    // shim) — RN builds /assets/ URLs at render time from registry metadata, so
+    // static bundle-string rewriting would only catch fragments.
+    const bundleBlob = mkBlob(bundleRes.body, 'application/javascript');
+    html = html.replace(scriptMatch[0], `<script src="${bundleBlob}"`);
+  }
+
+  // 3. Inject the router shim (URL virtualization) then the transport shim,
+  //    both before the bundle so they run first.
+  html = html.replace(/<head(\s[^>]*)?>/i, (h) => `${h}\n<script>${routerShim()}</script>\n<script>${shimScript(port)}</script>`);
+
+  // 4. Serve the HTML as a blob and point the iframe at it.
+  const htmlBlob = mkBlob(new TextEncoder().encode(html), 'text/html');
+
+  // 5. Reuse ServiceWorkerBridge with a postMessage adapter "port".
+  const bridge = new ServiceWorkerBridge(kernel.portRegistry);
+  const adapter = {
+    postMessage: (msg: unknown, transfer?: Transferable[]) => iframe.contentWindow?.postMessage(msg, '*', transfer ?? []),
+    onmessage: null as ((e: MessageEvent) => void) | null,
+    start() {}, close() {},
+  };
+  const onWindowMessage = (e: MessageEvent) => { if (e.source === iframe.contentWindow) adapter.onmessage?.(e); };
+  window.addEventListener('message', onWindowMessage);
+  bridge.attach(adapter as unknown as MessagePort);
+
+  iframe.src = htmlBlob;
+
+  return {
+    destroy() {
+      window.removeEventListener('message', onWindowMessage);
+      try { bridge.destroy(); } catch { /* ignore */ }
+      for (const u of blobUrls) URL.revokeObjectURL(u);
+    },
+  };
+}

--- a/apps/playground/src/lib/preview-nosw.ts
+++ b/apps/playground/src/lib/preview-nosw.ts
@@ -49,7 +49,7 @@ function vmFetch(kernel: Kernel, port: number, url: string, timeoutMs = 120000):
  * so it runs first. Tunnels the app's runtime fetch/XHR/WebSocket to the parent
  * over window.postMessage. `__LIFO_PORT` is stamped in by the host.
  */
-function shimScript(port: number): string {
+export function shimScript(port: number): string {
   return `(function(){
   var PORT=${port};
   var parentWin=window.parent, seq=0, pending=new Map(), wsConns=new Map();
@@ -139,13 +139,21 @@ function shimScript(port: number): string {
   window.XMLHttpRequest=ShimXHR;
   // --- WebSocket shim (HMR / React Refresh) ---
   var OrigWS=window.WebSocket;
-  function LifoWS(url,protocols){ var u; try{u=new URL(url,location.href);}catch(_){return new OrigWS(url,protocols);}
-    var sameHost=(u.host==='localhost:'+PORT||u.host===location.host)&&(u.protocol==='ws:'||u.protocol==='wss:');
-    if(!sameHost)return new OrigWS(url,protocols); var self=this;
-    this.url=u.href; this.readyState=0; this.bufferedAmount=0; this.protocol=Array.isArray(protocols)?(protocols[0]||''):(protocols||''); this.binaryType='blob';
+  function LifoWS(url,protocols){
+    var raw=String(url), pathSearch=null;
+    // Metro in a blob: iframe builds ws:///hot and ws:///message — window.location.host
+    // is '' in a blob document, so the URL has an empty authority (three slashes).
+    // Host detection is unreliable there (Node reads the path as the host; browsers
+    // vary), so match the raw string and tunnel to the preview PORT.
+    if(/^wss?:\\/\\/\\//i.test(raw)){ pathSearch=raw.replace(/^wss?:\\/\\//i,''); if(pathSearch.charAt(0)!=='/')pathSearch='/'+pathSearch; }
+    else { var u=null; try{u=new URL(raw,location.href);}catch(_){}
+      if(u&&(u.protocol==='ws:'||u.protocol==='wss:')&&(u.host==='localhost:'+PORT||u.host===location.host))pathSearch=u.pathname+u.search;
+      else return new OrigWS(url,protocols); }
+    var self=this;
+    this.url=raw; this.readyState=0; this.bufferedAmount=0; this.protocol=Array.isArray(protocols)?(protocols[0]||''):(protocols||''); this.binaryType='blob';
     this.onopen=null;this.onmessage=null;this.onclose=null;this.onerror=null; this._l={open:[],message:[],close:[],error:[]};
     this.connId='ws'+(seq++); wsConns.set(this.connId,this);
-    parentWin.postMessage({type:'ws-open',connId:this.connId,port:PORT,url:u.pathname+u.search,protocol:this.protocol},'*');
+    parentWin.postMessage({type:'ws-open',connId:this.connId,port:PORT,url:pathSearch,protocol:this.protocol},'*');
     this.__open=function(){self.readyState=1;self.__emit('open',{});};
     this.__msg=function(b64,binary){var data;if(binary){var buf=b64dec(b64).buffer;data=self.binaryType==='arraybuffer'?buf:new Blob([buf]);}else{data=new TextDecoder().decode(b64dec(b64));}self.__emit('message',{data:data});};
     this.__close=function(code,reason){if(self.readyState===3)return;self.readyState=3;self.__emit('close',{code:code||1000,reason:reason||'',wasClean:code===1000});};
@@ -168,8 +176,10 @@ function shimScript(port: number): string {
  * constructor, and the History stack, carrying the real route in location.hash
  * so the router reads a clean "/" path. Runs before the bundle.
  */
-function routerShim(): string {
+export function routerShim(bundleBlob: string, realBundlePath: string): string {
   return `(function() {
+  var BUNDLE_BLOB = ${JSON.stringify(bundleBlob)};
+  var BUNDLE_PATH = ${JSON.stringify(realBundlePath)};
   var rawHash = location.hash.slice(1) || '/';
   var hashIdx = rawHash.indexOf('#');
   var virtualHash = '';
@@ -183,7 +193,12 @@ function routerShim(): string {
   var virtualHref = virtualOrigin + virtualPathname + virtualSearch + virtualHash;
   try { Object.defineProperty(Document.prototype, 'URL', { get: function() { return virtualHref; }, configurable: true }); } catch(e) {}
   var OrigURL = URL;
-  var _URL = function(url, base) { var u = String(url); if (u.indexOf('blob:') === 0) u = virtualHref; if (arguments.length > 1) return new OrigURL(u, base); return new OrigURL(u); };
+  var _URL = function(url, base) { var u = String(url);
+    // Metro reads document.currentScript.src (our bundle blob) to build its HMR
+    // entry point — map that blob back to the real bundle URL so register-entrypoints
+    // matches the in-VM graph. Other blob: URLs are the virtual document route.
+    if (BUNDLE_BLOB && u === BUNDLE_BLOB) return new OrigURL(virtualOrigin + BUNDLE_PATH);
+    if (u.indexOf('blob:') === 0) u = virtualHref; if (arguments.length > 1) return new OrigURL(u, base); return new OrigURL(u); };
   _URL.prototype = OrigURL.prototype;
   _URL.createObjectURL = OrigURL.createObjectURL; _URL.revokeObjectURL = OrigURL.revokeObjectURL; _URL.canParse = OrigURL.canParse;
   window.URL = _URL;
@@ -243,20 +258,27 @@ export async function mountNoSwPreview(iframe: HTMLIFrameElement, kernel: Kernel
   let html = new TextDecoder().decode(htmlRes.body);
 
   // 2. Find the bundle <script src>, fetch it, rewrite static asset URLs to blobs.
+  //    We load the bundle from a blob: URL, so `document.currentScript.src` becomes
+  //    that blob. Metro derives its HMR entry point from currentScript.src
+  //    (getFullBundlerUrl), so we remember the REAL bundle path and map the blob
+  //    back to it in the router shim — otherwise register-entrypoints sends a blob:
+  //    URL Metro can't match and no HMR updates are ever pushed.
+  let bundleBlob = '';
+  let realBundlePath = '';
   const scriptMatch = html.match(/<script\s+src=["']([^"']+\.bundle[^"']*)["']/i);
   if (scriptMatch) {
-    const bundleUrl = scriptMatch[1].startsWith('/') ? scriptMatch[1] : '/' + scriptMatch[1];
-    const bundleRes = await vmFetch(kernel, port, bundleUrl);
+    realBundlePath = scriptMatch[1].startsWith('/') ? scriptMatch[1] : '/' + scriptMatch[1];
+    const bundleRes = await vmFetch(kernel, port, realBundlePath);
     // Assets are handled at RUNTIME (img.src / FontFace interceptors in the
     // shim) — RN builds /assets/ URLs at render time from registry metadata, so
     // static bundle-string rewriting would only catch fragments.
-    const bundleBlob = mkBlob(bundleRes.body, 'application/javascript');
+    bundleBlob = mkBlob(bundleRes.body, 'application/javascript');
     html = html.replace(scriptMatch[0], `<script src="${bundleBlob}"`);
   }
 
   // 3. Inject the router shim (URL virtualization) then the transport shim,
   //    both before the bundle so they run first.
-  html = html.replace(/<head(\s[^>]*)?>/i, (h) => `${h}\n<script>${routerShim()}</script>\n<script>${shimScript(port)}</script>`);
+  html = html.replace(/<head(\s[^>]*)?>/i, (h) => `${h}\n<script>${routerShim(bundleBlob, realBundlePath)}</script>\n<script>${shimScript(port)}</script>`);
 
   // 4. Serve the HTML as a blob and point the iframe at it.
   const htmlBlob = mkBlob(new TextEncoder().encode(html), 'text/html');

--- a/apps/playground/tests/preview-nosw-ws-shim.test.ts
+++ b/apps/playground/tests/preview-nosw-ws-shim.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { shimScript, routerShim } from '../src/lib/preview-nosw';
+
+/**
+ * The nosw preview runs the app inside a blob: iframe. In a blob document,
+ * `window.location.host` is '' — so Metro builds its HMR socket as `ws:///hot`
+ * (empty host, an invalid special-scheme URL). This test evaluates the injected
+ * WebSocket shim against that blob-iframe environment and asserts it still
+ * tunnels the empty-host socket to the preview port (regression for "no HMR on
+ * nosw with real Metro"). See preview-nosw.ts LifoWS.
+ */
+const PORT = 8081;
+
+function installShim() {
+  const posted: Array<Record<string, unknown>> = [];
+  const parentWin = { postMessage: (m: Record<string, unknown>) => posted.push(m) };
+  const FakeNode = function () {} as unknown as { prototype: Record<string, unknown> };
+  FakeNode.prototype.appendChild = function (n: unknown) { return n; };
+  FakeNode.prototype.insertBefore = function (n: unknown) { return n; };
+
+  const window: Record<string, unknown> = {
+    parent: parentWin,
+    addEventListener: () => {},
+    // blob: iframe — host/hostname/port are all empty; only origin is populated.
+    HTMLImageElement: undefined,
+    FontFace: undefined,
+    XMLHttpRequest: undefined,
+    fetch: () => Promise.resolve(),
+  };
+  const OrigWS = class NativeWS { constructor(public url: string, public protocols?: unknown) {} };
+  window.WebSocket = OrigWS;
+  const location = { href: 'blob:http://localhost:5173/uuid-1234', host: '', hostname: '', port: '', origin: 'http://localhost:5173', protocol: 'blob:' };
+
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  new Function('window', 'location', 'Node', 'URL', 'Map', 'TextEncoder', 'TextDecoder', 'btoa', 'atob',
+    shimScript(PORT),
+  )(window, location, FakeNode, URL, Map, TextEncoder, TextDecoder, btoa, atob);
+
+  return { WebSocket: window.WebSocket as new (url: string, p?: unknown) => Record<string, unknown>, posted, OrigWS };
+}
+
+describe('preview-nosw ws shim (blob iframe)', () => {
+  let env: ReturnType<typeof installShim>;
+  beforeEach(() => { env = installShim(); });
+
+  it('tunnels Metro empty-host HMR socket ws:///hot to the preview port', () => {
+    const ws = new env.WebSocket('ws:///hot') as Record<string, unknown> & { connId: string };
+    expect(ws instanceof (env.OrigWS as never)).toBe(false);
+    const open = env.posted.find((m) => m.type === 'ws-open');
+    expect(open).toBeTruthy();
+    expect(open!.url).toBe('/hot');
+    expect(open!.port).toBe(PORT);
+  });
+
+  it('tunnels the empty-host /message socket too', () => {
+    const ws = new env.WebSocket('ws:///message') as Record<string, unknown> & { connId: string };
+    expect(ws instanceof (env.OrigWS as never)).toBe(false);
+    const open = env.posted.find((m) => m.type === 'ws-open');
+    expect(open!.url).toBe('/message');
+  });
+
+  it('still tunnels an explicit localhost:PORT socket', () => {
+    new env.WebSocket(`ws://localhost:${PORT}/hot?x=1`);
+    const open = env.posted.find((m) => m.type === 'ws-open');
+    expect(open!.url).toBe('/hot?x=1');
+    expect(open!.port).toBe(PORT);
+  });
+
+  it('leaves genuinely cross-origin sockets on the native implementation', () => {
+    const ws = new env.WebSocket('wss://example.com/socket');
+    expect(ws instanceof (env.OrigWS as never)).toBe(true);
+    expect(env.posted.find((m) => m.type === 'ws-open')).toBeUndefined();
+  });
+});
+
+/**
+ * Metro derives its HMR entry point from document.currentScript.src (the bundle
+ * blob in nosw). The router shim must map that blob back to the real bundle URL,
+ * or register-entrypoints sends an unmatched blob: URL and no updates are pushed.
+ */
+describe('preview-nosw router shim (bundle url mapping)', () => {
+  function evalRouterShim(bundleBlob: string, realBundlePath: string) {
+    const window: Record<string, unknown> = {};
+    const history: Record<string, unknown> = { replaceState: () => {}, pushState: () => {}, go: () => {}, back: () => {}, forward: () => {}, state: null };
+    const location = { hash: '', origin: 'http://localhost:5173', href: 'blob:http://localhost:5173/doc-uuid' };
+    const FakeDoc = function () {} as unknown as { prototype: Record<string, unknown> };
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    new Function('window', 'history', 'location', 'Document', 'URL', 'Object', 'PopStateEvent',
+      routerShim(bundleBlob, realBundlePath),
+    )(window, history, location, FakeDoc, URL, Object, class {});
+    return window.URL as (u: string) => URL;
+  }
+
+  it('maps the bundle blob back to the real bundle URL for HMR registration', () => {
+    const blob = 'blob:http://localhost:5173/bundle-uuid-9';
+    const path = '/index.bundle?platform=web&dev=true&hot=false&transform.engine=hermes';
+    const ShimURL = evalRouterShim(blob, path);
+    expect(new ShimURL(blob).toString()).toBe('http://localhost:5173' + path);
+  });
+
+  it('still virtualizes other blob: URLs to the clean route (not the bundle URL)', () => {
+    const ShimURL = evalRouterShim('blob:http://localhost:5173/bundle-uuid-9', '/index.bundle?platform=web');
+    // a different blob (the document) resolves to the virtual origin root, not /index.bundle
+    expect(new ShimURL('blob:http://localhost:5173/other').pathname).toBe('/');
+  });
+});

--- a/bench/debug-metro-hmr.mjs
+++ b/bench/debug-metro-hmr.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * debug-metro-hmr.mjs — reproduce issue 2 (real Metro: 2nd edit doesn't HMR).
+ * Connects to Metro's /hot ws via ServiceWorkerBridge, registers, edits App
+ * TWICE, and logs the ws messages Metro pushes for each edit. If edit#1 pushes
+ * updates but edit#2 doesn't → watcher/Metro side; if both push → delivery/client.
+ */
+import http from 'node:http';
+import { Sandbox, ServiceWorkerBridge } from '../packages/core/dist/index.js';
+
+process.on('unhandledRejection', (e) => console.log('[REJ]', (e && e.message) || e));
+const CORS = 8812, PORT = 8081, APP = '/home/user/my-app';
+const server = http.createServer((q, r) => { (async () => { const t = new URL(q.url, 'http://x').searchParams.get('url'); if (!t) { r.statusCode = 400; return r.end('x'); } const u = await fetch(t, { headers: { accept: '*/*', 'user-agent': 'lifo' } }); r.statusCode = u.status; r.end(Buffer.from(await u.arrayBuffer())); })().catch((e) => { r.statusCode = 502; r.end(e.message); }); });
+await new Promise((r) => server.listen(CORS, r));
+const out = (s) => process.stdout.write(s);
+const log = (...a) => console.log('[t]', ...a);
+
+const sb = await Sandbox.create({ files: {}, cwd: '/home/user', persist: false, env: { LIFO_CORS_PROXY: `http://localhost:${CORS}/_cors?url=`, EXPO_NO_TELEMETRY: '1', BROWSER: 'none' } });
+await sb.commands.run(`npx create-expo-app@latest ${APP} --template blank --no-install`, { cwd: '/home/user', onStdout: out, onStderr: out, timeout: 300000 });
+await sb.commands.run('npm install', { cwd: APP, onStdout: out, onStderr: out, timeout: 600000 });
+await sb.commands.run('npm install react-dom react-native-web@~0.21.0', { cwd: APP, onStdout: out, onStderr: out, timeout: 600000 });
+sb.shell.execute(`node ${APP}/node_modules/expo/bin/cli start --web ${APP}`, { cwd: APP, env: { ...sb.env, EXPO_OFFLINE: '1' }, onStdout: out, onStderr: out }).catch(() => {});
+for (let i = 0; i < 300; i++) { if (sb.kernel.portRegistry.has(PORT)) break; await new Promise((r) => setTimeout(r, 400)); }
+log('port bound; triggering first bundle…');
+// GET / then the bundle so Metro builds the graph (needed before HMR registration).
+const req = (url) => new Promise((res) => { const h = sb.kernel.portRegistry.get(PORT); const v = { statusCode: 200, headers: {}, body: '' }; h({ method: 'GET', url, headers: { host: `localhost:${PORT}` }, body: '' }, v); v._donePromise ? v._donePromise.then(() => res(v)) : res(v); });
+const homeRes = await req('/');
+const homeHtml = homeRes.bodyBytes ? new TextDecoder().decode(homeRes.bodyBytes) : homeRes.body;
+const m = homeHtml.match(/<script\s+src=["']([^"']+\.bundle[^"']*)["']/i);
+const bundleUrl = m ? m[1] : '/index.bundle?platform=web&dev=true';
+log('exact bundle url:', bundleUrl);
+await req(bundleUrl);
+log('bundle built. opening /hot ws via bridge…');
+
+// Bridge + postMessage adapter (same transport the preview uses).
+const inbox = [];
+const adapter = { postMessage: (m) => inbox.push(m), onmessage: null, start() {}, close() {} };
+const bridge = new ServiceWorkerBridge(sb.kernel.portRegistry);
+bridge.attach(adapter);
+const send = (m) => adapter.onmessage?.({ data: m });
+const CONN = 'c1';
+let msgs = [];
+// drain adapter inbox → collect ws-message
+const drain = setInterval(() => { while (inbox.length) { const m = inbox.shift(); if (m.type === 'ws-opened') log('ws-opened'); else if (m.type === 'ws-message') { try { msgs.push(JSON.parse(atob(m.data))); } catch { msgs.push('<binary>'); } } else if (m.type === 'ws-close') log('ws-close'); } }, 50);
+
+send({ type: 'ws-open', connId: CONN, port: PORT, url: '/hot', protocol: '' });
+await new Promise((r) => setTimeout(r, 1000));
+// register entry point (Metro HMRClient protocol)
+const absEntry = `http://localhost:${PORT}${bundleUrl}`;
+log('register entry:', absEntry);
+send({ type: 'ws-send', connId: CONN, data: btoa(JSON.stringify({ type: 'register-entrypoints', entryPoints: [absEntry] })), binary: false });
+await new Promise((r) => setTimeout(r, 1500));
+log('after register, msgs:', msgs.map((m) => m && m.type));
+
+async function edit(marker) {
+  msgs = [];
+  sb.kernel.vfs.writeFile(`${APP}/App.tsx`, `import { Text, View } from 'react-native';\nexport default function App(){ return (<View><Text>${marker}</Text></View>); }\n`);
+  // some templates use App.js; write both to be safe
+  try { sb.kernel.vfs.writeFile(`${APP}/App.js`, `import { Text, View } from 'react-native';\nexport default function App(){ return (<View><Text>${marker}</Text></View>); }\n`); } catch {}
+  await new Promise((r) => setTimeout(r, 4000));
+  return msgs.map((m) => (m && m.type) || m);
+}
+
+log('--- EDIT #1 ---');
+const e1 = await edit('HMR_V1');
+log('edit#1 messages:', JSON.stringify(e1));
+log('--- EDIT #2 ---');
+const e2 = await edit('HMR_V2');
+log('edit#2 messages:', JSON.stringify(e2));
+
+clearInterval(drain);
+console.log('\n===== VERDICT =====');
+console.log('edit#1 update pushed:', e1.includes('update') || e1.includes('update-start'));
+console.log('edit#2 update pushed:', e2.includes('update') || e2.includes('update-start'));
+server.close();
+process.exit(0);

--- a/bench/debug-metro-jsdom-hmr.mjs
+++ b/bench/debug-metro-jsdom-hmr.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * debug-metro-jsdom-hmr.mjs — reproduce issue 2 with the REAL Metro web runtime.
+ *
+ * Boots `expo start --web` in the VM, then runs the actual served bundle under
+ * jsdom with a WebSocket shim tunneled through ServiceWorkerBridge (the exact
+ * transport the preview uses) and a fetch shim tunneled to the VM portRegistry.
+ * Then edits App TWICE and checks whether the jsdom DOM reflects each edit.
+ *
+ * If DOM shows V1 but not V2 -> the real Metro HMR runtime fails to APPLY the
+ * 2nd update (in-bundle/runtime bug). If both -> browser-only, not the runtime.
+ */
+import http from 'node:http';
+import { createRequire } from 'node:module';
+import { Sandbox, ServiceWorkerBridge } from '../packages/core/dist/index.js';
+const require = createRequire('/tmp/bmrepro/');
+const { JSDOM } = require('jsdom');
+
+process.on('unhandledRejection', (e) => console.log('[REJ]', (e && e.message) || e));
+const CORS = 8813, PORT = 8081, APP = '/home/user/my-app';
+const out = (s) => process.stdout.write(s);
+const log = (...a) => console.log('[t]', ...a);
+
+// CORS proxy for the VM's own outbound package fetches.
+const server = http.createServer((q, r) => { (async () => { const t = new URL(q.url, 'http://x').searchParams.get('url'); if (!t) { r.statusCode = 400; return r.end('x'); } const u = await fetch(t, { headers: { accept: '*/*', 'user-agent': 'lifo' } }); r.statusCode = u.status; r.end(Buffer.from(await u.arrayBuffer())); })().catch((e) => { r.statusCode = 502; r.end(e.message); }); });
+await new Promise((r) => server.listen(CORS, r));
+
+const sb = await Sandbox.create({ files: {}, cwd: '/home/user', persist: false, env: { LIFO_CORS_PROXY: `http://localhost:${CORS}/_cors?url=`, EXPO_NO_TELEMETRY: '1', BROWSER: 'none' } });
+await sb.commands.run(`npx create-expo-app@latest ${APP} --template blank --no-install`, { cwd: '/home/user', onStdout: out, onStderr: out, timeout: 300000 });
+await sb.commands.run('npm install', { cwd: APP, onStdout: out, onStderr: out, timeout: 600000 });
+const reactPkgRaw = sb.kernel.vfs.readFile(`${APP}/node_modules/react/package.json`);
+const reactVer = JSON.parse(typeof reactPkgRaw === 'string' ? reactPkgRaw : new TextDecoder().decode(reactPkgRaw)).version;
+log('react version:', reactVer);
+await sb.commands.run(`npm install react-dom@${reactVer} react-native-web@~0.21.0`, { cwd: APP, onStdout: out, onStderr: out, timeout: 600000 });
+sb.shell.execute(`node ${APP}/node_modules/expo/bin/cli start --web ${APP}`, { cwd: APP, env: { ...sb.env, EXPO_OFFLINE: '1' }, onStdout: out, onStderr: out }).catch(() => {});
+for (let i = 0; i < 300; i++) { if (sb.kernel.portRegistry.has(PORT)) break; await new Promise((r) => setTimeout(r, 400)); }
+if (!sb.kernel.portRegistry.has(PORT)) { console.log('port never bound'); process.exit(2); }
+log('port bound.');
+
+// vm request helper (same contract debug-metro-hmr.mjs proved works).
+const vmReq = (url, method = 'GET') => new Promise((res) => { const h = sb.kernel.portRegistry.get(PORT); const v = { statusCode: 200, headers: {}, body: '' }; h({ method, url, headers: { host: `localhost:${PORT}` }, body: '' }, v); v._donePromise ? v._donePromise.then(() => res(v)) : res(v); });
+const bodyOf = (v) => (v.bodyBytes ? new TextDecoder().decode(v.bodyBytes) : (typeof v.body === 'string' ? v.body : new TextDecoder().decode(v.body || new Uint8Array())));
+
+const home = await vmReq('/');
+const homeHtml = bodyOf(home);
+const m = homeHtml.match(/<script\s+src=["']([^"']+\.bundle[^"']*)["']/i);
+let bundleUrl = m ? m[1] : '/index.bundle?platform=web&dev=true';
+bundleUrl = /hot=false/.test(bundleUrl) ? bundleUrl.replace('hot=false', 'hot=true') : (/hot=/.test(bundleUrl) ? bundleUrl : bundleUrl + '&hot=true');
+log('bundle url (hot forced):', bundleUrl);
+const bres = await vmReq(bundleUrl);
+const bundle = bodyOf(bres);
+log('bundle bytes:', bundle.length);
+
+// ── jsdom with bridge-backed WebSocket + VM-backed fetch ──
+const dom = new JSDOM(homeHtml.replace(/<script[^>]*\.bundle[^>]*><\/script>/i, ''), { runScripts: 'outside-only', pretendToBeVisual: true, url: `http://localhost:${PORT}/` });
+const { window } = dom;
+if (!window.document.getElementById('root')) { const d = window.document.createElement('div'); d.id = 'root'; window.document.body.appendChild(d); }
+const errors = [];
+window.onerror = (msg, s, l, c, err) => errors.push('onerror: ' + (err && err.stack ? err.stack.split('\n').slice(0, 3).join('\n') : msg));
+window.addEventListener('unhandledrejection', (e) => errors.push('unhandledrejection: ' + (e.reason && e.reason.stack || e.reason)));
+
+// fetch shim → VM portRegistry (same-origin) or real network otherwise.
+window.fetch = async (input, init) => {
+  const url = typeof input === 'string' ? input : input.url;
+  try {
+    const u = new URL(url, `http://localhost:${PORT}/`);
+    if (u.host === `localhost:${PORT}`) {
+      const v = await vmReq(u.pathname + u.search, (init && init.method) || 'GET');
+      const body = bodyOf(v);
+      return { ok: v.statusCode < 400, status: v.statusCode, headers: { get: () => null }, text: async () => body, json: async () => JSON.parse(body) };
+    }
+  } catch { /* fall through */ }
+  return fetch(url, init);
+};
+
+// WebSocket shim → ServiceWorkerBridge (mirrors preview-nosw transport).
+const bridge = new ServiceWorkerBridge(sb.kernel.portRegistry);
+const wsByConn = new Map();
+let phase = 'init';
+const inboundLog = [];
+const adapter = {
+  onmessage: null,
+  // async delivery mirrors real window.postMessage (never synchronous inside
+  // the WebSocket constructor), so the client assigns .onopen before it fires.
+  postMessage: (msg) => setTimeout(() => {
+    const ws = wsByConn.get(msg.connId);
+    if (!ws) return;
+    if (msg.type === 'ws-opened') { ws.readyState = 1; ws.onopen && ws.onopen({ type: 'open' }); (ws._l.open || []).forEach((f) => f({ type: 'open' })); }
+    else if (msg.type === 'ws-message') {
+      const data = msg.binary ? Buffer.from(msg.data, 'base64').buffer : Buffer.from(msg.data, 'base64').toString('utf8');
+      // record the frame TYPE the /hot client receives, tagged by phase
+      const path = (() => { try { return new URL(ws.url).pathname; } catch { return '?'; } })();
+      let t = '<bin>'; if (typeof data === 'string') { try { t = JSON.parse(data).type; } catch { t = data.slice(0, 20); } }
+      inboundLog.push(`${phase} ${path} <- ${t}`);
+      const ev = { data }; ws.onmessage && ws.onmessage(ev); (ws._l.message || []).forEach((f) => f(ev));
+    }
+    else if (msg.type === 'ws-close') { ws.readyState = 3; ws.onclose && ws.onclose({ code: 1006 }); (ws._l.close || []).forEach((f) => f({ code: 1006 })); }
+  }, 0),
+  start() {}, close() {},
+};
+bridge.attach(adapter);
+const bridgeOnMsg = adapter.onmessage;
+adapter.onmessage = (e) => { const m = e.data; if (m && (m.type === 'ws-open' || m.type === 'ws-send' || m.type === 'ws-close')) { let t = ''; if (m.type === 'ws-send') { try { t = JSON.parse(Buffer.from(m.data, 'base64').toString('utf8')).type; } catch { t = '<bin/parse>'; } } inboundLog.push(`${phase} ${m.type}${t ? ' ' + t : ''} conn=${m.connId}${m.url ? ' ' + m.url : ''}`); } return bridgeOnMsg(e); };
+let wsSeq = 0;
+class LifoWS {
+  constructor(url) { const u = new URL(url, `http://localhost:${PORT}/`); this.url = u.href; this.readyState = 0; this.onopen = this.onmessage = this.onclose = this.onerror = null; this._l = { open: [], message: [], close: [], error: [] }; this.connId = 'ws' + (wsSeq++); wsByConn.set(this.connId, this); adapter.onmessage({ data: { type: 'ws-open', connId: this.connId, port: PORT, url: u.pathname + u.search, protocol: '' } }); }
+  send(data) { const u8 = typeof data === 'string' ? new TextEncoder().encode(data) : new Uint8Array(data.buffer || data); adapter.onmessage({ data: { type: 'ws-send', connId: this.connId, data: Buffer.from(u8).toString('base64'), binary: typeof data !== 'string' } }); }
+  close() { if (this.readyState >= 2) return; this.readyState = 2; adapter.onmessage({ data: { type: 'ws-close', connId: this.connId } }); }
+  addEventListener(t, fn) { (this._l[t] || (this._l[t] = [])).push(fn); }
+  removeEventListener(t, fn) { const a = this._l[t]; if (a) { const i = a.indexOf(fn); if (i >= 0) a.splice(i, 1); } }
+}
+LifoWS.CONNECTING = 0; LifoWS.OPEN = 1; LifoWS.CLOSING = 2; LifoWS.CLOSED = 3;
+window.WebSocket = LifoWS;
+
+// run the bundle
+try { window.eval(bundle); } catch (e) { errors.push('THROW: ' + (e.stack || e.message).split('\n').slice(0, 5).join('\n')); }
+await new Promise((r) => setTimeout(r, 3000));
+const rootText = () => (window.document.getElementById('root')?.textContent || '');
+log('initial render text:', JSON.stringify(rootText().slice(0, 120)));
+log('ws connections opened:', wsByConn.size, [...wsByConn.values()].map((w) => new URL(w.url).pathname));
+
+async function edit(marker, ph) {
+  phase = ph;
+  sb.kernel.vfs.writeFile(`${APP}/App.js`, `import { Text, View } from 'react-native';\nexport default function App(){ return (<View><Text>${marker}</Text></View>); }\n`);
+  for (let i = 0; i < 30; i++) { await new Promise((r) => setTimeout(r, 300)); if (rootText().includes(marker)) return true; }
+  return false;
+}
+
+log('--- EDIT #1 (JSDOM_V1) ---');
+const ok1 = await edit('JSDOM_V1', 'edit1');
+log('edit#1 reflected in DOM:', ok1, '| text:', JSON.stringify(rootText().slice(0, 120)));
+log('--- EDIT #2 (JSDOM_V2) ---');
+const ok2 = await edit('JSDOM_V2', 'edit2');
+log('edit#2 reflected in DOM:', ok2, '| text:', JSON.stringify(rootText().slice(0, 120)));
+
+console.log('\n===== /hot + /message inbound frame timeline =====');
+console.log(inboundLog.join('\n'));
+
+console.log('\n===== errors =====');
+console.log(errors.length ? errors.slice(0, 4).join('\n---\n') : '(none)');
+console.log('\n===== VERDICT =====');
+console.log('edit#1 applied (live HMR):', ok1);
+console.log('edit#2 applied (live HMR):', ok2);
+console.log(ok1 && !ok2 ? '>>> REPRODUCED: real Metro runtime applies #1 but NOT #2 (in-runtime bug)'
+  : ok1 && ok2 ? '>>> Both applied — issue 2 is browser-only (jsdom cannot repro)'
+  : '>>> Neither applied — jsdom cannot run Metro React Refresh (inconclusive)');
+server.close();
+process.exit(0);

--- a/bench/dump-metro-hmr-url.mjs
+++ b/bench/dump-metro-hmr-url.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/** Boot expo start --web, fetch the bundle, and print how it builds the HMR ws URL. */
+import http from 'node:http';
+import { Sandbox } from '../packages/core/dist/index.js';
+const CORS = 8814, PORT = 8081, APP = '/home/user/my-app';
+const out = (s) => process.stdout.write(s);
+const server = http.createServer((q, r) => { (async () => { const t = new URL(q.url, 'http://x').searchParams.get('url'); if (!t) { r.statusCode = 400; return r.end('x'); } const u = await fetch(t, { headers: { accept: '*/*', 'user-agent': 'lifo' } }); r.statusCode = u.status; r.end(Buffer.from(await u.arrayBuffer())); })().catch((e) => { r.statusCode = 502; r.end(e.message); }); });
+await new Promise((r) => server.listen(CORS, r));
+const sb = await Sandbox.create({ files: {}, cwd: '/home/user', persist: false, env: { LIFO_CORS_PROXY: `http://localhost:${CORS}/_cors?url=`, EXPO_NO_TELEMETRY: '1', BROWSER: 'none' } });
+await sb.commands.run(`npx create-expo-app@latest ${APP} --template blank --no-install`, { cwd: '/home/user', onStdout: out, onStderr: out, timeout: 300000 });
+await sb.commands.run('npm install', { cwd: APP, onStdout: out, onStderr: out, timeout: 600000 });
+const rv = JSON.parse(new TextDecoder().decode(sb.kernel.vfs.readFile(`${APP}/node_modules/react/package.json`))).version;
+await sb.commands.run(`npm install react-dom@${rv} react-native-web@~0.21.0`, { cwd: APP, onStdout: out, onStderr: out, timeout: 600000 });
+sb.shell.execute(`node ${APP}/node_modules/expo/bin/cli start --web ${APP}`, { cwd: APP, env: { ...sb.env, EXPO_OFFLINE: '1' }, onStdout: out, onStderr: out }).catch(() => {});
+for (let i = 0; i < 300; i++) { if (sb.kernel.portRegistry.has(PORT)) break; await new Promise((r) => setTimeout(r, 400)); }
+const req = (url) => new Promise((res) => { const h = sb.kernel.portRegistry.get(PORT); const v = { statusCode: 200, headers: {}, body: '' }; h({ method: 'GET', url, headers: { host: `localhost:${PORT}` }, body: '' }, v); v._donePromise ? v._donePromise.then(() => res(v)) : res(v); });
+const bodyOf = (v) => (v.bodyBytes ? new TextDecoder().decode(v.bodyBytes) : v.body);
+const home = bodyOf(await req('/'));
+const bu = (home.match(/<script\s+src=["']([^"']+\.bundle[^"']*)["']/i) || [])[1] || '/index.bundle?platform=web&dev=true&hot=true';
+console.log('\n\nBUNDLE URL:', bu);
+const bundle = bodyOf(await req(bu.replace('hot=false', 'hot=true')));
+console.log('bundle bytes:', bundle.length);
+// find WebSocket construction sites and their URL expression
+const lines = bundle.split('\n');
+const hits = [];
+lines.forEach((ln, i) => { if (/new WebSocket\(|getHMRUrl|WebSocketHMRClient|\/hot|createHMRClient|hmrServerUrl|getDevServer|serverHost|hmrPort/.test(ln)) hits.push([i, ln]); });
+function block(a, b) { console.log(`\n----- L${a}-${b} -----`); for (let i = a - 1; i < b && i < lines.length; i++) console.log(`L${i + 1}| ${lines[i].trim().slice(0, 170)}`); }
+console.log('\n===== entry-point / bundle-url construction =====');
+block(1703, 1710);   // setup() pendingEntryPoints.push
+block(3862, 3872);   // currentScript.src -> bundleUrl
+block(4803, 4820);   // getBundleUrl.web.ts
+block(4885, 4902);   // registerBundle(requestUrl) caller
+block(4983, 4996);   // currentSrc
+server.close();
+process.exit(0);

--- a/bench/gen-keepset.mjs
+++ b/bench/gen-keepset.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * gen-keepset.mjs — DETERMINISTIC node_modules keep-set for a Lifo/Expo box.
+ *
+ * Single generation pass (no error-iteration):
+ *   keep = files READ  ∪  files exists()-probed-and-present  ∪  every package.json
+ * traced across BOTH a production `expo export` (full graph) AND a dev
+ * `expo start --web` bundle (dev-only runtime). Rationale:
+ *   - Metro's crawl uses readdir/stat, NOT exists(); so an exists()===true on an
+ *     UNREAD file is a require.resolve() target (config polyfills, transform
+ *     worker, ...) — exactly the files a reads-only prune wrongly drops.
+ *   - export gives the full production graph; dev adds react-refresh/dev runtime.
+ *
+ * Then it VALIDATES: prune to the keep-set, restore a fresh box, clear cache,
+ * cold `expo start --web` bundle, assert byte-identical output. No iteration.
+ *
+ *   node bench/gen-keepset.mjs
+ */
+import { performance } from 'node:perf_hooks';
+import http from 'node:http';
+import zlib from 'node:zlib';
+import { Sandbox, exportVfsSnapshot } from '../packages/core/dist/index.js';
+
+const T0 = performance.now();
+const log = (...a) => console.log(`[${((performance.now() - T0) / 1000).toFixed(1)}s]`, ...a);
+process.on('unhandledRejection', (e) => log('REJ:', e?.message || e));
+process.on('uncaughtException', (e) => log('UNCAUGHT:', e?.message || e));
+
+const CORS = 8795, PORT = 8081, APP = '/home/user/my-app';
+const isNM = (f) => f.includes('/node_modules/');
+const isPkgJson = (f) => f.endsWith('/package.json');
+const isCache = (f) => f.startsWith('/tmp/') || f.includes('/.expo/') || f.includes('/.cache/') || f.includes('/.metro') || f.includes('/dist/');
+const gz = (b) => zlib.gzipSync(b, { level: 6 }).length;
+const MB = (n) => (n / 1048576).toFixed(2) + ' MB';
+const out = (s) => process.stdout.write(s);
+
+function startCors() {
+  const server = http.createServer((req, res) => {
+    (async () => {
+      const t = new URL(req.url, 'http://localhost').searchParams.get('url');
+      if (!t) { res.statusCode = 400; return res.end('x'); }
+      const up = await fetch(t, { headers: { accept: '*/*', 'user-agent': 'lifo' } });
+      res.statusCode = up.status; res.end(Buffer.from(await up.arrayBuffer()));
+    })().catch((e) => { res.statusCode = 502; res.end(e.message); });
+  });
+  return new Promise((r) => server.listen(CORS, () => r(server)));
+}
+
+// reads = readFile; existsHits = exists()===true on nm; miss = absent probes.
+function instrument(vfs) {
+  const reads = new Set(), existsHits = new Set(), miss = new Set();
+  const rf = vfs.readFile;
+  vfs.readFile = function (p, ...r) { if (typeof p === 'string') reads.add(p); try { return rf.call(this, p, ...r); } catch (e) { if (typeof p === 'string' && isNM(p)) miss.add(p); throw e; } };
+  const ex = vfs.exists;
+  vfs.exists = function (p, ...r) { const res = ex.call(this, p, ...r); if (typeof p === 'string' && isNM(p)) (res ? existsHits : miss).add(p); return res; };
+  return { reads, existsHits, miss };
+}
+
+function vmRequest(kernel, port, url, timeoutMs = 120000) {
+  const h = kernel.portRegistry.get(port); if (!h) throw new Error(`no handler ${port}`);
+  const vRes = { statusCode: 200, headers: {}, body: '' };
+  h({ method: 'GET', url, headers: { host: `localhost:${port}` }, body: '' }, vRes);
+  const fin = () => ({ status: vRes.statusCode, bytes: vRes.bodyBytes ? vRes.bodyBytes.byteLength : Buffer.byteLength(vRes.body || '') });
+  if (vRes._donePromise) return Promise.race([vRes._donePromise.then(fin), new Promise((_, j) => setTimeout(() => j(new Error('timeout')), timeoutMs))]);
+  return Promise.resolve(fin());
+}
+async function waitForPort(kernel, port, ms) { const s = performance.now(); while (performance.now() - s < ms) { if (kernel.portRegistry.has(port)) return true; await new Promise((r) => setTimeout(r, 400)); } return false; }
+function allFiles(vfs, dir = '/', acc = []) { let e; try { e = vfs.readdir(dir); } catch { return acc; } for (const x of e) { if (dir === '/proc' || dir === '/dev') continue; const f = dir === '/' ? `/${x.name}` : `${dir}/${x.name}`; let st; try { st = vfs.stat(f); } catch { continue; } if (st.type === 'directory') allFiles(vfs, f, acc); else acc.push(f); } return acc; }
+function mkdirp(vfs, p) { let c = ''; for (const s of p.split('/').filter(Boolean)) { c += '/' + s; if (!vfs.exists(c)) vfs.mkdir(c); } }
+const cli = `${APP}/node_modules/@expo/cli/build/bin/cli`;
+
+async function main() {
+  const cors = await startCors();
+  const env = { LIFO_CORS_PROXY: `http://localhost:${CORS}/_cors?url=`, EXPO_NO_TELEMETRY: '1', BROWSER: 'none' };
+
+  // ── GENERATION box ──────────────────────────────────────────────────────────
+  log('GEN: boot + scaffold + install…');
+  const A = await Sandbox.create({ files: {}, cwd: '/home/user', persist: false, env });
+  const tr = instrument(A.kernel.vfs);
+  const ro = { cwd: '/home/user', onStdout: out, onStderr: out, timeout: 600000 };
+  await A.commands.run(`npx create-expo-app@latest ${APP} --template blank --no-install`, ro);
+  await A.commands.run('npm install', { ...ro, cwd: APP });
+  await A.commands.run('npm install react-dom react-native-web@~0.21.0', { ...ro, cwd: APP });
+  tr.reads.clear(); tr.existsHits.clear(); tr.miss.clear();
+
+  const MODE = process.env.MODE || 'both'; // both | dev | export | exportdev
+  if (MODE !== 'dev') {
+    const devFlag = MODE === 'exportdev' ? '--dev ' : '';
+    log(`GEN: expo export ${devFlag}--platform web…`);
+    await A.commands.run(`node ${cli} export ${devFlag}--platform web --output-dir ${APP}/dist ${APP}`,
+      { cwd: APP, env: { ...A.env, EXPO_OFFLINE: '1' }, onStdout: out, onStderr: out, timeout: 300000 })
+      .catch((e) => log('export ended:', e.message)); // post-bundle writer may crash; reads already captured
+  } else log('GEN: skipping export (MODE=dev)');
+
+  if (MODE !== 'exportdev' && MODE !== 'export') {
+    log('GEN: expo start --web dev bundle (dev runtime)…');
+    A.shell.execute(`node ${cli} start --web ${APP}`, { cwd: APP, env: { ...A.env, EXPO_OFFLINE: '1' }, onStdout: out, onStderr: out }).catch((e) => log('start ended:', e.message));
+    if (await waitForPort(A.kernel, PORT, 120000)) {
+      await vmRequest(A.kernel, PORT, '/').catch(() => {});
+      const a1 = await vmRequest(A.kernel, PORT, '/index.bundle?platform=web&dev=true&hot=false').catch((e) => ({ status: 0, bytes: 0, err: e.message }));
+      log(`GEN dev bundle → ${a1.status}, ${a1.bytes} bytes`);
+    } else log('GEN dev server never bound');
+  } else log(`GEN: skipping dev-server trace (MODE=${MODE})`);
+  // reference bytes come from box B's validation regardless.
+  globalThis.__aBytes = globalThis.__aBytes || 0;
+
+  // ── Compute keep-set (deterministic) ────────────────────────────────────────
+  const allA = allFiles(A.kernel.vfs);
+  const nmAll = allA.filter(isNM);
+  const existSet = new Set(nmAll);
+  const keepNm = new Set();
+  for (const f of tr.reads) if (isNM(f) && existSet.has(f)) keepNm.add(f);
+  for (const f of tr.existsHits) if (existSet.has(f)) keepNm.add(f);   // resolve-only targets
+  for (const f of nmAll) if (isPkgJson(f)) keepNm.add(f);
+  log(`keep-set: reads+exists+pkgjson = ${keepNm.size} nm files of ${nmAll.length} (${(keepNm.size / nmAll.length * 100).toFixed(1)}%)`);
+
+  const nonNm = allA.filter((f) => !isNM(f) && !isCache(f)); // app source, no cache/dist
+  const readBytes = (f) => { try { return A.kernel.vfs.readFile(f); } catch { return null; } };
+
+  // ── Static import-closure: add relative-import targets of kept JS files ──────
+  // Metro resolves statically-imported files via its crawl file-map without
+  // read()/exists() (e.g. renderApplication -> ./AppContainer), so trace misses
+  // them. Close over relative specifiers deterministically.
+  const EXTS = ['.js', '.jsx', '.ts', '.tsx', '.json', '.cjs', '.mjs', '.web.js', '.web.jsx', '.web.ts', '.web.tsx',
+    '/index.js', '/index.jsx', '/index.ts', '/index.tsx', '/index.web.js'];
+  const vfsA = A.kernel.vfs;
+  const isFile = (p) => { try { return vfsA.stat(p).type === 'file'; } catch { return false; } };
+  const norm = (dir, spec) => { const st = []; for (const p of (dir + '/' + spec).split('/')) { if (p === '..') st.pop(); else if (p && p !== '.') st.push(p); } return '/' + st.join('/'); };
+  const specRe = /(?:require\(|import\s+[^'"]*?from\s+|import\(|export\s+[^'"]*?from\s+)\s*['"](\.[^'"]+)['"]/g;
+  const decoder = new TextDecoder();
+  let frontier = [...keepNm].filter((f) => /\.(js|jsx|ts|tsx|cjs|mjs)$/.test(f));
+  let added = 0;
+  while (frontier.length) {
+    const next = [];
+    for (const f of frontier) {
+      const data = readBytes(f); if (!data) continue;
+      const src = decoder.decode(data);
+      const dir = f.slice(0, f.lastIndexOf('/'));
+      for (const m of src.matchAll(specRe)) {
+        const base = norm(dir, m[1]);
+        for (const e of ['', ...EXTS]) { const c = base + e; if (isFile(c) && !keepNm.has(c)) { keepNm.add(c); added++; if (/\.(js|jsx|ts|tsx|cjs|mjs)$/.test(c)) next.push(c); } }
+      }
+    }
+    frontier = next;
+  }
+  log(`static import-closure added ${added} files → keep-set now ${keepNm.size} (${(keepNm.size / nmAll.length * 100).toFixed(1)}%)`);
+
+  // ── VALIDATE: fresh box with keep-set only, cold bundle, byte-match ──────────
+  log('VALIDATE: building pruned box B…');
+  const B = await Sandbox.create({ files: {}, cwd: '/home/user', persist: false, env });
+  const tb = instrument(B.kernel.vfs);
+  for (const f of [...keepNm, ...nonNm]) { const d = readBytes(f); if (d == null) continue; mkdirp(B.kernel.vfs, f.slice(0, f.lastIndexOf('/'))); B.kernel.vfs.writeFile(f, d); }
+  const snap = await exportVfsSnapshot(B.kernel.vfs);
+  const snapGz = gz(Buffer.from(snap.buffer, snap.byteOffset, snap.byteLength));
+  const nmInB = allFiles(B.kernel.vfs).filter(isNM).length;
+  log(`B has ${nmInB} nm files, PRUNED SNAPSHOT ${MB(snapGz)} — cold bundling…`);
+
+  tb.miss.clear();
+  let blog = ''; const sink = (s) => { blog += s; out(s); };
+  B.shell.execute(`node ${cli} start --web ${APP}`, { cwd: APP, env: { ...B.env, EXPO_OFFLINE: '1' }, onStdout: sink, onStderr: sink }).catch((e) => log('B start ended:', e.message));
+  let b1 = { status: 0, bytes: 0 };
+  if (await waitForPort(B.kernel, PORT, 60000)) { await vmRequest(B.kernel, PORT, '/').catch(() => {}); b1 = await vmRequest(B.kernel, PORT, '/index.bundle?platform=web&dev=true&hot=false').catch((e) => ({ status: 0, bytes: 0, err: e.message })); }
+  else log('B never bound');
+
+  const aBytes = globalThis.__aBytes || 0;
+  const ok = b1.status === 200 && (aBytes > 0 ? Math.abs(b1.bytes - aBytes) < aBytes * 0.02 : b1.bytes > 1_000_000);
+  console.log('\n================= KEEP-SET GENERATOR =================');
+  console.log('node_modules files:     ', nmAll.length);
+  console.log('keep-set (deterministic):', keepNm.size, `(${(keepNm.size / nmAll.length * 100).toFixed(1)}%)`);
+  console.log('  from reads:           ', [...tr.reads].filter((f) => isNM(f) && existSet.has(f)).length);
+  console.log('  from exists() probes: ', [...tr.existsHits].filter((f) => existSet.has(f)).length);
+  console.log('PRUNED SNAPSHOT gz:     ', MB(snapGz), '(vs full ~99 MB)');
+  console.log('GEN dev bundle:', aBytes, 'bytes   B (pruned, cold):', b1.bytes, 'bytes');
+  console.log(ok ? '✅ PASS — deterministic keep-set cold-bundles, no iteration'
+    : '❌ FAIL — gap remains (missing below)');
+  if (!ok) {
+    const missing = [...tb.miss].filter((f) => A.kernel.vfs.exists(f) && !keepNm.has(f));
+    for (const m of blog.matchAll(/Unable to resolve "([^"]+)" from "([^"]+)"/g)) missing.push(`resolve: ${m[1]} from ${m[2]}`);
+    console.log(`gap (${missing.length}):`); missing.slice(0, 30).forEach((m) => console.log('   ', String(m).replace(APP + '/node_modules/', '')));
+  }
+  console.log('=====================================================\n');
+  cors.close();
+  process.exit(ok ? 0 : 1);
+}
+main().catch((e) => { console.error('FATAL', e); process.exit(1); });

--- a/bench/prune-trace.mjs
+++ b/bench/prune-trace.mjs
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+/**
+ * prune-trace.mjs — measure how small a Lifo box snapshot can get if we keep
+ * only the node_modules files actually TOUCHED while running a real Expo web
+ * bundle.
+ *
+ * Idea: a blank Expo app installs a huge node_modules, but `expo start --web`
+ * only reads a fraction of it to produce the first web bundle. We trace every
+ * VFS access, snapshot AFTER the first bundle (so Metro's warm cache + the
+ * built bundle are captured), then compare:
+ *    full snapshot (everything)   vs   pruned snapshot (touched files only).
+ *
+ *   node bench/prune-trace.mjs
+ *
+ * Requires the core package to be built (pnpm --filter @lifo-sh/core build).
+ */
+import { performance } from 'node:perf_hooks';
+import http from 'node:http';
+import zlib from 'node:zlib';
+import { Sandbox, exportVfsSnapshot } from '../packages/core/dist/index.js';
+
+const CORS_PORT = 8791;
+const PREVIEW_PORT = 8081;
+const APP_DIR = '/home/user/my-app';
+
+const log = (...a) => console.log(`[${((performance.now() - T0) / 1000).toFixed(1)}s]`, ...a);
+const T0 = performance.now();
+
+// VM code runs in this realm, so a VM async-throw surfaces as a host rejection.
+// Log it but keep the measurement alive.
+process.on('unhandledRejection', (e) => log('UNHANDLED REJECTION:', e?.message || e));
+process.on('uncaughtException', (e) => log('UNCAUGHT:', e?.message || e));
+
+// ── 1. Tiny /_cors?url= proxy (Node fetch has no CORS restriction) ───────────
+function startCorsProxy() {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      (async () => {
+        const u = new URL(req.url, 'http://localhost');
+        const target = u.searchParams.get('url');
+        if (!target) { res.statusCode = 400; return res.end('missing url'); }
+        const chunks = [];
+        for await (const c of req) chunks.push(c);
+        const hasBody = req.method !== 'GET' && req.method !== 'HEAD';
+        const up = await fetch(target, {
+          method: req.method,
+          headers: {
+            accept: req.headers['accept'] || '*/*',
+            'user-agent': req.headers['user-agent'] || 'lifo',
+            ...(req.headers['content-type'] ? { 'content-type': req.headers['content-type'] } : {}),
+          },
+          body: hasBody ? Buffer.concat(chunks) : undefined,
+        });
+        const body = Buffer.from(await up.arrayBuffer());
+        res.statusCode = up.status;
+        res.setHeader('content-type', up.headers.get('content-type') || 'application/octet-stream');
+        res.end(body);
+      })().catch((e) => { res.statusCode = 502; res.end('cors err: ' + e.message); });
+    });
+    server.listen(CORS_PORT, () => resolve(server));
+  });
+}
+
+// ── 2. Instrument the VFS: record accesses BY KIND ───────────────────────────
+// reads   = readFile  (bytes actually needed to execute/transform)
+// stats   = stat/lstat/readdir/exists/... (crawler probes — NOT proof of need)
+// writes  = writeFile (generated artifacts: metro cache, bundle, .expo)
+function instrument(vfs) {
+  const reads = new Set(), stats = new Set(), writes = new Set();
+  const rec = (set) => (p) => { if (typeof p === 'string') set.add(p); };
+  const map = {
+    readFile: rec(reads),
+    writeFile: rec(writes),
+    stat: rec(stats), lstat: rec(stats), readdir: rec(stats),
+    exists: rec(stats), readlink: rec(stats), realpath: rec(stats),
+  };
+  for (const [m, record] of Object.entries(map)) {
+    const orig = vfs[m];
+    if (typeof orig !== 'function') continue;
+    vfs[m] = function (p, ...rest) { record(p); return orig.call(this, p, ...rest); };
+  }
+  return { reads, stats, writes };
+}
+
+// ── 3. Fire a virtual HTTP request into a bound port (no service worker) ──────
+function vmRequest(kernel, port, url, { method = 'GET', headers = {}, timeoutMs = 120000 } = {}) {
+  const handler = kernel.portRegistry.get(port);
+  if (!handler) throw new Error(`no handler on port ${port}`);
+  const vReq = { method, url, headers: { host: `localhost:${port}`, ...headers }, body: '' };
+  const vRes = { statusCode: 200, headers: {}, body: '' };
+  handler(vReq, vRes);
+  const finish = () => {
+    const text = vRes.bodyBytes ? new TextDecoder().decode(vRes.bodyBytes) : (vRes.body || '');
+    return {
+      status: vRes.statusCode,
+      headers: vRes.headers,
+      bytes: vRes.bodyBytes ? vRes.bodyBytes.byteLength : Buffer.byteLength(vRes.body || ''),
+      text,
+    };
+  };
+  if (vRes._donePromise) {
+    const to = new Promise((_, rej) => setTimeout(() => rej(new Error('vmRequest timeout')), timeoutMs));
+    return Promise.race([vRes._donePromise.then(finish), to]);
+  }
+  return Promise.resolve(finish());
+}
+
+async function waitForPort(kernel, port, timeoutMs = 180000) {
+  const start = performance.now();
+  while (performance.now() - start < timeoutMs) {
+    if (kernel.portRegistry.has(port)) return true;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  return false;
+}
+
+// ── 4. Snapshot size helpers ─────────────────────────────────────────────────
+function gz(buf) { return zlib.gzipSync(buf, { level: 6 }).length; }
+const MB = (n) => (n / 1048576).toFixed(1) + ' MB';
+
+// Sum raw + gzip size of a set of VFS files (pruned view) without building a tar.
+function measureFiles(vfs, keep) {
+  let raw = 0;
+  const parts = [];
+  for (const p of keep) {
+    try {
+      const st = vfs.stat(p);
+      if (st.type !== 'file') continue;
+      const data = vfs.readFile(p);
+      raw += data.byteLength;
+      parts.push(data);
+    } catch { /* pruned probe path that doesn't exist as a file */ }
+  }
+  const blob = Buffer.concat(parts.map((u) => Buffer.from(u.buffer, u.byteOffset, u.byteLength)));
+  return { raw, gz: gz(blob), count: parts.length };
+}
+
+// Walk every file in the VFS.
+function allFiles(vfs, dir = '/', out = []) {
+  let entries;
+  try { entries = vfs.readdir(dir); } catch { return out; }
+  for (const e of entries) {
+    if (dir === '/proc' || dir === '/dev') continue;
+    const full = dir === '/' ? `/${e.name}` : `${dir}/${e.name}`;
+    let st;
+    try { st = vfs.stat(full); } catch { continue; }
+    if (st.type === 'directory') allFiles(vfs, full, out);
+    else out.push(full);
+  }
+  return out;
+}
+
+async function main() {
+  const cors = await startCorsProxy();
+  log(`cors proxy on :${CORS_PORT}`);
+
+  const sb = await Sandbox.create({
+    files: {},
+    cwd: '/home/user',
+    persist: false,
+    env: {
+      LIFO_CORS_PROXY: `http://localhost:${CORS_PORT}/_cors?url=`,
+      EXPO_NO_TELEMETRY: '1',
+      EXPO_NO_DEPENDENCY_VALIDATION: '1',
+      BROWSER: 'none',
+    },
+  });
+  log('sandbox booted');
+
+  const trace = instrument(sb.kernel.vfs);
+
+  const onOut = (s) => process.stdout.write(s);
+  const runOpts = (cwd) => ({ cwd, onStdout: onOut, onStderr: onOut, timeout: 900000 });
+
+  log('running create-expo-app (blank template)…');
+  // Absolute VM path — a relative name gets resolved against a host path by
+  // create-expo-app's find-up, landing the app in the wrong place.
+  const r1 = await sb.commands.run(
+    `npx create-expo-app@latest ${APP_DIR} --template blank --no-install`,
+    runOpts('/home/user'),
+  ).catch((e) => ({ exitCode: -1, err: e.message }));
+  log('create-expo-app exit', r1.exitCode, r1.err || '');
+  try { log('app package.json:', sb.kernel.vfs.readFile(`${APP_DIR}/package.json`).length, 'bytes'); }
+  catch (e) { log('!! app not at expected path:', e.message); }
+
+  log('npm install…');
+  const r2 = await sb.commands.run('npm install', runOpts(APP_DIR))
+    .catch((e) => ({ exitCode: -1, err: e.message }));
+  log('npm install exit', r2.exitCode, r2.err || '');
+
+  // The blank template is native-only; `expo start --web` needs the web runtime
+  // deps. Install them explicitly (offline expo can't auto-add them).
+  log('installing web deps (react-dom, react-native-web)…');
+  const r2b = await sb.commands.run('npm install react-dom react-native-web@~0.21.0', runOpts(APP_DIR))
+    .catch((e) => ({ exitCode: -1, err: e.message }));
+  log('web deps exit', r2b.exitCode, r2b.err || '');
+
+  // Count node_modules footprint BEFORE trace measurement.
+  const filesAfterInstall = allFiles(sb.kernel.vfs);
+  const nmAll = filesAfterInstall.filter((f) => f.includes('/node_modules/'));
+  log(`node_modules files after install: ${nmAll.length}`);
+
+  // Clear the trace so we only capture what the dev-server + BUNDLE touches
+  // (install reads lots we don't need at bundle time).
+  trace.reads.clear(); trace.stats.clear(); trace.writes.clear();
+
+  log('starting expo web dev server (background)…');
+  // Invoke the installed CLI directly (NOT npx — npx leaks the host cwd to the
+  // spawned bin) and pass the project root explicitly so cwd is irrelevant.
+  const expoCli = `${APP_DIR}/node_modules/@expo/cli/build/bin/cli`;
+  // Do NOT await — it's long-running. Poll for the port.
+  sb.shell.execute(`node ${expoCli} start --web ${APP_DIR}`, {
+    cwd: APP_DIR,
+    // EXPO_OFFLINE skips the Expo version endpoint (fatal Bad Gateway otherwise);
+    // Metro bundling is fully local so offline is fine.
+    env: { ...sb.env, EXPO_OFFLINE: '1' },
+    onStdout: onOut,
+    onStderr: onOut,
+  }).catch((e) => log('expo start ended:', e.message));
+
+  const bound = await waitForPort(sb.kernel, PREVIEW_PORT);
+  log(`port ${PREVIEW_PORT} bound: ${bound}`);
+  if (!bound) { console.error('DEV SERVER NEVER BOUND — aborting'); await dump(sb, trace); process.exit(2); }
+
+  // GET / first (lets Metro finish its startup crawl / haste-map hashing).
+  log('GET /');
+  try { const res = await vmRequest(sb.kernel, PREVIEW_PORT, '/'); log(`  → ${res.status}, ${res.bytes} bytes`); }
+  catch (e) { log(`  → ERROR ${e.message}`); }
+
+  // Snapshot the STARTUP+CRAWL reads, then clear so trace.reads captures ONLY
+  // the reads done to actually build the bundle (module transforms).
+  const crawlReads = new Set([...trace.reads].filter(isNM));
+  trace.reads.clear();
+
+  log('GET /index.bundle (isolating bundle-time reads)');
+  let bundleModulePaths = new Set();
+  try {
+    const res = await vmRequest(sb.kernel, PREVIEW_PORT, '/index.bundle?platform=web&dev=true&hot=false');
+    log(`  → ${res.status}, ${res.bytes} bytes`);
+    // Metro dev bundle embeds each module's real path (verboseName). Extract the
+    // node_modules source files that actually made it into the bundle graph.
+    for (const m of res.text.matchAll(/node_modules\/(?:@[\w.-]+\/)?[\w.-]+(?:\/[\w.@$+-]+)*\.(?:js|jsx|ts|tsx|json|cjs|mjs)/g)) {
+      bundleModulePaths.add(`${APP_DIR}/${m[0]}`);
+    }
+    log(`  bundle references ${bundleModulePaths.size} distinct node_modules source files`);
+  } catch (e) { log(`  → ERROR ${e.message}`); }
+
+  await dump(sb, trace, crawlReads, bundleModulePaths);
+  cors.close();
+  process.exit(0);
+}
+
+const isNM = (f) => f.includes('/node_modules/');
+const isPkgJson = (f) => f.endsWith('/package.json');
+
+async function dump(sb, trace, crawlReads = new Set(), bundleModulePaths = new Set()) {
+  const vfs = sb.kernel.vfs;
+  log('measuring…');
+
+  // CAPTURE the live trace FIRST — exportVfsSnapshot/allFiles/measureFiles below
+  // all go through the instrumented VFS and would otherwise pollute it to 100%.
+  const bundleReads = [...trace.reads].filter(isNM);   // reads to BUILD the bundle
+  const traceStats = [...trace.stats];
+  const writes = [...trace.writes];
+  const pkgJsons = [...traceStats, ...crawlReads, ...trace.reads].filter((f) => isNM(f) && isPkgJson(f));
+
+  const fullTar = await exportVfsSnapshot(vfs);
+  const fullGz = gz(Buffer.from(fullTar.buffer, fullTar.byteOffset, fullTar.byteLength));
+
+  const all = allFiles(vfs);
+  const nmNow = all.filter(isNM);
+  const nonNm = all.filter((f) => !isNM(f));
+
+  // A) bundle-time reads (modules Metro transforms) + resolution package.jsons
+  // B) + startup-crawl reads (what Metro reads just to boot the dev server)
+  const keepBundle = new Set([...bundleReads, ...pkgJsons]);
+  const keepBoot = new Set([...bundleReads, ...crawlReads, ...pkgJsons]);
+
+  // The TRUE critical path: source files that actually made it into the bundle
+  // graph + their package.jsons (needed for resolution).
+  const graphPkgJsons = [...pkgJsons].filter((p) => {
+    // keep pkg.json of any package whose files are in the graph
+    const pkgDir = p.slice(0, -'/package.json'.length);
+    for (const f of bundleModulePaths) if (f.startsWith(pkgDir + '/')) return true;
+    return false;
+  });
+  const keepGraph = new Set([...bundleModulePaths, ...graphPkgJsons]);
+
+  // Option-2 keep-set: everything Metro actually READ (startup toolchain boot +
+  // bundle-time transforms + hashing) + resolution package.jsons. This is the
+  // "keep real Metro, delete the rest" candidate.
+  const keepMetro = new Set([...bundleReads, ...crawlReads, ...pkgJsons]);
+
+  const nmFull = measureFiles(vfs, new Set(nmNow));
+  const nmGraph = measureFiles(vfs, keepGraph);
+  const nmBundleReads = measureFiles(vfs, new Set(bundleReads));
+  const nmCrawlReads = measureFiles(vfs, crawlReads);
+  const nmKeepMetro = measureFiles(vfs, keepMetro);
+  const nonNmNoCache = measureFiles(vfs, new Set(nonNm.filter((f) => !f.includes('/.expo/') && !f.includes('/.cache/'))));
+
+  console.log('\n================= PRUNE TRACE RESULTS =================');
+  console.log('Full VFS files:               ', all.length, `(nm ${nmNow.length}, non-nm ${nonNm.length})`);
+  console.log('nm READ at STARTUP (boot):    ', nmCrawlReads.count, `(${((nmCrawlReads.count / nmNow.length) * 100).toFixed(1)}%)`);
+  console.log('nm READ during BUNDLE:        ', nmBundleReads.count, `(${((nmBundleReads.count / nmNow.length) * 100).toFixed(1)}%)`);
+  console.log('nm READ total (keep-Metro):   ', nmKeepMetro.count, `(${((nmKeepMetro.count / nmNow.length) * 100).toFixed(1)}%)`);
+  console.log('BUNDLE GRAPH source files:    ', bundleModulePaths.size, `+ ${graphPkgJsons.length} pkg.json`);
+  console.log('------------------------------------------------------');
+  console.log('FULL   node_modules gz:       ', MB(nmFull.gz), `(full snapshot tar.gz ${MB(fullGz)})`);
+  console.log('KEEP-METRO node_modules gz:   ', MB(nmKeepMetro.gz), `(${nmKeepMetro.count} files — toolchain + graph)`);
+  console.log('GRAPH-ONLY node_modules gz:   ', MB(nmGraph.gz), `(${nmGraph.count} files — app runtime only)`);
+  console.log('app source (no cache) gz:     ', MB(nonNmNoCache.gz));
+  console.log('------------------------------------------------------');
+  console.log('=> OPTION-2 snapshot (keep Metro): ', MB(nmKeepMetro.gz + nonNmNoCache.gz), ' <-- toolchain+graph+app');
+  console.log('=> Prebuilt-bundle snapshot:       ', MB(nmGraph.gz + nonNmNoCache.gz), ' <-- graph+app only');
+  console.log('   full snapshot:                  ', MB(fullGz));
+  console.log('======================================================\n');
+}
+
+main().catch((e) => { console.error('FATAL', e); process.exit(1); });

--- a/bench/test-bm-assets.mjs
+++ b/bench/test-bm-assets.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * test-bm-assets.mjs — verify the browser-metro command emits external-asset
+ * URIs (assetPublicPath) and serves the raw asset bytes from the dev port.
+ */
+// Polyfill browser blob APIs so the command's browser path (materialize assets
+// as blob: URLs) runs headlessly. Blob is global in Node 22.
+const capturedBlobs = [];
+globalThis.URL.createObjectURL = (blob) => { const u = 'blob:lifo/' + capturedBlobs.length; capturedBlobs.push(blob); return u; };
+globalThis.URL.revokeObjectURL = () => {};
+
+const { Sandbox } = await import('../packages/core/dist/index.js');
+
+const PORT = 8087, APP = '/home/user/my-app';
+const out = (s) => process.stdout.write(s);
+// 1x1 PNG
+const PNG = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC', 'base64');
+
+const files = {
+  [`${APP}/package.json`]: JSON.stringify({ name: 'demo', main: 'index.tsx', dependencies: { expo: '~54.0.0', react: '19.1.0', 'react-dom': '19.1.0', 'react-native': '0.81.5', 'react-native-web': '~0.21.0' } }),
+  [`${APP}/App.tsx`]: `import { Image, View } from 'react-native';\nconst logo = require('./assets/logo.png');\nexport default function App(){ return (<View><Image source={logo} style={{width:10,height:10}} /></View>); }\n`,
+  [`${APP}/index.tsx`]: `import { registerRootComponent } from 'expo';\nimport App from './App';\nregisterRootComponent(App);\n`,
+};
+
+const sb = await Sandbox.create({ files, cwd: APP, persist: false, env: {} });
+// Write the binary asset into the VFS.
+sb.kernel.vfs.mkdir?.(`${APP}/assets`);
+sb.kernel.vfs.writeFile(`${APP}/assets/logo.png`, new Uint8Array(PNG));
+console.log('asset written:', sb.kernel.vfs.exists(`${APP}/assets/logo.png`));
+
+sb.shell.execute(`browser-metro ${APP} --port ${PORT}`, { cwd: APP, onStdout: out, onStderr: out }).catch((e) => console.log('cmd:', e.message));
+let bound = false;
+for (let i = 0; i < 60; i++) { if (sb.kernel.portRegistry.has(PORT)) { bound = true; break; } await new Promise((r) => setTimeout(r, 500)); }
+console.log('bound:', bound);
+if (!bound) process.exit(2);
+
+const h = sb.kernel.portRegistry.get(PORT);
+const get = (url) => { const r = { statusCode: 200, headers: {}, body: '' }; h({ method: 'GET', url, headers: {}, body: '' }, r); return r; };
+
+const bundle = get('/index.bundle').body;
+const hasBlob = /blob:lifo\/\d+/.test(bundle);
+const hasPath = bundle.includes('/__bm_assets/');
+console.log('bundle asset URI → blob:', hasBlob, '| leftover /__bm_assets path:', hasPath);
+console.log('blobs created:', capturedBlobs.length, '| first blob size:', capturedBlobs[0]?.size, '(expected', PNG.length + ')');
+console.log('first blob type:', capturedBlobs[0]?.type);
+
+const ok = hasBlob && !hasPath && capturedBlobs.length === 1 && capturedBlobs[0].size === PNG.length && capturedBlobs[0].type === 'image/png';
+console.log('\n' + (ok ? '✅ PASS — asset materialized as blob: URL from VFS bytes (rewritten in bundle)' : '❌ FAIL'));
+process.exit(ok ? 0 : 1);

--- a/bench/test-bm-command.mjs
+++ b/bench/test-bm-command.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * test-bm-command.mjs — end-to-end (headless) of the in-VM `browser-metro`
+ * command: seed a .tsx Expo web app in the VFS, run the command, and confirm it
+ * bundles via esm.reactnative.run and serves the bundle on a port. (Render is
+ * browser-only; this validates VFS→bundle→serve.)
+ */
+import { performance } from 'node:perf_hooks';
+import { Sandbox } from '../packages/core/dist/index.js';
+
+const T0 = performance.now();
+const log = (...a) => console.log(`[${((performance.now() - T0) / 1000).toFixed(1)}s]`, ...a);
+process.on('unhandledRejection', (e) => log('REJ:', e?.message || e));
+
+const PORT = 8082, APP = '/home/user/my-app';
+const out = (s) => process.stdout.write(s);
+
+const files = {
+  [`${APP}/package.json`]: JSON.stringify({ name: 'demo', main: 'index.tsx', dependencies: { expo: '~54.0.0', react: '19.1.0', 'react-dom': '19.1.0', 'react-native': '0.81.5', 'react-native-web': '~0.21.0' } }),
+  [`${APP}/index.tsx`]: `import { registerRootComponent } from 'expo';\nimport App from './App';\nregisterRootComponent(App);\n`,
+  [`${APP}/App.tsx`]: `import { Text, View } from 'react-native';\nexport default function App(){ return (<View><Text>Hello from browser-metro in Lifo</Text></View>); }\n`,
+};
+
+const sb = await Sandbox.create({ files, cwd: APP, persist: false, env: {} });
+log('registered browser-metro?', typeof sb.commands.run === 'function' && sb.kernel.portRegistry instanceof Map);
+
+// Run the long-running dev server (do NOT await).
+sb.shell.execute(`browser-metro ${APP} --port ${PORT}`, { cwd: APP, onStdout: out, onStderr: out }).catch((e) => log('cmd ended:', e.message));
+
+// Wait for the port to bind.
+let bound = false;
+for (let i = 0; i < 60; i++) { if (sb.kernel.portRegistry.has(PORT)) { bound = true; break; } await new Promise((r) => setTimeout(r, 500)); }
+log('port bound:', bound);
+
+function vmGet(url) {
+  const h = sb.kernel.portRegistry.get(PORT);
+  if (!h) return { status: 0, bytes: 0, text: '' };
+  const vRes = { statusCode: 200, headers: {}, body: '' };
+  h({ method: 'GET', url, headers: { host: `localhost:${PORT}` }, body: '' }, vRes);
+  return { status: vRes.statusCode, bytes: Buffer.byteLength(vRes.body || ''), text: vRes.body || '', ct: vRes.headers['content-type'] };
+}
+
+if (bound) {
+  const html = vmGet('/');
+  log(`GET / → ${html.status} ${html.ct} | has #root: ${html.text.includes('id="root"')} | has bundle script: ${html.text.includes('/index.bundle')}`);
+  const bundle = vmGet('/index.bundle');
+  log(`GET /index.bundle → ${bundle.status} ${bundle.ct} | ${(bundle.bytes / 1048576).toFixed(2)} MB | RNW: ${bundle.text.includes('react-native-web')} | registerRootComponent: ${bundle.text.includes('registerRootComponent')}`);
+  const ok = html.status === 200 && html.text.includes('id="root"') && bundle.status === 200 && bundle.bytes > 500000;
+  console.log('\n' + (ok ? '✅ PASS — in-VM browser-metro command bundles + serves the app on a port' : '❌ FAIL'));
+  process.exit(ok ? 0 : 1);
+} else {
+  console.log('\n❌ FAIL — port never bound');
+  process.exit(2);
+}

--- a/bench/test-bm-hmr.mjs
+++ b/bench/test-bm-hmr.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * test-bm-hmr.mjs — granular HMR for browser-metro: edit a file TWICE and
+ * confirm each edit produces a HOT update (not a full reload), delivered via
+ * /__bmhmr with the new source in updatedModules.
+ */
+import { Sandbox } from '../packages/core/dist/index.js';
+
+const PORT = 8090, APP = '/home/user/rn-app';
+const out = (s) => process.stdout.write(s);
+const files = {
+  [`${APP}/package.json`]: JSON.stringify({ name: 'rn-app', main: 'index.tsx', dependencies: { expo: '~54.0.0', react: '19.1.0', 'react-dom': '19.1.0', 'react-native': '0.81.5', 'react-native-web': '~0.21.0' } }),
+  [`${APP}/index.tsx`]: `import { registerRootComponent } from 'expo';\nimport App from './App';\nregisterRootComponent(App);\n`,
+  [`${APP}/App.tsx`]: `import { Text, View } from 'react-native';\nexport default function App(){ return (<View><Text>MARKER_V0</Text></View>); }\n`,
+};
+
+const sb = await Sandbox.create({ files, cwd: APP, persist: false, env: {} });
+sb.shell.execute(`browser-metro ${APP} --port ${PORT}`, { cwd: APP, onStdout: out, onStderr: out }).catch((e) => console.log('cmd:', e.message));
+let bound = false;
+for (let i = 0; i < 60; i++) { if (sb.kernel.portRegistry.has(PORT)) { bound = true; break; } await new Promise((r) => setTimeout(r, 500)); }
+console.log('bound:', bound);
+if (!bound) process.exit(2);
+
+const h = sb.kernel.portRegistry.get(PORT);
+const getJson = (url) => { const r = { statusCode: 200, headers: {}, body: '' }; h({ method: 'GET', url, headers: {}, body: '' }, r); return JSON.parse(r.body); };
+
+// edit App.tsx, then wait until /__bmhmr shows an update past `sinceSeq`
+async function editAndWait(marker, sinceSeq) {
+  sb.kernel.vfs.writeFile(`${APP}/App.tsx`, `import { Text, View } from 'react-native';\nexport default function App(){ return (<View><Text>${marker}</Text></View>); }\n`);
+  for (let i = 0; i < 40; i++) {
+    await new Promise((r) => setTimeout(r, 300));
+    const d = getJson(`/__bmhmr?b=1&h=${sinceSeq}`);
+    if (d.reload) return { reload: true };
+    if (d.updates && d.updates.length) return d;
+  }
+  return { timeout: true };
+}
+
+const base = getJson('/__bmhmr?b=1&h=0');
+console.log('initial:', JSON.stringify(base));
+
+console.log('--- edit #1 (MARKER_V1) ---');
+const d1 = await editAndWait('MARKER_V1', 0);
+const u1 = d1.updates && d1.updates[0];
+const code1 = u1 ? Object.values(u1.update.updatedModules).join('\n') : '';
+console.log('edit#1:', d1.reload ? 'RELOAD' : d1.timeout ? 'TIMEOUT' : `hot seq=${u1.seq}, hasV1=${code1.includes('MARKER_V1')}`);
+
+console.log('--- edit #2 (MARKER_V2) ---');
+const d2 = await editAndWait('MARKER_V2', u1 ? u1.seq : 0);
+const u2 = d2.updates && d2.updates[0];
+const code2 = u2 ? Object.values(u2.update.updatedModules).join('\n') : '';
+console.log('edit#2:', d2.reload ? 'RELOAD' : d2.timeout ? 'TIMEOUT' : `hot seq=${u2.seq}, hasV2=${code2.includes('MARKER_V2')}`);
+
+const ok = !d1.reload && !d1.timeout && u1 && code1.includes('MARKER_V1') && !d2.reload && !d2.timeout && u2 && u2.seq > u1.seq && code2.includes('MARKER_V2');
+console.log('\n' + (ok ? '✅ PASS — both edits produced HOT updates (no reload)' : '❌ FAIL'));
+process.exit(ok ? 0 : 1);

--- a/bench/test-browser-metro.mjs
+++ b/bench/test-browser-metro.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * test-browser-metro.mjs — confirm browser-metro 1.0.31 bundles a .tsx Expo web
+ * app via esm.reactnative.run, using RapidNative's real plugin config (RN→RNW
+ * alias, React auto-import, shim stubs). Headless core de-risk.
+ */
+import { performance } from 'node:perf_hooks';
+import { VirtualFS, Bundler, typescriptTransformer, createReactRefreshTransformer, createDataBxPathPlugin, createExpoWebShimsPlugin, createUnsupportedWebPackagesPlugin } from '../packages/core/node_modules/browser-metro/dist/index.js';
+
+const T0 = performance.now();
+const log = (...a) => console.log(`[${((performance.now() - T0) / 1000).toFixed(1)}s]`, ...a);
+
+const files = {
+  '/package.json': { content: JSON.stringify({ name: 'demo', main: 'index.tsx', dependencies: { expo: '~54.0.0', react: '19.1.0', 'react-dom': '19.1.0', 'react-native': '0.81.5', 'react-native-web': '~0.21.0' } }), isExternal: false },
+  '/index.tsx': { content: `import { registerRootComponent } from 'expo';\nimport App from './App';\nregisterRootComponent(App);\n`, isExternal: false },
+  '/App.tsx': { content: `import { Text, View } from 'react-native';\nexport default function App(){ return (<View><Text>Hello from browser-metro in Lifo</Text></View>); }\n`, isExternal: false },
+};
+
+// RapidNative's real expo-web plugin (alias + React import + classname-patch
+// prepend), with minimal shim stubs (runtime shims not needed to test bundling).
+const isJSX = (f) => f.endsWith('.tsx') || f.endsWith('.jsx');
+const hasReactImport = (s) => /\bimport\s+React\b/.test(s) || /\bimport\s+\*\s+as\s+React\b/.test(s);
+const expoWebPlugin = {
+  name: 'expo-web',
+  transformSource({ src, filename }) {
+    if (filename.endsWith('.json')) return { src: `module.exports = ${src};` };
+    let m = src, changed = false;
+    if (isJSX(filename) && !hasReactImport(src)) { m = 'import React from "react";\n' + m; changed = true; }
+    if (filename === '/index.tsx' || filename === '/index.ts' || filename === '/index.js') { m = 'require("__classname-patch__");\n' + m; changed = true; }
+    return changed ? { src: m } : null;
+  },
+  transformOutput({ code }) { return { code: 'var __DEV__=false; var global=globalThis;\n' + code }; },
+  moduleAliases() { return { 'react-native': 'react-native-web' }; },
+  shimModules() { return { '__classname-patch__': 'module.exports={};', 'nativewind': 'module.exports={};', 'react-native-css-interop': 'module.exports={};', 'expo-font': 'module.exports={};' }; },
+};
+
+async function main() {
+  const vfs = new VirtualFS(files);
+  const entry = vfs.getEntryFile();
+  log('entry:', entry);
+  const bundler = new Bundler(vfs, {
+    resolver: { sourceExts: ['web.tsx', 'web.ts', 'web.jsx', 'web.js', 'tsx', 'ts', 'jsx', 'js', 'json'] },
+    transformer: createReactRefreshTransformer(typescriptTransformer),
+    server: { packageServerUrl: 'https://esm.reactnative.run' },
+    plugins: [createDataBxPathPlugin(), expoWebPlugin, createExpoWebShimsPlugin(), createUnsupportedWebPackagesPlugin()],
+    routerShim: true,
+    env: {},
+  });
+  try {
+    const t = performance.now();
+    const b = await bundler.bundle(entry);
+    log(`✅ bundled: ${(b.length / 1048576).toFixed(2)} MB in ${((performance.now() - t) / 1000).toFixed(1)}s`);
+    log(`   react-native-web present: ${b.includes('react-native-web')} | createElement: ${b.includes('createElement')} | registerRootComponent: ${b.includes('registerRootComponent')}`);
+  } catch (e) {
+    log('❌ FAILED:', e.message);
+  }
+  process.exit(0);
+}
+main().catch((e) => { console.error('FATAL', e); process.exit(1); });

--- a/bench/test-nosw-bridge.mjs
+++ b/bench/test-nosw-bridge.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * test-nosw-bridge.mjs — headless check of the SW-FREE transport's HOST half:
+ * ServiceWorkerBridge driven by a postMessage adapter (what the parent window
+ * does for the blob iframe). Simulates the iframe posting {type:'request'} and
+ * asserts the bridge answers {type:'response'} from the in-VM Metro server.
+ * (The iframe-side shims are browser-only and tested manually in the playground.)
+ */
+import { performance } from 'node:perf_hooks';
+import http from 'node:http';
+import { Sandbox, ServiceWorkerBridge } from '../packages/core/dist/index.js';
+
+const T0 = performance.now();
+const log = (...a) => console.log(`[${((performance.now() - T0) / 1000).toFixed(1)}s]`, ...a);
+process.on('unhandledRejection', (e) => log('REJ:', e?.message || e));
+const CORS = 8801, PORT = 8081, APP = '/home/user/my-app';
+const server = http.createServer((req, res) => { (async () => { const t = new URL(req.url, 'http://localhost').searchParams.get('url'); if (!t) { res.statusCode = 400; return res.end('x'); } const up = await fetch(t, { headers: { accept: '*/*', 'user-agent': 'lifo' } }); res.statusCode = up.status; res.end(Buffer.from(await up.arrayBuffer())); })().catch((e) => { res.statusCode = 502; res.end(e.message); }); });
+await new Promise((r) => server.listen(CORS, r));
+const out = (s) => process.stdout.write(s);
+const sb = await Sandbox.create({ files: {}, cwd: '/home/user', persist: false, env: { LIFO_CORS_PROXY: `http://localhost:${CORS}/_cors?url=`, EXPO_NO_TELEMETRY: '1', BROWSER: 'none' } });
+const ro = { cwd: '/home/user', onStdout: out, onStderr: out, timeout: 600000 };
+await sb.commands.run(`npx create-expo-app@latest ${APP} --template blank --no-install`, ro);
+await sb.commands.run('npm install', { ...ro, cwd: APP });
+await sb.commands.run('npm install react-dom react-native-web@~0.21.0', { ...ro, cwd: APP });
+sb.shell.execute(`node ${APP}/node_modules/expo/bin/cli start --web ${APP}`, { cwd: APP, env: { ...sb.env, EXPO_OFFLINE: '1' }, onStdout: out, onStderr: out }).catch(() => {});
+for (let i = 0; i < 300; i++) { if (sb.kernel.portRegistry.has(PORT)) break; await new Promise((r) => setTimeout(r, 400)); }
+log('port bound:', sb.kernel.portRegistry.has(PORT));
+
+// The postMessage adapter the parent uses in place of a real MessagePort.
+// Match responses by requestId (requests can overlap / complete out of order).
+const pending = new Map();
+const adapter = {
+  postMessage: (msg) => { if (msg?.type === 'response') { const r = pending.get(msg.requestId); if (r) { pending.delete(msg.requestId); r(msg); } } },
+  onmessage: null,
+  start() {}, close() {},
+};
+
+const bridge = new ServiceWorkerBridge(sb.kernel.portRegistry);
+bridge.attach(adapter);
+const iframeSend = (msg) => adapter.onmessage?.({ data: msg });
+
+let idc = 0;
+async function get(url) {
+  const requestId = 'r' + (idc++);
+  const p = new Promise((res) => { pending.set(requestId, res); setTimeout(() => { if (pending.delete(requestId)) res({ statusCode: 0 }); }, 90000); });
+  iframeSend({ type: 'request', requestId, port: PORT, method: 'GET', url, headers: {}, body: '' });
+  const r = await p;
+  const bytes = r.bodyBuffer ? r.bodyBuffer.byteLength : 0;
+  return { status: r.statusCode, bytes, text: r.bodyBuffer ? new TextDecoder().decode(new Uint8Array(r.bodyBuffer)) : '' };
+}
+
+log('request / via bridge+adapter…');
+const html = await get('/');
+log(`  / → ${html.status}, ${html.bytes} bytes`);
+const m = html.text.match(/<script\s+src=["']([^"']+\.bundle[^"']*)["']/i);
+const bundleUrl = m ? (m[1].startsWith('/') ? m[1] : '/' + m[1]) : null;
+log('  bundle url:', bundleUrl);
+let bundle = { status: 0, bytes: 0 };
+if (bundleUrl) { bundle = await get(bundleUrl); log(`  bundle → ${bundle.status}, ${bundle.bytes} bytes`); }
+
+const ok = html.status === 200 && html.text.includes('id="root"') && bundle.status === 200 && bundle.bytes > 500000;
+console.log('\n========= SW-FREE HOST TRANSPORT =========');
+console.log('HTML via adapter:', html.status, html.bytes, 'bytes, has #root:', html.text.includes('id="root"'));
+console.log('bundle via adapter:', bundle.status, bundle.bytes, 'bytes');
+console.log(ok ? '✅ PASS — bridge+postMessage adapter serves the app from the in-VM server (no SW)' : '❌ FAIL');
+console.log('=========================================\n');
+server.close();
+process.exit(ok ? 0 : 1);

--- a/bench/test-prune-cmd.mjs
+++ b/bench/test-prune-cmd.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * test-prune-cmd.mjs — end-to-end test of the `lifo prune` command:
+ *   scaffold+install → `lifo prune my-app` → snapshot (measure) → restore into a
+ *   fresh box → cold `expo start --web` bundle → assert byte-identical.
+ */
+import { performance } from 'node:perf_hooks';
+import http from 'node:http';
+import { Sandbox, exportVfsSnapshot, importVfsSnapshot, pruneExpoModules } from '../packages/core/dist/index.js';
+
+const T0 = performance.now();
+const log = (...a) => console.log(`[${((performance.now() - T0) / 1000).toFixed(1)}s]`, ...a);
+process.on('unhandledRejection', (e) => log('REJ:', e?.message || e));
+process.on('uncaughtException', (e) => log('UNCAUGHT:', e?.message || e));
+
+const CORS = 8798, PORT = 8081, APP = '/home/user/my-app';
+const MB = (n) => (n / 1048576).toFixed(2) + ' MB';
+const out = (s) => process.stdout.write(s);
+const server = http.createServer((req, res) => { (async () => { const t = new URL(req.url, 'http://localhost').searchParams.get('url'); if (!t) { res.statusCode = 400; return res.end('x'); } const up = await fetch(t, { headers: { accept: '*/*', 'user-agent': 'lifo' } }); res.statusCode = up.status; res.end(Buffer.from(await up.arrayBuffer())); })().catch((e) => { res.statusCode = 502; res.end(e.message); }); });
+await new Promise((r) => server.listen(CORS, r));
+const env = { LIFO_CORS_PROXY: `http://localhost:${CORS}/_cors?url=`, EXPO_NO_TELEMETRY: '1', BROWSER: 'none' };
+
+function vmReq(kernel, url) { const h = kernel.portRegistry.get(PORT); if (!h) throw new Error('no server'); const vRes = { statusCode: 200, headers: {}, body: '' }; h({ method: 'GET', url, headers: { host: `localhost:${PORT}` }, body: '' }, vRes); const fin = () => ({ status: vRes.statusCode, bytes: vRes.bodyBytes ? vRes.bodyBytes.byteLength : Buffer.byteLength(vRes.body || '') }); return vRes._donePromise ? Promise.race([vRes._donePromise.then(fin), new Promise((_, j) => setTimeout(() => j(new Error('timeout')), 120000))]) : Promise.resolve(fin()); }
+async function waitPort(kernel, ms) { const s = performance.now(); while (performance.now() - s < ms) { if (kernel.portRegistry.has(PORT)) return true; await new Promise((r) => setTimeout(r, 400)); } return false; }
+function allNM(vfs, dir = '/', acc = []) { let e; try { e = vfs.readdir(dir); } catch { return acc; } for (const x of e) { if (dir === '/proc' || dir === '/dev') continue; const f = dir === '/' ? `/${x.name}` : `${dir}/${x.name}`; let st; try { st = vfs.stat(f); } catch { continue; } if (st.type === 'directory') allNM(vfs, f, acc); else if (f.includes('/node_modules/')) acc.push(f); } return acc; }
+const cli = `${APP}/node_modules/expo/bin/cli`; // the entry `npm run web` uses
+
+// ── set up the "user's project" ─────────────────────────────────────────────
+log('scaffold + install…');
+const A = await Sandbox.create({ files: {}, cwd: '/home/user', persist: false, env });
+const ro = { cwd: '/home/user', onStdout: out, onStderr: out, timeout: 600000 };
+await A.commands.run(`npx create-expo-app@latest ${APP} --template blank --no-install`, ro);
+await A.commands.run('npm install', { ...ro, cwd: APP });
+await A.commands.run('npm install react-dom react-native-web@~0.21.0', { ...ro, cwd: APP });
+const before = allNM(A.kernel.vfs).length;
+log(`node_modules before: ${before} files`);
+
+// reference bundle (what the pruned box must reproduce)
+A.shell.execute(`node ${cli} start --web ${APP}`, { cwd: APP, env: { ...A.env, EXPO_OFFLINE: '1' }, onStdout: out, onStderr: out }).catch(() => {});
+await waitPort(A.kernel, 120000);
+await vmReq(A.kernel, '/').catch(() => {});
+const refBytes = (await vmReq(A.kernel, '/index.bundle?platform=web&dev=true&hot=false').catch(() => ({ bytes: 0 }))).bytes;
+log(`reference bundle: ${refBytes} bytes`);
+
+// ── run the host-side prune engine (what the playground button will call) ────
+log('>>> pruneExpoModules(sandbox) — auto-detect project <<<');
+const pr = await pruneExpoModules(A, { port: 8091, onLog: (s) => log('  prune:', s) }).catch((e) => ({ err: e.message }));
+log('prune result:', JSON.stringify(pr));
+if (pr.err) { console.log('❌ FAIL — prune errored:', pr.err); process.exit(1); }
+const after = allNM(A.kernel.vfs).length;
+log(`node_modules after: ${after} files (${((after / before) * 100).toFixed(1)}%)`);
+
+const snap = await exportVfsSnapshot(A.kernel.vfs);
+log(`PRUNED SNAPSHOT: ${MB(snap.byteLength)}`);
+const toqrKept = A.kernel.vfs.exists(`${APP}/node_modules/toqr`);
+log(`toqr kept (bare-import closure): ${toqrKept}`);
+
+// ── validate: restore into a fresh box, clear cache, cold bundle ─────────────
+log('restore into fresh box B + cold bundle…');
+const B = await Sandbox.create({ files: {}, cwd: '/home/user', persist: false, env });
+await importVfsSnapshot(B.kernel.vfs, new Uint8Array(snap.buffer, snap.byteOffset, snap.byteLength));
+for (const f of allNM(B.kernel.vfs).concat([])) { /* keep nm */ }
+// clear metro cache to force cold
+for (const f of (function all(vfs, d = '/', a = []) { let e; try { e = vfs.readdir(d); } catch { return a; } for (const x of e) { if (d === '/proc' || d === '/dev') continue; const f = d === '/' ? `/${x.name}` : `${d}/${x.name}`; let st; try { st = vfs.stat(f); } catch { continue; } if (st.type === 'directory') all(vfs, f, a); else a.push(f); } return a; })(B.kernel.vfs)) {
+  if (f.startsWith('/tmp/') || f.includes('/.expo/') || f.includes('/.cache/') || f.includes('/.metro')) { try { B.kernel.vfs.unlink(f); } catch {} }
+}
+B.shell.execute(`node ${cli} start --web ${APP}`, { cwd: APP, env: { ...B.env, EXPO_OFFLINE: '1' }, onStdout: out, onStderr: out }).catch(() => {});
+let bBytes = 0;
+if (await waitPort(B.kernel, 60000)) { await vmReq(B.kernel, '/').catch(() => {}); bBytes = (await vmReq(B.kernel, '/index.bundle?platform=web&dev=true&hot=false').catch(() => ({ bytes: 0 }))).bytes; }
+
+const smallEnough = snap.byteLength < 20 * 1048576; // pruned should be well under 20MB
+const ok = smallEnough && bBytes > 0 && refBytes > 0 && Math.abs(bBytes - refBytes) < refBytes * 0.02;
+console.log('\n================= lifo prune TEST =================');
+console.log('node_modules:', before, '→', after, `(${((after / before) * 100).toFixed(1)}%)`);
+console.log('pruned snapshot:', MB(snap.byteLength));
+console.log('reference bundle:', refBytes, ' pruned+restored cold bundle:', bBytes);
+console.log(ok ? '✅ PASS — `lifo prune` shrinks the box and Metro still cold-bundles' : '❌ FAIL');
+console.log('==================================================\n');
+server.close();
+process.exit(ok ? 0 : 1);

--- a/bench/validate-prune.mjs
+++ b/bench/validate-prune.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * validate-prune.mjs — Option 2 proof: keep REAL Metro, converge on the MINIMAL
+ * node_modules subset that still cold-bundles the web app.
+ *
+ *   Box A: scaffold + install + expo start --web + first bundle (trace reads).
+ *   keep := files Metro READ (file-granular) + every package.json.
+ *   Loop: build fresh Box B with only `keep` (NO cache → forced cold bundle);
+ *         if bundle 200 & bytes match → done; else add the files Metro tried to
+ *         resolve but couldn't (ENOENT on existing-in-A paths) and retry.
+ *
+ *   node bench/validate-prune.mjs
+ */
+import { performance } from 'node:perf_hooks';
+import http from 'node:http';
+import zlib from 'node:zlib';
+import { Sandbox, exportVfsSnapshot } from '../packages/core/dist/index.js';
+
+const T0 = performance.now();
+const log = (...a) => console.log(`[${((performance.now() - T0) / 1000).toFixed(1)}s]`, ...a);
+process.on('unhandledRejection', (e) => log('REJ:', e?.message || e));
+process.on('uncaughtException', (e) => log('UNCAUGHT:', e?.message || e));
+
+const CORS_PORT = 8793, PORT = 8081, APP = '/home/user/my-app';
+const isNM = (f) => f.includes('/node_modules/');
+const isPkgJson = (f) => f.endsWith('/package.json');
+const isCache = (f) => f.startsWith('/tmp/') || f.includes('/.expo/') || f.includes('/.cache/') || f.includes('/.metro');
+const gz = (b) => zlib.gzipSync(b, { level: 6 }).length;
+const MB = (n) => (n / 1048576).toFixed(2) + ' MB';
+const out = (s) => process.stdout.write(s);
+
+function startCors() {
+  const server = http.createServer((req, res) => {
+    (async () => {
+      const t = new URL(req.url, 'http://localhost').searchParams.get('url');
+      if (!t) { res.statusCode = 400; return res.end('x'); }
+      const up = await fetch(t, { headers: { accept: '*/*', 'user-agent': 'lifo' } });
+      res.statusCode = up.status; res.end(Buffer.from(await up.arrayBuffer()));
+    })().catch((e) => { res.statusCode = 502; res.end(e.message); });
+  });
+  return new Promise((r) => server.listen(CORS_PORT, () => r(server)));
+}
+
+// reads = readFile paths; miss = nm paths that were probed but ABSENT
+// (ENOENT throw on read/stat, OR exists()===false — how require.resolve probes).
+function instrument(vfs) {
+  const reads = new Set(), miss = new Set();
+  const wrap = (m, rec) => {
+    const orig = vfs[m]; if (typeof orig !== 'function') return;
+    vfs[m] = function (p, ...rest) {
+      if (rec && typeof p === 'string') reads.add(p);
+      try { return orig.call(this, p, ...rest); }
+      catch (e) { if (typeof p === 'string' && isNM(p)) miss.add(p); throw e; }
+    };
+  };
+  wrap('readFile', true);
+  for (const m of ['stat', 'lstat', 'readlink', 'realpath']) wrap(m, false);
+  const origExists = vfs.exists;
+  if (typeof origExists === 'function') {
+    vfs.exists = function (p, ...rest) {
+      const r = origExists.call(this, p, ...rest);
+      if (!r && typeof p === 'string' && isNM(p)) miss.add(p);
+      return r;
+    };
+  }
+  return { reads, miss };
+}
+
+function vmRequest(kernel, port, url, timeoutMs = 120000) {
+  const handler = kernel.portRegistry.get(port);
+  if (!handler) throw new Error(`no handler on ${port}`);
+  const vRes = { statusCode: 200, headers: {}, body: '' };
+  handler({ method: 'GET', url, headers: { host: `localhost:${port}` }, body: '' }, vRes);
+  const finish = () => ({
+    status: vRes.statusCode,
+    bytes: vRes.bodyBytes ? vRes.bodyBytes.byteLength : Buffer.byteLength(vRes.body || ''),
+    text: vRes.bodyBytes ? new TextDecoder().decode(vRes.bodyBytes) : (vRes.body || ''),
+  });
+  if (vRes._donePromise) {
+    const to = new Promise((_, rej) => setTimeout(() => rej(new Error('timeout')), timeoutMs));
+    return Promise.race([vRes._donePromise.then(finish), to]);
+  }
+  return Promise.resolve(finish());
+}
+
+async function waitForPort(kernel, port, ms = 120000) {
+  const s = performance.now();
+  while (performance.now() - s < ms) { if (kernel.portRegistry.has(port)) return true; await new Promise((r) => setTimeout(r, 400)); }
+  return false;
+}
+
+function allFiles(vfs, dir = '/', acc = []) {
+  let e; try { e = vfs.readdir(dir); } catch { return acc; }
+  for (const x of e) {
+    if (dir === '/proc' || dir === '/dev') continue;
+    const full = dir === '/' ? `/${x.name}` : `${dir}/${x.name}`;
+    let st; try { st = vfs.stat(full); } catch { continue; }
+    if (st.type === 'directory') allFiles(vfs, full, acc); else acc.push(full);
+  }
+  return acc;
+}
+function mkdirp(vfs, path) { let c = ''; for (const p of path.split('/').filter(Boolean)) { c += '/' + p; if (!vfs.exists(c)) vfs.mkdir(c); } }
+
+async function startExpo(sb, sink = out) {
+  const cli = `${APP}/node_modules/@expo/cli/build/bin/cli`;
+  sb.shell.execute(`node ${cli} start --web ${APP}`, { cwd: APP, env: { ...sb.env, EXPO_OFFLINE: '1' }, onStdout: sink, onStderr: sink })
+    .catch((e) => log('expo ended:', e.message));
+}
+async function coldBundle(sb, label) {
+  await vmRequest(sb.kernel, PORT, '/').catch(() => {});
+  const r = await vmRequest(sb.kernel, PORT, '/index.bundle?platform=web&dev=true&hot=false').catch((e) => ({ status: 0, bytes: 0, text: '', err: e.message }));
+  log(`  ${label} → ${r.status}, ${r.bytes} bytes ${r.err || ''}`);
+  return r;
+}
+
+const EXTS = ['', '.js', '.jsx', '.ts', '.tsx', '.json', '.cjs', '.mjs', '/index.js', '/index.ts', '.web.js', '.native.js'];
+// Given a Metro "Unable to resolve X from Y" pair, find the real file in A.
+function resolveTarget(vfs, fromFileAbs, spec) {
+  const dir = fromFileAbs.slice(0, fromFileAbs.lastIndexOf('/'));
+  const bases = [];
+  if (spec.startsWith('.')) {
+    // relative
+    const parts = (dir + '/' + spec).split('/'); const stack = [];
+    for (const p of parts) { if (p === '..') stack.pop(); else if (p !== '.' && p !== '') stack.push(p); }
+    bases.push('/' + stack.join('/'));
+  } else {
+    // bare package import — resolve under the app's node_modules
+    bases.push(`${APP}/node_modules/${spec}`);
+  }
+  for (const b of bases) for (const e of EXTS) { const cand = b + e; if (vfs.exists(cand)) { try { if (vfs.stat(cand).type === 'file') return cand; } catch {} } }
+  return null;
+}
+
+async function main() {
+  const cors = await startCors();
+  const env = { LIFO_CORS_PROXY: `http://localhost:${CORS_PORT}/_cors?url=`, EXPO_NO_TELEMETRY: '1', BROWSER: 'none' };
+
+  // ── BOX A: cold flow, keep it alive as the file source ──────────────────────
+  log('BOX A: booting…');
+  const A = await Sandbox.create({ files: {}, cwd: '/home/user', persist: false, env });
+  const trace = instrument(A.kernel.vfs);
+  const ro = { cwd: '/home/user', onStdout: out, onStderr: out, timeout: 600000 };
+  await A.commands.run(`npx create-expo-app@latest ${APP} --template blank --no-install`, ro);
+  await A.commands.run('npm install', { ...ro, cwd: APP });
+  await A.commands.run('npm install react-dom react-native-web@~0.21.0', { ...ro, cwd: APP });
+  trace.reads.clear();
+  await startExpo(A);
+  if (!(await waitForPort(A.kernel, PORT))) { log('A never bound'); process.exit(2); }
+  const a1 = await coldBundle(A, 'A bundle');
+
+  const allA = allFiles(A.kernel.vfs);
+  const nmAll = allA.filter(isNM);
+  const nonNm = allA.filter((f) => !isNM(f) && !isCache(f)); // app source, NO cache
+  const readBytes = (f) => { try { return A.kernel.vfs.readFile(f); } catch { return null; } };
+
+  // Initial keep: nm files Metro READ (file-granular) + every package.json.
+  const keep = new Set([...[...trace.reads].filter(isNM), ...nmAll.filter(isPkgJson)]);
+  log(`initial keep: ${keep.size} nm files (of ${nmAll.length})`);
+
+  // ── Converge: build B from keep, cold-bundle, add unresolved files, retry ───
+  let iter = 0, ok = false, b1 = { status: 0, bytes: 0 }, snapGz = 0;
+  while (iter++ < 20 && !ok) {
+    const B = await Sandbox.create({ files: {}, cwd: '/home/user', persist: false, env });
+    const tb = instrument(B.kernel.vfs);
+    for (const f of [...keep, ...nonNm]) { const data = readBytes(f); if (data == null) continue; mkdirp(B.kernel.vfs, f.slice(0, f.lastIndexOf('/'))); B.kernel.vfs.writeFile(f, data); }
+    const nmInB = allFiles(B.kernel.vfs).filter(isNM).length;
+    const snap = await exportVfsSnapshot(B.kernel.vfs);
+    snapGz = gz(Buffer.from(snap.buffer, snap.byteOffset, snap.byteLength));
+    log(`iter ${iter}: B has ${nmInB} nm files, snapshot ${MB(snapGz)} — cold bundling…`);
+    tb.miss.clear();
+    let blog = '';
+    const sink = (s) => { blog += s; };
+    await startExpo(B, sink);
+    // Metro binds in ~1s when config loads; if not bound in 30s it crashed.
+    if (await waitForPort(B.kernel, PORT, 30000)) b1 = await coldBundle(B, `iter ${iter}`);
+    else { log(`iter ${iter}: B never bound (config crash)`); b1 = { status: 0, bytes: 0 }; }
+
+    ok = b1.status === 200 && Math.abs(b1.bytes - a1.bytes) < a1.bytes * 0.02;
+    if (!ok) {
+      const errText = blog + (b1.text || '');
+      const add = new Set();
+      // (1) config-time probes: exists()===false / ENOENT on files present in A.
+      for (const f of tb.miss) if (A.kernel.vfs.exists(f) && !keep.has(f)) add.add(f);
+      // (2) bundle-time "Unable to resolve X from Y" (Metro file-map resolution).
+      for (const m of errText.matchAll(/Unable to resolve "([^"]+)" from "([^"]+)"/g)) {
+        const fromAbs = m[2].startsWith('/') ? m[2] : `${APP}/${m[2]}`;
+        const t = resolveTarget(A.kernel.vfs, fromAbs, m[1]);
+        if (t && !keep.has(t)) add.add(t);
+      }
+      log(`iter ${iter}: FAIL — adding ${add.size} files`);
+      [...add].slice(0, 20).forEach((f) => log('     + ' + f.replace(APP + '/node_modules/', '')));
+      if (add.size === 0) { log('  no addable files — different failure, stopping'); B.destroy?.(); break; }
+      for (const f of add) keep.add(f);
+    }
+    B.destroy?.();
+  }
+
+  console.log('\n================= VALIDATION VERDICT =================');
+  console.log('A cold bundle:', a1.status, a1.bytes, 'bytes');
+  console.log('B cold bundle:', b1.status, b1.bytes, 'bytes  (pruned + fresh box, cache cleared)');
+  console.log('iterations to converge:', iter);
+  console.log('final kept nm files:', keep.size, 'of', nmAll.length, `(${((keep.size / nmAll.length) * 100).toFixed(1)}%)`);
+  console.log('PRUNED SNAPSHOT gz:', MB(snapGz), ' (vs full ~99 MB)');
+  console.log(ok ? '✅ PASS — real Metro cold-bundles from the pruned subset' : '❌ FAIL — see missing files above');
+  console.log('======================================================\n');
+  cors.close();
+  process.exit(ok ? 0 : 1);
+}
+main().catch((e) => { console.error('FATAL', e); process.exit(1); });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "acorn": "^8.17.0",
+    "browser-metro": "1.0.31",
     "ws": "^8.19.0"
   },
   "peerDependencies": {

--- a/packages/core/src/commands/system/browser-metro-shims.ts
+++ b/packages/core/src/commands/system/browser-metro-shims.ts
@@ -1,0 +1,950 @@
+/**
+ * bundler-shims.ts
+ *
+ * Virtual module source strings injected into every project bundle by the
+ * expo-web bundler plugin. They run inside the iframe, not in this process,
+ * so they must be self-contained ES5-compatible JS strings.
+ *
+ * Three shims are provided:
+ *  1. GLOBALS_PREAMBLE       — prepended to the final bundle output
+ *  2. CLASSNAME_PATCH_MODULE — registered as "__classname-patch__"
+ *  3. NATIVEWIND_SHIM        — registered as "nativewind"
+ */
+
+/**
+ * Ensures React Native globals (__DEV__, global) exist in the browser
+ * before any app code runs. Prepended to the bundler output by expoWebPlugin.
+ */
+export const GLOBALS_PREAMBLE =
+  "if(typeof __DEV__==='undefined')globalThis.__DEV__=true;\n" +
+  "if(typeof global==='undefined')globalThis.global=globalThis;\n" +
+  // Install the `globalThis.expo` runtime that expo-modules-core's web build
+  // normally sets up via installExpoGlobalPolyfill() (polyfill/index.web.ts).
+  // On a device the JSI installs it; on Expo web the polyfill side-effect does.
+  // Our bundle doesn't run that side-effect, so `globalThis.expo.NativeModule`
+  // (and EventEmitter / registerWebModule's `modules` registry) are undefined —
+  // which makes any web NativeModule do `class X extends undefined` and crash at
+  // module load (e.g. expo-speech-recognition). This is a guarded, minimal mirror
+  // of CoreModule; the real polyfill early-returns if `globalThis.expo` exists.
+  "(function(){if(globalThis.expo&&globalThis.expo.NativeModule)return;" +
+  "function EE(){this.__l={};}" +
+  "EE.prototype.addListener=function(n,f){(this.__l[n]=this.__l[n]||[]).push(f);var s=this;return{remove:function(){s.removeListener(n,f);}};};" +
+  "EE.prototype.removeListener=function(n,f){var a=this.__l[n];if(a){var i=a.indexOf(f);if(i>=0)a.splice(i,1);}};" +
+  "EE.prototype.removeAllListeners=function(n){if(n)delete this.__l[n];else this.__l={};};" +
+  "EE.prototype.emit=function(n){var a=this.__l[n];if(a){var x=Array.prototype.slice.call(arguments,1);a.slice().forEach(function(f){try{f.apply(null,x);}catch(e){}});}};" +
+  "EE.prototype.listenerCount=function(n){return (this.__l[n]||[]).length;};" +
+  "function NM(){EE.call(this);}NM.prototype=Object.create(EE.prototype);NM.prototype.constructor=NM;" +
+  "function SO(){EE.call(this);}SO.prototype=Object.create(EE.prototype);SO.prototype.constructor=SO;" +
+  "var e=globalThis.expo||{};" +
+  "e.EventEmitter=e.EventEmitter||EE;e.NativeModule=e.NativeModule||NM;e.SharedObject=e.SharedObject||SO;e.SharedRef=e.SharedRef||SO;" +
+  "e.modules=e.modules||{};" +
+  "e.uuidv4=e.uuidv4||function(){return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g,function(c){var r=Math.random()*16|0;return (c==='x'?r:(r&0x3|0x8)).toString(16);});};" +
+  "e.reloadAppAsync=e.reloadAppAsync||function(){try{window.location.reload();}catch(_){}return Promise.resolve();};" +
+  "e.getViewConfig=e.getViewConfig||function(){throw new Error('getViewConfig is not implemented in the web preview');};" +
+  "globalThis.expo=e;})();\n";
+
+/**
+ * Registered as the virtual module "__classname-patch__" and required at the
+ * top of the bundle entry file so it runs before any component renders.
+ *
+ * Monkey-patches React.createElement so that:
+ *  - Any `className` string prop is converted to a react-native-web $$css
+ *    style object, letting Tailwind CDN class names work with RNW components.
+ *  - Any `__cssVars` style objects (produced by nativewind's `vars()`) are
+ *    applied as inline CSS custom properties via a ref injected onto the element.
+ */
+export const CLASSNAME_PATCH_MODULE = `
+var React = require("react");
+var _orig = React.createElement;
+
+// React's set of CSS properties whose numeric values are unitless (no px
+// suffix). Mirrors React DOM's internal list. Used when applying user
+// style via element.style[k] = v in a ref callback — numeric values for
+// any other key default to pixels (RN convention).
+var _UNITLESS = {
+  animationIterationCount: true, aspectRatio: true, borderImageOutset: true,
+  borderImageSlice: true, borderImageWidth: true, boxFlex: true,
+  boxFlexGroup: true, boxOrdinalGroup: true, columnCount: true, columns: true,
+  flex: true, flexGrow: true, flexPositive: true, flexShrink: true,
+  flexNegative: true, flexOrder: true, gridArea: true, gridRow: true,
+  gridRowEnd: true, gridRowSpan: true, gridRowStart: true, gridColumn: true,
+  gridColumnEnd: true, gridColumnSpan: true, gridColumnStart: true,
+  fontWeight: true, lineClamp: true, lineHeight: true, opacity: true,
+  order: true, orphans: true, scale: true, tabSize: true, widows: true,
+  zIndex: true, zoom: true,
+};
+
+// Extract __cssVars from a style prop (could be object, array, or nested)
+function _extractCssVars(style) {
+  if (!style) return null;
+  if (style.__cssVars) return style.__cssVars;
+  if (Array.isArray(style)) {
+    for (var i = 0; i < style.length; i++) {
+      var v = _extractCssVars(style[i]);
+      if (v) return v;
+    }
+  }
+  return null;
+}
+
+// Remove __cssVars objects from style to prevent RNW from processing them
+function _cleanStyle(style) {
+  if (!style) return style;
+  if (style.__cssVars) return undefined;
+  if (Array.isArray(style)) {
+    return style.filter(function(s) { return !s || !s.__cssVars; });
+  }
+  return style;
+}
+
+// Strip keys with undefined values from style objects (recurses into arrays).
+function _stripUndefined(style) {
+  if (!style) return style;
+  if (Array.isArray(style)) {
+    return style.map(_stripUndefined);
+  }
+  if (typeof style !== "object") return style;
+  var out = {};
+  for (var k in style) {
+    if (Object.prototype.hasOwnProperty.call(style, k) && style[k] !== undefined) {
+      out[k] = style[k];
+    }
+  }
+  return out;
+}
+
+// Apply a single style key/value to a DOM element. Numeric values get a
+// px suffix unless the key is in the unitless list. Null/undefined skipped.
+function _applyStyleKey(el, key, value) {
+  if (value == null) return;
+  if (typeof value === "number" && !_UNITLESS[key]) value = value + "px";
+  try { el.style[key] = value; } catch (e) {}
+}
+
+React.createElement = function() {
+  var args = Array.prototype.slice.call(arguments);
+  var type = args[0];
+  var props = args[1];
+
+  if (!props || typeof type === "string") {
+    return _orig.apply(this, args);
+  }
+
+  var className = (typeof props.className === "string" && props.className) ? props.className : null;
+  var cssVars = _extractCssVars(props.style);
+
+  if (!className && !cssVars) {
+    return _orig.apply(this, args);
+  }
+
+  props = Object.assign({}, props);
+  var cleanedStyle = _stripUndefined(_cleanStyle(props.style));
+
+  // Build the $$css class object from className tokens.
+  var cssObj = null;
+  if (className) {
+    cssObj = { $$css: true };
+    className.split(/\\s+/).forEach(function(c) { if (c) cssObj[c] = c; });
+    delete props.className;
+  }
+
+  // Detect the incompatibility case: className present AND user style is
+  // a non-empty plain object containing real CSS values. styleq cannot
+  // merge $$css tokens with mixed-type values — pairing them in an array
+  // makes React DOM Object.assign the array onto CSSStyleDeclaration,
+  // tripping its indexed-property setter ("Failed to set an indexed
+  // property [0] on CSSStyleDeclaration"). Defer the user style to a
+  // ref callback that writes via element.style[k] = v after mount.
+  var deferredUserStyle = null;
+  if (cssObj && cleanedStyle && typeof cleanedStyle === "object" && !Array.isArray(cleanedStyle)) {
+    // Plain object: defer to ref only if it has any real keys. An empty
+    // object (often the post-_stripUndefined shape of a buggy user style)
+    // collapses to just cssObj — same as having no user style at all.
+    if (Object.keys(cleanedStyle).length > 0) {
+      deferredUserStyle = cleanedStyle;
+    }
+    props.style = cssObj;
+  } else if (cssObj && Array.isArray(cleanedStyle) && cleanedStyle.length > 0) {
+    // Array form — preserve previous behavior, styleq handles arrays.
+    props.style = [cssObj].concat(cleanedStyle);
+  } else if (cssObj) {
+    props.style = cssObj;
+  } else if (cssVars && (!props.style || props.style.__cssVars)) {
+    // cssVars-only path with no remaining style — clear it.
+    props.style = undefined;
+  }
+
+  // Compose one ref that runs cssVars, deferred user style, then chains
+  // to the caller's original ref. Either or both may be active.
+  if (cssVars || deferredUserStyle) {
+    var existingRef = props.ref;
+    var _vars = cssVars;
+    var _userStyle = deferredUserStyle;
+    props.ref = function(el) {
+      if (el && el.style) {
+        if (_vars) {
+          for (var k in _vars) {
+            if (Object.prototype.hasOwnProperty.call(_vars, k)) {
+              el.style.setProperty(k, _vars[k]);
+            }
+          }
+        }
+        if (_userStyle) {
+          for (var k2 in _userStyle) {
+            if (Object.prototype.hasOwnProperty.call(_userStyle, k2)) {
+              _applyStyleKey(el, k2, _userStyle[k2]);
+            }
+          }
+        }
+      }
+      if (typeof existingRef === "function") existingRef(el);
+      else if (existingRef && typeof existingRef === "object" && existingRef !== null) {
+        existingRef.current = el;
+      }
+    };
+  }
+
+  args[1] = props;
+  return _orig.apply(this, args);
+};
+module.exports = {};
+`;
+
+/**
+ * Registered as the virtual module "nativewind". Provides web-compatible
+ * implementations of the nativewind APIs used in React Native projects:
+ *
+ *  - useColorScheme: React hook that tracks light/dark preference, responds
+ *    to system media-query changes, and exposes setColorScheme/toggleColorScheme.
+ *  - vars: wraps a CSS-variable object in a __cssVars marker so
+ *    CLASSNAME_PATCH_MODULE can apply them as inline CSS custom properties.
+ *  - cssInterop / remapProps: no-ops (handled natively on web).
+ *  - createStyleSheet: delegates to React Native StyleSheet.create.
+ */
+/**
+ * Registered as the virtual module "expo-constants". Reads the project's
+ * app.json at bundle time and exposes it as Constants.expoConfig so that
+ * `import Constants from 'expo-constants'; Constants.expoConfig?.name`
+ * works inside the browser preview.
+ */
+/**
+ * Build the expo-constants shim with the app.json content inlined.
+ * Must be called with the raw app.json string from the VFS.
+ */
+export function buildExpoConstantsShim(appJsonContent: string | undefined): string {
+  let expoConfigJson = 'null';
+  if (appJsonContent) {
+    try {
+      const parsed = JSON.parse(appJsonContent);
+      const config = parsed.expo || parsed;
+      expoConfigJson = JSON.stringify(config);
+    } catch(e) {}
+  }
+  return `
+var _expoConfig = ${expoConfigJson};
+
+var _constants = {
+  expoConfig: _expoConfig,
+  manifest: _expoConfig,
+  executionEnvironment: "storeClient",
+  appOwnership: null,
+  sessionId: "browser-metro",
+  isDevice: false,
+  platform: { ios: {}, android: {}, web: {} },
+  getWebViewUserAgentAsync: function() { return Promise.resolve(typeof navigator !== "undefined" ? navigator.userAgent : ""); },
+  installationId: "browser-metro-shim",
+  statusBarHeight: 0,
+  systemFonts: [],
+};
+module.exports = _constants;
+module.exports.__esModule = true;
+module.exports.default = _constants;
+`;
+}
+
+export const NATIVEWIND_SHIM = `
+var React = require("react");
+var RN = require("react-native");
+
+var _STORAGE_KEY = "__nativewind_color_scheme";
+var _listeners = new Set();
+var _userPref = null;
+
+// Restore persisted preference from localStorage (shared across iframes)
+if (typeof window !== "undefined" && window.localStorage) {
+  try { _userPref = window.localStorage.getItem(_STORAGE_KEY); } catch(e) {}
+}
+
+function _getSystemScheme() {
+  if (typeof window !== "undefined" && window.matchMedia) {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+  return "light";
+}
+
+function _getEffective() {
+  return (_userPref === "system" || _userPref === null) ? _getSystemScheme() : _userPref;
+}
+
+function _persistAndBroadcast(pref) {
+  _userPref = pref;
+  if (typeof window !== "undefined" && window.localStorage) {
+    try { window.localStorage.setItem(_STORAGE_KEY, pref); } catch(e) {}
+  }
+  var eff = _getEffective();
+  _listeners.forEach(function(l) { l(eff); });
+}
+
+if (typeof window !== "undefined") {
+  // Sync across iframes via localStorage storage event
+  window.addEventListener("storage", function(e) {
+    if (e.key === _STORAGE_KEY && e.newValue) {
+      _userPref = e.newValue;
+      var eff = _getEffective();
+      _listeners.forEach(function(l) { l(eff); });
+    }
+  });
+  if (window.matchMedia) {
+    window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", function() {
+      if (_userPref === "system" || _userPref === null) {
+        _listeners.forEach(function(l) { l(_getEffective()); });
+      }
+    });
+  }
+}
+
+exports.useColorScheme = function useColorScheme() {
+  var _s = React.useState(function() { return _getEffective(); });
+  var colorScheme = _s[0], setCS = _s[1];
+
+  React.useEffect(function() {
+    var listener = function(s) { setCS(s); };
+    _listeners.add(listener);
+    return function() { _listeners.delete(listener); };
+  }, []);
+
+  return {
+    colorScheme: colorScheme,
+    setColorScheme: function(scheme) {
+      _persistAndBroadcast(scheme);
+      var eff = scheme === "system" ? _getSystemScheme() : scheme;
+      setCS(eff);
+    },
+    toggleColorScheme: function() {
+      var next = colorScheme === "dark" ? "light" : "dark";
+      _persistAndBroadcast(next);
+      setCS(next);
+    }
+  };
+};
+
+exports.vars = function vars(obj) {
+  var result = {};
+  result.__cssVars = obj;
+  return result;
+};
+
+exports.cssInterop = function cssInterop(Component) {
+  return Component;
+};
+
+exports.remapProps = function remapProps(Component) {
+  return Component;
+};
+
+exports.createStyleSheet = function createStyleSheet(styles) {
+  return RN.StyleSheet.create(styles);
+};
+`;
+
+/**
+ * Shim for @expo-google-fonts/* packages.
+ * Returns useFonts as a stub that always returns [true, null] (fonts are loaded
+ * via Google Fonts CSS in the browser preview). Any named export (font variant
+ * names like Oswald_700Bold) returns an empty string — the actual font rendering
+ * is handled by @font-face CSS injected into the bundle HTML.
+ *
+ * Uses a Proxy so ANY named import resolves without needing to enumerate every
+ * possible font variant ahead of time.
+ */
+/**
+ * Shim for expo-font.
+ * The real expo-font uses native APIs that don't work in the browser preview.
+ * This shim provides a useFonts() that registers fonts via CSS @font-face
+ * using the data URL sources from the bundled @expo-google-fonts/* packages.
+ */
+export const EXPO_FONT_SHIM = `
+var _registered = {};
+function useFonts(fontMap) {
+  if (fontMap && typeof document !== 'undefined') {
+    var entries = Object.entries(fontMap);
+    for (var i = 0; i < entries.length; i++) {
+      var name = entries[i][0], src = entries[i][1];
+      if (src && typeof src === 'string' && !_registered[name]) {
+        _registered[name] = true;
+        var style = document.createElement('style');
+        style.textContent = '@font-face { font-family: "' + name + '"; src: url("' + src + '"); }';
+        document.head.appendChild(style);
+      }
+    }
+  }
+  return [true, null];
+}
+exports.useFonts = useFonts;
+exports.loadAsync = function loadAsync() { return Promise.resolve(); };
+exports.isLoaded = function isLoaded() { return true; };
+exports.isLoading = function isLoading() { return false; };
+exports.default = exports;
+`;
+
+/**
+ * Shim for react-native-reanimated.
+ * The real reanimated requires native worklet runtime which doesn't exist in
+ * the browser preview. This shim provides a web-compatible implementation
+ * using requestAnimationFrame-based animations.
+ *
+ * Injected via VFS + resolveRequest (not shimModules) to avoid changing the
+ * dependency batch hash used for package prefetching.
+ */
+export const REANIMATED_SHIM = `
+var React = require("react");
+var RN = require("react-native");
+
+// Mock worklet runtime
+if (typeof global !== "undefined" && !global._WORKLET_RUNTIME) {
+  global._WORKLET_RUNTIME = { createWorklet: function(fn) { return fn; }, runOnJS: function(fn) { return function() { return fn.apply(null, arguments); }; }, runOnUI: function(fn) { return function() { return fn.apply(null, arguments); }; }, makeShareableClone: function(v) { return v; } };
+  global._IS_WORKLET_RUNTIME = false;
+  global.__reanimatedWorkletInit = function() {};
+}
+if (typeof window !== "undefined" && !window._WORKLET_RUNTIME) {
+  window._WORKLET_RUNTIME = global._WORKLET_RUNTIME;
+  window._IS_WORKLET_RUNTIME = false;
+  window.__reanimatedWorkletInit = function() {};
+}
+
+// SharedValue class with animation support
+function SharedValue(initialValue) {
+  this._value = initialValue;
+  this._listeners = new Set();
+  this._animationId = null;
+  this._springState = null;
+}
+
+SharedValue.prototype = {
+  get value() { return this._value; },
+  set value(newValue) {
+    if (this._animationId !== null) {
+      if (typeof this._animationId === "number") cancelAnimationFrame(this._animationId);
+      else clearTimeout(this._animationId);
+      this._animationId = null;
+    }
+    if (newValue && typeof newValue === "object" && newValue.__isAnimationDescriptor) {
+      this._startAnimation(newValue);
+    } else {
+      this._setValue(newValue);
+    }
+  },
+  _setValue: function(v) {
+    if (this._value !== v) { this._value = v; this._listeners.forEach(function(l) { l(v); }); }
+  },
+  _startAnimation: function(desc) {
+    var self = this;
+    var type = desc.type;
+    var toValue = desc.toValue;
+    var config = desc.config || {};
+    var callback = desc.callback;
+    var fromValue = typeof this._value === "number" ? this._value : 0;
+    var startTime = performance.now();
+
+    if (type === "delay") {
+      var delayMs = desc.delayMs || 0;
+      var inner = desc.inner;
+      this._animationId = setTimeout(function() {
+        self._animationId = null;
+        if (inner && typeof inner === "object" && inner.__isAnimationDescriptor) {
+          self._startAnimation(inner);
+        } else if (inner !== undefined) {
+          self._setValue(typeof inner === "number" ? inner : inner);
+        }
+      }, delayMs);
+      return;
+    }
+
+    if (type === "sequence") {
+      var anims = desc.animations || [];
+      var idx = 0;
+      var runNext = function() {
+        if (idx >= anims.length) { if (callback) callback(true); return; }
+        var anim = anims[idx++];
+        if (anim && typeof anim === "object" && anim.__isAnimationDescriptor) {
+          var origCb = anim.callback;
+          anim.callback = function(finished) { if (origCb) origCb(finished); runNext(); };
+          self._startAnimation(anim);
+        } else {
+          if (typeof anim === "number") self._setValue(anim);
+          runNext();
+        }
+      };
+      runNext();
+      return;
+    }
+
+    if (type === "repeat") {
+      var innerAnim = desc.inner;
+      var reps = desc.numberOfReps;
+      var reverse = desc.reverse;
+      var count = 0;
+      var origFrom = fromValue;
+      var runRep = function() {
+        if (reps > 0 && count >= reps) { if (callback) callback(true); return; }
+        count++;
+        var anim = JSON.parse(JSON.stringify(innerAnim));
+        anim.__isAnimationDescriptor = true;
+        if (reverse && count % 2 === 0) {
+          var tmp = anim.toValue; anim.toValue = origFrom; origFrom = tmp;
+        }
+        anim.callback = function() { runRep(); };
+        self._startAnimation(anim);
+      };
+      runRep();
+      return;
+    }
+
+    var animate = function(currentTime) {
+      var elapsed = currentTime - startTime;
+      if (type === "timing") {
+        var duration = config.duration !== undefined ? config.duration : 300;
+        var easing = config.easing || function(t) { return t; };
+        if (elapsed >= duration) {
+          self._setValue(toValue);
+          self._animationId = null;
+          if (callback) callback(true);
+          return;
+        }
+        var progress = easing(elapsed / duration);
+        self._setValue(fromValue + (toValue - fromValue) * progress);
+        self._animationId = requestAnimationFrame(animate);
+      } else if (type === "spring") {
+        var damping = config.damping !== undefined ? config.damping : 10;
+        var stiffness = config.stiffness !== undefined ? config.stiffness : 100;
+        var mass = config.mass !== undefined ? config.mass : 1;
+        if (!self._springState) { self._springState = { velocity: config.velocity || 0, position: fromValue }; }
+        var dt = 1 / 60;
+        var sf = -stiffness * (self._springState.position - toValue);
+        var df = -damping * self._springState.velocity;
+        var acc = (sf + df) / mass;
+        self._springState.velocity += acc * dt;
+        self._springState.position += self._springState.velocity * dt;
+        self._setValue(self._springState.position);
+        if (Math.abs(self._springState.velocity) < 0.01 && Math.abs(self._springState.position - toValue) < 0.01) {
+          self._setValue(toValue); self._springState = null; self._animationId = null; if (callback) callback(true); return;
+        }
+        self._animationId = requestAnimationFrame(animate);
+      }
+    };
+    this._animationId = requestAnimationFrame(animate);
+  },
+  addListener: function(listener) {
+    var self = this;
+    this._listeners.add(listener);
+    return function() { self._listeners.delete(listener); };
+  }
+};
+
+// Hooks
+function useSharedValue(initialValue) {
+  var ref = React.useRef(null);
+  if (ref.current === null) ref.current = new SharedValue(initialValue);
+  return ref.current;
+}
+
+function useAnimatedStyle(styleFactory, deps) {
+  var _s = React.useReducer(function(x) { return x + 1; }, 0);
+  var forceUpdate = _s[1];
+  var styleRef = React.useRef({});
+  var listenersRef = React.useRef([]);
+
+  var computeStyle = function() {
+    listenersRef.current.forEach(function(u) { u(); });
+    listenersRef.current = [];
+    var accessed = [];
+    var origGet = Object.getOwnPropertyDescriptor(SharedValue.prototype, "value").get;
+    Object.defineProperty(SharedValue.prototype, "value", {
+      get: function() { accessed.push(this); return origGet.call(this); }, configurable: true
+    });
+    try { styleRef.current = styleFactory(); } catch(e) { styleRef.current = {}; }
+    Object.defineProperty(SharedValue.prototype, "value", { get: origGet, configurable: true });
+    accessed.forEach(function(sv) {
+      var unsub = sv.addListener(function() { styleRef.current = styleFactory(); forceUpdate(); });
+      listenersRef.current.push(unsub);
+    });
+    return styleRef.current;
+  };
+
+  React.useEffect(function() {
+    computeStyle();
+    return function() { listenersRef.current.forEach(function(u) { u(); }); };
+  }, deps || []);
+
+  if (Object.keys(styleRef.current).length === 0) {
+    try { styleRef.current = styleFactory(); } catch(e) { styleRef.current = {}; }
+  }
+  return styleRef.current;
+}
+
+function useAnimatedProps(f, d) { return useAnimatedStyle(f, d); }
+function useAnimatedRef() { return React.useRef(null); }
+// Tracks a scrollable ref's offset as a shared value. Used by the default Expo
+// tabs template's ParallaxScrollView (import { useScrollViewOffset }). Missing
+// it made the compiled call \`.useScrollViewOffset.call(void 0, ref)\` read
+// 'call' off undefined and crash the whole screen.
+function useScrollViewOffset(animatedRef) {
+  var offset = useSharedValue(0);
+  React.useEffect(function () {
+    var node = animatedRef && animatedRef.current;
+    if (!node) return undefined;
+    var el = node && typeof node.getScrollableNode === 'function' ? node.getScrollableNode() : node;
+    if (!el || typeof el.addEventListener !== 'function') return undefined;
+    var handler = function () { offset.value = el.scrollTop || el.scrollY || 0; };
+    handler();
+    el.addEventListener('scroll', handler, { passive: true });
+    return function () { el.removeEventListener('scroll', handler); };
+  }, [animatedRef]);
+  return offset;
+}
+function useDerivedValue(f, d) {
+  var sv = useSharedValue(null);
+  React.useEffect(function() { try { sv.value = f(); } catch(e) {} }, d || []);
+  return sv;
+}
+function useAnimatedReaction(prep, react, d) {
+  React.useEffect(function() { try { react(prep()); } catch(e) {} }, d || []);
+}
+function useAnimatedScrollHandler(handlers) {
+  return function(event) {
+    if (typeof handlers === "function") handlers(event);
+    else if (handlers.onScroll) handlers.onScroll(event);
+  };
+}
+function useAnimatedGestureHandler(handlers) {
+  var ctxRef = React.useRef({});
+  return React.useCallback(function(event) {
+    var e = event.nativeEvent; var ctx = ctxRef.current;
+    if (e.state === 2) { if (handlers.onStart) handlers.onStart(e, ctx); }
+    else if (e.state === 4) { if (handlers.onActive) handlers.onActive(e, ctx); }
+    else if (e.state === 5) { if (handlers.onEnd) handlers.onEnd(e, ctx); }
+  }, [handlers]);
+}
+function useWorkletCallback(cb, d) { return React.useCallback(cb, d || []); }
+function useFrameCallback(cb) {
+  React.useEffect(function() {
+    var id; var frame = function() { cb(); id = requestAnimationFrame(frame); };
+    id = requestAnimationFrame(frame);
+    return function() { cancelAnimationFrame(id); };
+  }, [cb]);
+}
+function useAnimatedKeyboard() { return { height: useSharedValue(0), state: useSharedValue(0) }; }
+function useAnimatedSensor() { return { sensor: useSharedValue({ x: 0, y: 0, z: 0 }) }; }
+
+// Animation functions
+function withTiming(toValue, config, callback) {
+  return { __isAnimationDescriptor: true, type: "timing", toValue: toValue, config: config || {}, callback: callback };
+}
+function withSpring(toValue, config, callback) {
+  return { __isAnimationDescriptor: true, type: "spring", toValue: toValue, config: config || {}, callback: callback };
+}
+function withDecay(config, callback) {
+  var v = (config && config.velocity) || 0;
+  var d = (config && config.deceleration) || 0.998;
+  return v / (1 - d);
+}
+function withDelay(delayMs, animation) {
+  return { __isAnimationDescriptor: true, type: "delay", delayMs: delayMs, inner: animation };
+}
+function withRepeat(animation, numberOfReps, reverse, callback) {
+  return { __isAnimationDescriptor: true, type: "repeat", inner: animation, numberOfReps: numberOfReps || -1, reverse: !!reverse, callback: callback };
+}
+function withSequence() {
+  var anims = Array.prototype.slice.call(arguments);
+  return { __isAnimationDescriptor: true, type: "sequence", animations: anims };
+}
+function cancelAnimation(sv) {
+  if (sv && sv._animationId !== null) {
+    if (typeof sv._animationId === "number") cancelAnimationFrame(sv._animationId);
+    else clearTimeout(sv._animationId);
+    sv._animationId = null;
+  }
+}
+
+// Easing
+var Easing = {
+  linear: function(t) { return t; },
+  ease: function(t) { return t * t * (3 - 2 * t); },
+  quad: function(t) { return t * t; },
+  cubic: function(t) { return t * t * t; },
+  poly: function(n) { return function(t) { return Math.pow(t, n); }; },
+  sin: function(t) { return 1 - Math.cos(t * Math.PI / 2); },
+  circle: function(t) { return 1 - Math.sqrt(1 - t * t); },
+  exp: function(t) { return t === 0 ? 0 : Math.pow(2, 10 * (t - 1)); },
+  elastic: function(b) { b = b || 1; return function(t) { var p = b * Math.PI; return 1 - Math.pow(Math.cos(t * Math.PI / 2), 3) * Math.cos(t * p); }; },
+  back: function(s) { s = s || 1.70158; return function(t) { return t * t * ((s + 1) * t - s); }; },
+  bounce: function(t) {
+    if (t < 1/2.75) return 7.5625*t*t;
+    if (t < 2/2.75) { t -= 1.5/2.75; return 7.5625*t*t + 0.75; }
+    if (t < 2.5/2.75) { t -= 2.25/2.75; return 7.5625*t*t + 0.9375; }
+    t -= 2.625/2.75; return 7.5625*t*t + 0.984375;
+  },
+  bezier: function(x1, y1, x2, y2) {
+    return function(t) {
+      var cx = 3*x1, bx = 3*(x2-x1)-cx, ax = 1-cx-bx;
+      var cy = 3*y1, by = 3*(y2-y1)-cy, ay = 1-cy-by;
+      var sx = function(t) { return ((ax*t+bx)*t+cx)*t; };
+      var sy = function(t) { return ((ay*t+by)*t+cy)*t; };
+      var solve = function(x) { var t2 = x; for (var i = 0; i < 8; i++) { var x2 = sx(t2)-x; if (Math.abs(x2)<0.001) break; var d2 = (3*ax*t2+2*bx)*t2+cx; if (Math.abs(d2)<0.000001) break; t2 -= x2/d2; } return t2; };
+      return sy(solve(t));
+    };
+  },
+  in: function(e) { return e; },
+  out: function(e) { return function(t) { return 1 - e(1 - t); }; },
+  inOut: function(e) { return function(t) { return t < 0.5 ? e(t*2)/2 : (2 - e(2 - t*2))/2; }; }
+};
+
+// Interpolation
+var Extrapolate = { CLAMP: "clamp", EXTEND: "extend", IDENTITY: "identity" };
+var Extrapolation = Extrapolate;
+
+function interpolate(value, inputRange, outputRange, extrapolate) {
+  extrapolate = extrapolate || Extrapolate.EXTEND;
+  for (var i = 0; i < inputRange.length - 1; i++) {
+    if (value >= inputRange[i] && value <= inputRange[i + 1]) {
+      var ratio = (value - inputRange[i]) / (inputRange[i + 1] - inputRange[i]);
+      return outputRange[i] + ratio * (outputRange[i + 1] - outputRange[i]);
+    }
+  }
+  if (value < inputRange[0]) {
+    if (extrapolate === "clamp") return outputRange[0];
+    if (extrapolate === "identity") return value;
+    var r = (value - inputRange[0]) / (inputRange[1] - inputRange[0]);
+    return outputRange[0] + r * (outputRange[1] - outputRange[0]);
+  }
+  var last = inputRange.length - 1;
+  if (extrapolate === "clamp") return outputRange[last];
+  if (extrapolate === "identity") return value;
+  var r2 = (value - inputRange[last]) / (inputRange[last] - inputRange[last - 1]);
+  return outputRange[last] + r2 * (outputRange[last] - outputRange[last - 1]);
+}
+
+function interpolateColor(value, inputRange, outputRange) {
+  return interpolate(value, inputRange, outputRange);
+}
+
+// Utility functions
+function runOnJS(fn) { return function() { return fn.apply(null, arguments); }; }
+function runOnUI(fn) { return function() { return fn.apply(null, arguments); }; }
+function makeMutable(v) { return new SharedValue(v); }
+function makeShareable(v) { return v; }
+function processColor(c) { return c; }
+function convertToRGBA(c) { return c; }
+function measure() { return { x: 0, y: 0, width: 0, height: 0, pageX: 0, pageY: 0 }; }
+function scrollTo() {}
+
+// Animated components
+function createAnimatedComponent(Component) {
+  var Comp = React.forwardRef(function(props, ref) {
+    var style = props.style; var animatedProps = props.animatedProps;
+    var rest = Object.assign({}, props);
+    delete rest.style; delete rest.animatedProps;
+    var finalStyle = style && typeof style === "object" && style.value !== undefined ? style.value : style;
+    return React.createElement(Component, Object.assign({}, rest, animatedProps || {}, { style: finalStyle, ref: ref }));
+  });
+  Comp.displayName = "Animated(" + (Component.displayName || Component.name || "Component") + ")";
+  return Comp;
+}
+
+var AnimatedNS = {
+  View: createAnimatedComponent(RN.View),
+  Text: createAnimatedComponent(RN.Text),
+  Image: createAnimatedComponent(RN.Image),
+  ScrollView: createAnimatedComponent(RN.ScrollView),
+  FlatList: createAnimatedComponent(RN.FlatList),
+  createAnimatedComponent: createAnimatedComponent
+};
+
+// Layout animation stub
+var LayoutStub = { duration: function() { return LayoutStub; }, delay: function() { return LayoutStub; }, springify: function() { return LayoutStub; }, damping: function() { return LayoutStub; }, mass: function() { return LayoutStub; }, stiffness: function() { return LayoutStub; }, overshootClamping: function() { return LayoutStub; }, restDisplacementThreshold: function() { return LayoutStub; }, restSpeedThreshold: function() { return LayoutStub; }, build: function() { return LayoutStub; } };
+
+// Gesture stubs
+var GestureDetector = function(props) { return React.createElement(RN.View, null, props.children); };
+var Gesture = { Tap: function() { return {}; }, Pan: function() { return {}; }, Pinch: function() { return {}; }, Rotation: function() { return {}; }, Fling: function() { return {}; }, LongPress: function() { return {}; }, Race: function() { return {}; }, Simultaneous: function() { return {}; }, Exclusive: function() { return {}; } };
+
+// Exports
+exports.useSharedValue = useSharedValue;
+exports.useAnimatedStyle = useAnimatedStyle;
+exports.useAnimatedProps = useAnimatedProps;
+exports.useAnimatedRef = useAnimatedRef;
+exports.useScrollViewOffset = useScrollViewOffset;
+exports.useScrollOffset = useScrollViewOffset;
+exports.useDerivedValue = useDerivedValue;
+exports.useAnimatedReaction = useAnimatedReaction;
+exports.useAnimatedScrollHandler = useAnimatedScrollHandler;
+exports.useAnimatedGestureHandler = useAnimatedGestureHandler;
+exports.useWorkletCallback = useWorkletCallback;
+exports.useFrameCallback = useFrameCallback;
+exports.useAnimatedKeyboard = useAnimatedKeyboard;
+exports.useAnimatedSensor = useAnimatedSensor;
+exports.withTiming = withTiming;
+exports.withSpring = withSpring;
+exports.withDecay = withDecay;
+exports.withDelay = withDelay;
+exports.withRepeat = withRepeat;
+exports.withSequence = withSequence;
+exports.cancelAnimation = cancelAnimation;
+exports.Easing = Easing;
+exports.Extrapolate = Extrapolate;
+exports.Extrapolation = Extrapolation;
+exports.interpolate = interpolate;
+exports.interpolateColor = interpolateColor;
+exports.runOnJS = runOnJS;
+exports.runOnUI = runOnUI;
+exports.makeMutable = makeMutable;
+exports.makeShareable = makeShareable;
+exports.processColor = processColor;
+exports.convertToRGBA = convertToRGBA;
+exports.measure = measure;
+exports.scrollTo = scrollTo;
+exports.createAnimatedComponent = createAnimatedComponent;
+exports.GestureDetector = GestureDetector;
+exports.Gesture = Gesture;
+exports.SharedTransition = { custom: function() { return {}; }, duration: function() { return {}; } };
+exports.Layout = LayoutStub;
+exports.FadeIn = LayoutStub; exports.FadeOut = LayoutStub;
+exports.FadeInRight = LayoutStub; exports.FadeInLeft = LayoutStub;
+exports.FadeInUp = LayoutStub; exports.FadeInDown = LayoutStub;
+exports.FadeOutRight = LayoutStub; exports.FadeOutLeft = LayoutStub;
+exports.FadeOutUp = LayoutStub; exports.FadeOutDown = LayoutStub;
+exports.SlideInRight = LayoutStub; exports.SlideInLeft = LayoutStub;
+exports.SlideInUp = LayoutStub; exports.SlideInDown = LayoutStub;
+exports.SlideOutRight = LayoutStub; exports.SlideOutLeft = LayoutStub;
+exports.SlideOutUp = LayoutStub; exports.SlideOutDown = LayoutStub;
+exports.ZoomIn = LayoutStub; exports.ZoomOut = LayoutStub;
+exports.BounceIn = LayoutStub; exports.BounceOut = LayoutStub;
+exports.FlipInXUp = LayoutStub; exports.FlipInXDown = LayoutStub;
+exports.FlipInYLeft = LayoutStub; exports.FlipInYRight = LayoutStub;
+exports.FlipOutXUp = LayoutStub; exports.FlipOutXDown = LayoutStub;
+exports.FlipOutYLeft = LayoutStub; exports.FlipOutYRight = LayoutStub;
+exports.StretchInX = LayoutStub; exports.StretchInY = LayoutStub;
+exports.StretchOutX = LayoutStub; exports.StretchOutY = LayoutStub;
+exports.RotateInDownLeft = LayoutStub; exports.RotateInDownRight = LayoutStub;
+exports.RotateInUpLeft = LayoutStub; exports.RotateInUpRight = LayoutStub;
+exports.RotateOutDownLeft = LayoutStub; exports.RotateOutDownRight = LayoutStub;
+exports.RotateOutUpLeft = LayoutStub; exports.RotateOutUpRight = LayoutStub;
+exports.LightSpeedInRight = LayoutStub; exports.LightSpeedInLeft = LayoutStub;
+exports.LightSpeedOutRight = LayoutStub; exports.LightSpeedOutLeft = LayoutStub;
+exports.PinwheelIn = LayoutStub; exports.PinwheelOut = LayoutStub;
+exports.RollInLeft = LayoutStub; exports.RollInRight = LayoutStub;
+exports.RollOutLeft = LayoutStub; exports.RollOutRight = LayoutStub;
+exports.Animated = AnimatedNS;
+exports.default = Object.assign({}, AnimatedNS, exports);
+exports.__esModule = true;
+`;
+
+/**
+ * Shim for react-native-webview.
+ * The real package wraps a native UIWebView/WKWebView/Android WebView which doesn't
+ * exist in the browser. This shim renders an <iframe> wrapped in an RN View so flex
+ * layout from RN parents continues to work.
+ *
+ * Supports `source.uri` and `source.html`, forwards a ref with best-effort imperative
+ * methods (reload, goBack, goForward, injectJavaScript, postMessage), and bridges
+ * onMessage via window 'message' events (only fires for same-origin / srcDoc).
+ *
+ * Injected via VFS + resolveRequest (not shimModules) to avoid changing the
+ * dependency batch hash used for package prefetching, since react-native-webview
+ * ships in the default scaffold package.json.
+ */
+export const WEBVIEW_SHIM = `
+var React = require("react");
+var RN = require("react-native");
+
+var WebView = React.forwardRef(function WebView(props, ref) {
+  var iframeRef = React.useRef(null);
+  var src = props.source && props.source.uri ? props.source.uri : null;
+  var html = props.source && props.source.html != null ? props.source.html : null;
+  var injectedJS = props.injectedJavaScript;
+
+  var srcDoc = null;
+  if (html != null) {
+    srcDoc = injectedJS ? html + "<script>" + injectedJS + "<\\/script>" : html;
+  }
+
+  React.useImperativeHandle(ref, function() {
+    return {
+      reload: function() { var f = iframeRef.current; if (f) { try { f.src = f.src; } catch(e) {} } },
+      stopLoading: function() {},
+      goBack: function() { var f = iframeRef.current; if (f && f.contentWindow) { try { f.contentWindow.history.back(); } catch(e) {} } },
+      goForward: function() { var f = iframeRef.current; if (f && f.contentWindow) { try { f.contentWindow.history.forward(); } catch(e) {} } },
+      injectJavaScript: function(script) {
+        var f = iframeRef.current;
+        if (f && f.contentWindow) { try { f.contentWindow.eval(script); } catch(e) {} }
+      },
+      postMessage: function(message) {
+        var f = iframeRef.current;
+        if (f && f.contentWindow) { try { f.contentWindow.postMessage(message, "*"); } catch(e) {} }
+      },
+      requestFocus: function() { var f = iframeRef.current; if (f && f.contentWindow) { try { f.contentWindow.focus(); } catch(e) {} } },
+      clearCache: function() {},
+      clearHistory: function() {},
+      clearFormData: function() {}
+    };
+  }, []);
+
+  React.useEffect(function() {
+    if (!props.onMessage || typeof window === "undefined") return;
+    var handler = function(event) {
+      if (iframeRef.current && event.source === iframeRef.current.contentWindow) {
+        props.onMessage({ nativeEvent: { data: event.data, url: src || "" } });
+      }
+    };
+    window.addEventListener("message", handler);
+    return function() { window.removeEventListener("message", handler); };
+  }, [props.onMessage, src]);
+
+  React.useEffect(function() {
+    if (props.onLoadStart) props.onLoadStart({ nativeEvent: { url: src || "" } });
+  }, []);
+
+  var flat = (RN.StyleSheet && RN.StyleSheet.flatten) ? RN.StyleSheet.flatten(props.style) : props.style;
+  var containerStyle = Object.assign({ flex: 1, overflow: "hidden" }, flat || {});
+
+  var iframeProps = {
+    ref: iframeRef,
+    style: { width: "100%", height: "100%", border: "none", backgroundColor: containerStyle.backgroundColor || "transparent" },
+    title: props.testID || "react-native-webview",
+    sandbox: props.sandbox || "allow-scripts allow-same-origin allow-forms allow-popups allow-presentation allow-modals",
+    referrerPolicy: "no-referrer-when-downgrade",
+    allow: "fullscreen; camera; microphone; geolocation; clipboard-read; clipboard-write",
+    allowFullScreen: true,
+    onLoad: function() {
+      if (props.onLoad) props.onLoad({ nativeEvent: { url: src || "" } });
+      if (props.onLoadEnd) props.onLoadEnd({ nativeEvent: { url: src || "" } });
+      if (props.onNavigationStateChange) props.onNavigationStateChange({ url: src || "", title: "", loading: false, canGoBack: false, canGoForward: false });
+    },
+    onError: function() {
+      if (props.onError) props.onError({ nativeEvent: { description: "iframe failed to load", url: src || "" } });
+      if (props.onLoadEnd) props.onLoadEnd({ nativeEvent: { url: src || "" } });
+    }
+  };
+  if (srcDoc != null) iframeProps.srcDoc = srcDoc;
+  else if (src) iframeProps.src = src;
+
+  return React.createElement(RN.View, { style: containerStyle },
+    React.createElement("iframe", iframeProps)
+  );
+});
+
+WebView.displayName = "WebView";
+
+exports.WebView = WebView;
+exports.default = WebView;
+exports.__esModule = true;
+`;

--- a/packages/core/src/commands/system/browser-metro.ts
+++ b/packages/core/src/commands/system/browser-metro.ts
@@ -19,7 +19,7 @@
  * expo-router synthetic entry.
  */
 import {
-  Bundler,
+  IncrementalBundler,
   VirtualFS,
   typescriptTransformer,
   createReactRefreshTransformer,
@@ -27,7 +27,7 @@ import {
   createExpoWebShimsPlugin,
   createUnsupportedWebPackagesPlugin,
 } from 'browser-metro';
-import type { FileMap, BundlerConfig, BundlerPlugin } from 'browser-metro';
+import type { FileMap, BundlerConfig, BundlerPlugin, FileChange } from 'browser-metro';
 import type { Command } from '../types.js';
 import type { Kernel, VirtualRequest, VirtualResponse } from '../../kernel/index.js';
 import { resolve } from '../../utils/path.js';
@@ -175,13 +175,18 @@ function publicEnv(env: Record<string, string>): Record<string, string> {
   return out;
 }
 
-function pageHtml(): string {
+// The HMR client: polls /__bmhmr and either reloads (a rebuild that can't be
+// hot-applied) or forwards each hot update to the bundle's in-iframe HMR runtime
+// via window.postMessage({type:'hmr-update', …}) — which does React Refresh.
+function pageHtml(bundleVersion: number, hmrSeq: number): string {
   return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <style>html,body{height:100%;margin:0}body{overflow:hidden}#root{display:flex;height:100%;flex:1}</style>
 <script src="https://cdn.tailwindcss.com"></script>
-<script>(function(){var v;function p(){fetch('/__bmver',{cache:'no-store'}).then(function(r){return r.text();}).then(function(t){if(v===undefined)v=t;else if(t!==v)location.reload();setTimeout(p,1000);}).catch(function(){setTimeout(p,1500);});}p();})();</script>
+<script>(function(){var B=${bundleVersion},H=${hmrSeq};function p(){fetch('/__bmhmr?b='+B+'&h='+H,{cache:'no-store'}).then(function(r){return r.json();}).then(function(d){if(d.reload){location.reload();return;}if(d.updates){for(var i=0;i<d.updates.length;i++){var u=d.updates[i];window.postMessage({type:'hmr-update',updatedModules:u.update.updatedModules,removedModules:u.update.removedModules,reverseDepsMap:u.update.reverseDepsMap},'*');H=u.seq;}}setTimeout(p,300);}).catch(function(){setTimeout(p,800);});}p();})();</script>
 </head><body><div id="root"></div><script src="/index.bundle"></script></body></html>`;
 }
+
+interface HmrEntry { seq: number; update: { updatedModules: Record<string, string>; removedModules: string[]; reverseDepsMap?: Record<string, string[]> } }
 
 export function createBrowserMetroCommand(kernel: Kernel): Command {
   return async (ctx) => {
@@ -200,97 +205,143 @@ export function createBrowserMetroCommand(kernel: Kernel): Command {
       resolver: { sourceExts: SOURCE_EXTS },
       transformer: createReactRefreshTransformer(typescriptTransformer),
       server: { packageServerUrl: PACKAGE_SERVER },
+      hmr: { enabled: true, reactRefresh: true },
       plugins: [createDataBxPathPlugin(), makeExpoWebPlugin(), createExpoWebShimsPlugin(), createUnsupportedWebPackagesPlugin()],
       routerShim: true,
       assetPublicPath: ASSET_PREFIX,
       env: publicEnv(ctx.env),
     };
 
-    let currentBundle = '';
-    let version = 0;
-    let building = false;
-
-    // Assets live in the VFS (not on any HTTP origin like RapidNative's Supabase
-    // Storage), so we can't just point assetPublicPath at a URL. In the browser
-    // we read the bytes and materialize each asset as a blob: URL, then rewrite
-    // the bundle's `${ASSET_PREFIX}/…` URIs to those blobs — the preview iframe
-    // (same-origin) uses them directly, no per-request serving. In Node (no
-    // createObjectURL) we keep the paths and serve bytes via the port route.
+    // Assets live in the VFS (not on an HTTP origin like RapidNative's Supabase
+    // Storage), so we read the bytes and materialize each as a blob: URL, then
+    // rewrite the bundle's `${ASSET_PREFIX}/…` URIs (in the full bundle AND in
+    // hot-update module code) to those blobs — the same-origin preview iframe
+    // uses them directly. In Node (no createObjectURL) we keep the paths and
+    // serve bytes via the port route as a fallback.
     const canBlob = typeof URL !== 'undefined' && typeof URL.createObjectURL === 'function' && typeof Blob !== 'undefined';
-    let assetBlobs: string[] = [];
-    const revokeAssetBlobs = () => { for (const u of assetBlobs) { try { URL.revokeObjectURL(u); } catch { /* ignore */ } } assetBlobs = []; };
+    const assetBlobs = new Map<string, string>(); // uri -> blob URL
+    const revokeAssetBlobs = () => { for (const u of assetBlobs.values()) { try { URL.revokeObjectURL(u); } catch { /* ignore */ } } assetBlobs.clear(); };
     const ASSET_URI_RE = new RegExp(ASSET_PREFIX.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '/[^"\'`\\s)]+', 'g');
-    const materializeAssets = (bundle: string): string => {
-      if (!canBlob) return bundle;
-      revokeAssetBlobs();
-      const uris = new Set(bundle.match(ASSET_URI_RE) || []);
-      for (const uri of uris) {
-        const full = dir + uri.slice(ASSET_PREFIX.length);
-        try {
-          const bytes = kernel.vfs.readFile(full) as Uint8Array;
-          const blobUrl = URL.createObjectURL(new Blob([bytes as BlobPart], { type: mimeOf(uri) }));
-          assetBlobs.push(blobUrl);
-          bundle = bundle.split(uri).join(blobUrl);
-        } catch { /* leave the path; port route serves it as a fallback */ }
+    const materializeAssets = (code: string): string => {
+      if (!canBlob) return code;
+      for (const uri of new Set(code.match(ASSET_URI_RE) || [])) {
+        let blobUrl = assetBlobs.get(uri);
+        if (!blobUrl) {
+          try {
+            const bytes = kernel.vfs.readFile(dir + uri.slice(ASSET_PREFIX.length)) as Uint8Array;
+            blobUrl = URL.createObjectURL(new Blob([bytes as BlobPart], { type: mimeOf(uri) }));
+            assetBlobs.set(uri, blobUrl);
+          } catch { continue; }
+        }
+        code = code.split(uri).join(blobUrl);
       }
-      return bundle;
+      return code;
     };
 
-    const rebuild = async (): Promise<boolean> => {
-      const vfs = new VirtualFS(readFileMap(kernel.vfs, dir));
-      const entry = ensureEntry(vfs);
-      if (!entry) { ctx.stderr.write('browser-metro: no entry file (index/App or expo-router/entry) found\n'); return false; }
-      const bundle = await new Bundler(vfs, config).bundle(entry);
-      currentBundle = materializeAssets(bundle);
-      version++;
-      return true;
-    };
+    // ── incremental bundler over a persistent VFS ────────────────────────────
+    const bvfs = new VirtualFS(readFileMap(kernel.vfs, dir));
+    const entry = ensureEntry(bvfs);
+    if (!entry) { ctx.stderr.write('browser-metro: no entry file (index/App or expo-router/entry) found\n'); return 1; }
+    const bundler = new IncrementalBundler(bvfs, config);
+
+    let currentBundle = '';   // latest full bundle (for fresh loads / reloads)
+    let bundleVersion = 1;    // bumped when a rebuild can't be hot-applied → clients reload
+    let hmrSeq = 0;           // bumped per hot update
+    let hmrLog: HmrEntry[] = [];
 
     ctx.stdout.write(`browser-metro: bundling ${dir} (packages from ${PACKAGE_SERVER})…\n`);
     const t0 = Date.now();
     try {
-      if (!(await rebuild())) return 1;
+      const r = await bundler.build(entry);
+      currentBundle = materializeAssets(r.bundle);
     } catch (e) {
       ctx.stderr.write(`browser-metro: bundle failed: ${e instanceof Error ? e.message : String(e)}\n`);
       return 1;
     }
-    ctx.stdout.write(`browser-metro: bundled in ${((Date.now() - t0) / 1000).toFixed(1)}s (${(currentBundle.length / 1048576).toFixed(2)} MB). Serving on port ${port}.\n`);
+    ctx.stdout.write(`browser-metro: bundled in ${((Date.now() - t0) / 1000).toFixed(1)}s (${(currentBundle.length / 1048576).toFixed(2)} MB). Serving on port ${port} (HMR on).\n`);
 
     const handler = (req: VirtualRequest, res: VirtualResponse): void => {
-      const path = req.url.split('?')[0];
+      const [path, query] = req.url.split('?');
       if (path === '/index.bundle' || path.endsWith('/index.bundle')) {
         res.statusCode = 200; res.headers['content-type'] = 'application/javascript; charset=utf-8'; res.body = currentBundle;
-      } else if (path === '/__bmver') {
-        res.statusCode = 200; res.headers['content-type'] = 'text/plain'; res.body = String(version);
+      } else if (path === '/__bmhmr') {
+        const q = new URLSearchParams(query || '');
+        const cb = Number(q.get('b') || 0), ch = Number(q.get('h') || 0);
+        res.statusCode = 200; res.headers['content-type'] = 'application/json';
+        res.body = cb < bundleVersion
+          ? JSON.stringify({ reload: true, bundleVersion })
+          : JSON.stringify({ reload: false, bundleVersion, hmrSeq, updates: hmrLog.filter((u) => u.seq > ch) });
       } else if (path.startsWith(ASSET_PREFIX + '/')) {
-        // Serve an external asset's raw bytes from the VFS (binary-safe).
         const full = dir + path.slice(ASSET_PREFIX.length);
         try {
-          const bytes = kernel.vfs.readFile(full) as Uint8Array;
-          res.statusCode = 200;
-          res.headers['content-type'] = mimeOf(path);
-          res.headers['cache-control'] = 'no-cache';
-          res.bodyBytes = bytes;
+          res.statusCode = 200; res.headers['content-type'] = mimeOf(path); res.headers['cache-control'] = 'no-cache';
+          res.bodyBytes = kernel.vfs.readFile(full) as Uint8Array;
         } catch {
           res.statusCode = 404; res.headers['content-type'] = 'text/plain'; res.body = `asset not found: ${path}`;
         }
       } else {
-        res.statusCode = 200; res.headers['content-type'] = 'text/html; charset=utf-8'; res.body = pageHtml();
+        res.statusCode = 200; res.headers['content-type'] = 'text/html; charset=utf-8'; res.body = pageHtml(bundleVersion, hmrSeq);
       }
     };
     kernel.portRegistry.set(port, handler);
 
-    // Rebuild on file change (debounced), full reload via the version poller.
+    // ── file-watch → incremental rebuild → HMR (or reload) ───────────────────
+    const decoder = new TextDecoder();
     let timer: ReturnType<typeof setTimeout> | undefined;
-    const unwatch = kernel.vfs.watch(() => {
-      if (building) return;
+    let building = false;
+    let pending = new Set<string>();
+
+    const flush = async (): Promise<void> => {
+      if (building) return;                 // a rebuild is running; the timer will re-fire
+      const paths = [...pending]; pending = new Set();
+      const changes: FileChange[] = [];
+      let routeStructureChanged = false;
+      for (const abs of paths) {
+        const rel = abs.slice(dir.length);
+        if (!rel.startsWith('/') || SKIP_SEG.test(rel)) continue;
+        if (!kernel.vfs.exists(abs)) {
+          if (bvfs.exists(rel)) { bvfs.delete(rel); changes.push({ path: rel, type: 'delete' }); if (rel.startsWith('/app/')) routeStructureChanged = true; }
+          continue;
+        }
+        if (ASSET_EXT.test(rel)) { assetBlobs.delete(ASSET_PREFIX + rel); continue; }
+        const existed = bvfs.exists(rel);
+        try { bvfs.write(rel, decoder.decode(kernel.vfs.readFile(abs) as Uint8Array)); } catch { continue; }
+        changes.push({ path: rel, type: existed ? 'update' : 'create' });
+        if (!existed && rel.startsWith('/app/')) routeStructureChanged = true;
+      }
+      if (changes.length === 0) return;
+      // expo-router: adding/removing a route file regenerates the route context.
+      if (routeStructureChanged && bvfs.getPackageMain() === 'expo-router/entry') {
+        bvfs.write('/__expo_ctx.js', buildExpoRouteContext(bvfs));
+        changes.push({ path: '/__expo_ctx.js', type: 'update' });
+      }
+      building = true;
+      try {
+        const r = await bundler.rebuild(changes);
+        if (r.type === 'full' || !r.hmrUpdate || r.hmrUpdate.requiresReload) {
+          currentBundle = materializeAssets(r.bundle); bundleVersion++; hmrLog = [];
+          ctx.stdout.write(`browser-metro: full rebuild → reload (v${bundleVersion}).\n`);
+        } else {
+          currentBundle = materializeAssets(r.bundle);
+          const updatedModules: Record<string, string> = {};
+          for (const [k, v] of Object.entries(r.hmrUpdate.updatedModules)) updatedModules[k] = materializeAssets(v);
+          hmrLog.push({ seq: ++hmrSeq, update: { updatedModules, removedModules: r.hmrUpdate.removedModules, reverseDepsMap: r.hmrUpdate.reverseDepsMap } });
+          if (hmrLog.length > 300) hmrLog = hmrLog.slice(-300);
+          ctx.stdout.write(`browser-metro: hot update (${Object.keys(updatedModules).length} module(s)).\n`);
+        }
+      } catch (e) {
+        ctx.stderr.write(`browser-metro: rebuild failed: ${e instanceof Error ? e.message : String(e)}\n`);
+      } finally {
+        building = false;
+        if (pending.size) { clearTimeout(timer); timer = setTimeout(() => { void flush(); }, 50); }
+      }
+    };
+
+    const unwatch = kernel.vfs.watch((event: { path?: string; oldPath?: string }) => {
+      if (event.path) pending.add(event.path);
+      if (event.oldPath) pending.add(event.oldPath);
       clearTimeout(timer);
-      timer = setTimeout(async () => {
-        building = true;
-        try { await rebuild(); ctx.stdout.write(`browser-metro: rebuilt (v${version}).\n`); }
-        catch (e) { ctx.stderr.write(`browser-metro: rebuild failed: ${e instanceof Error ? e.message : String(e)}\n`); }
-        finally { building = false; }
-      }, 250);
+      timer = setTimeout(() => { void flush(); }, 200);
     });
 
     // Run until the command is aborted (Ctrl-C / kill).

--- a/packages/core/src/commands/system/browser-metro.ts
+++ b/packages/core/src/commands/system/browser-metro.ts
@@ -1,0 +1,307 @@
+/**
+ * browser-metro — a Metro REPLACEMENT that runs inside Lifo.
+ *
+ * Instead of downloading node_modules and running real Metro/Babel in the VM
+ * (heavy on mobile), this bundles the project with the `browser-metro` library:
+ * user files are sucrase-transformed in-realm and npm packages are fetched
+ * PRE-BUNDLED from the hosted package server (esm.reactnative.run). The result
+ * is a small (~2MB) self-contained bundle served on a virtual port, so the
+ * existing preview (service-worker or SW-free) shows it unchanged.
+ *
+ * It's a switchable OPTION — run this instead of `expo start --web` when you
+ * want the light/mobile path; keep real Metro for the power cases.
+ *
+ * Usage: browser-metro [projectDir] [--port <n>]
+ *
+ * Ported from RapidNative's production integration (rapidnative-website):
+ * the expo-web plugin (react-native→react-native-web alias, React auto-import,
+ * className patch), the runtime shims (browser-metro-shims.ts), and the
+ * expo-router synthetic entry.
+ */
+import {
+  Bundler,
+  VirtualFS,
+  typescriptTransformer,
+  createReactRefreshTransformer,
+  createDataBxPathPlugin,
+  createExpoWebShimsPlugin,
+  createUnsupportedWebPackagesPlugin,
+} from 'browser-metro';
+import type { FileMap, BundlerConfig, BundlerPlugin } from 'browser-metro';
+import type { Command } from '../types.js';
+import type { Kernel, VirtualRequest, VirtualResponse } from '../../kernel/index.js';
+import { resolve } from '../../utils/path.js';
+import {
+  GLOBALS_PREAMBLE, CLASSNAME_PATCH_MODULE, NATIVEWIND_SHIM,
+  EXPO_FONT_SHIM, REANIMATED_SHIM, WEBVIEW_SHIM, buildExpoConstantsShim,
+} from './browser-metro-shims.js';
+
+const PACKAGE_SERVER = 'https://esm.reactnative.run';
+const SOURCE_EXTS = ['web.tsx', 'web.ts', 'web.jsx', 'web.js', 'tsx', 'ts', 'jsx', 'js', 'json'];
+// External assets get { uri: ASSET_PREFIX + <vfs path> }; the dev server serves
+// their bytes at that prefix (preview routes root-absolute paths to this port).
+const ASSET_PREFIX = '/__bm_assets';
+const MIME: Record<string, string> = {
+  png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif', webp: 'image/webp',
+  svg: 'image/svg+xml', ico: 'image/x-icon', bmp: 'image/bmp',
+  ttf: 'font/ttf', otf: 'font/otf', woff: 'font/woff', woff2: 'font/woff2',
+  mp4: 'video/mp4', webm: 'video/webm', mp3: 'audio/mpeg', wav: 'audio/wav',
+};
+const mimeOf = (p: string) => MIME[p.split('?')[0].split('.').pop()?.toLowerCase() ?? ''] ?? 'application/octet-stream';
+const ASSET_EXT = /\.(png|jpe?g|gif|webp|ttf|otf|woff2?|mp4|mp3|wav|bin|ico)$/i;
+const SKIP_SEG = /(^|\/)(node_modules|\.git|\.expo|dist|\.cache|\.next)(\/|$)/;
+
+// Virtual paths the expo-web plugin resolves shimmed native packages to.
+const EXPO_CONSTANTS_VPATH = '/__shims__/expo-constants.js';
+const REANIMATED_VPATH = '/__shims__/react-native-reanimated.js';
+const WORKLETS_VPATH = '/__shims__/react-native-worklets.js';
+const WEBVIEW_VPATH = '/__shims__/react-native-webview.js';
+
+const isJSX = (f: string) => f.endsWith('.tsx') || f.endsWith('.jsx');
+const hasReactImport = (s: string) => /\bimport\s+React\b/.test(s) || /\bimport\s+\*\s+as\s+React\b/.test(s);
+
+function makeExpoWebPlugin(): BundlerPlugin {
+  return {
+    name: 'expo-web',
+    transformSource({ src, filename }) {
+      if (filename.endsWith('.json')) return { src: `module.exports = ${src};` };
+      let m = src, changed = false;
+      if (isJSX(filename) && !hasReactImport(src)) { m = 'import React from "react";\n' + m; changed = true; }
+      if (filename === '/index.tsx' || filename === '/index.ts' || filename === '/index.js') {
+        m = 'require("__classname-patch__");\n' + m; changed = true;
+      }
+      return changed ? { src: m } : null;
+    },
+    transformOutput({ code }) { return { code: GLOBALS_PREAMBLE + code }; },
+    resolveRequest(_ctx, name) {
+      if (name === 'expo-constants') return EXPO_CONSTANTS_VPATH;
+      if (name === 'react-native-reanimated') return REANIMATED_VPATH;
+      if (name === 'react-native-worklets') return WORKLETS_VPATH;
+      if (name === 'react-native-webview') return WEBVIEW_VPATH;
+      return null;
+    },
+    moduleAliases() { return { 'react-native': 'react-native-web' }; },
+    shimModules() {
+      return {
+        '__classname-patch__': CLASSNAME_PATCH_MODULE,
+        nativewind: NATIVEWIND_SHIM,
+        'react-native-css-interop': 'module.exports = {};',
+        'expo-font': EXPO_FONT_SHIM,
+      };
+    },
+  };
+}
+
+// ── expo-router synthetic entry (ported) ─────────────────────────────────────
+function buildExpoRouteContext(vfs: VirtualFS): string {
+  const routeExts = new Set(['tsx', 'ts', 'jsx', 'js']);
+  const entries: { contextKey: string; requirePath: string }[] = [];
+  for (const p of vfs.list()) {
+    if (!p.startsWith('/app/')) continue;
+    const ext = p.split('.').pop() || '';
+    if (!routeExts.has(ext)) continue;
+    entries.push({ contextKey: './' + p.slice('/app/'.length), requirePath: '.' + p.replace(/\.[^.]+$/, '') });
+  }
+  const loads = entries
+    .map((e) => `  try { modules["${e.contextKey}"] = require("${e.requirePath}"); } catch(e) { moduleErrors["${e.contextKey}"] = e; }`)
+    .join('\n');
+  return `var modules = {};
+var moduleErrors = {};
+function ctx(id) { if (id in moduleErrors) throw moduleErrors[id]; return modules[id]; }
+ctx.keys = function() { return Object.keys(modules).concat(Object.keys(moduleErrors)); };
+module.exports = ctx;
+${loads}
+`;
+}
+
+function buildExpoRouterEntry(): string {
+  return `import { registerRootComponent } from "expo";
+import { ExpoRoot } from "expo-router";
+import React from "react";
+function App() {
+  var ctx = require("./__expo_ctx");
+  if (typeof ctx !== "function" || typeof ctx.keys !== "function") return null;
+  return React.createElement(ExpoRoot, { context: ctx });
+}
+if (!window.__EXPO_ROOT_REGISTERED) {
+  registerRootComponent(App);
+  window.__EXPO_ROOT_REGISTERED = true;
+}
+`;
+}
+
+function ensureEntry(vfs: VirtualFS): string | null {
+  const entry = vfs.getEntryFile();
+  if (entry) return entry;
+  if (vfs.getPackageMain() === 'expo-router/entry') {
+    vfs.write('/__expo_ctx.js', buildExpoRouteContext(vfs));
+    vfs.write('/index.tsx', buildExpoRouterEntry());
+    return '/index.tsx';
+  }
+  return null;
+}
+
+// ── Lifo VFS → browser-metro FileMap ─────────────────────────────────────────
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function readFileMap(vfs: any, dir: string): FileMap {
+  const decoder = new TextDecoder();
+  const fm: FileMap = {};
+  const walk = (abs: string) => {
+    let entries;
+    try { entries = vfs.readdir(abs); } catch { return; }
+    for (const e of entries) {
+      const full = abs.endsWith('/') ? abs + e.name : abs + '/' + e.name;
+      const rel = full.slice(dir.length) || '/' + e.name;
+      if (SKIP_SEG.test(rel)) continue;
+      let st;
+      try { st = vfs.stat(full); } catch { continue; }
+      if (st.type === 'directory') { walk(full); continue; }
+      if (ASSET_EXT.test(rel)) { fm[rel] = { content: '', isExternal: true }; continue; }
+      try { fm[rel] = { content: decoder.decode(vfs.readFile(full)), isExternal: false }; } catch { /* skip */ }
+    }
+  };
+  walk(dir);
+  // Inject shim modules resolved via the expo-web plugin's resolveRequest.
+  fm[EXPO_CONSTANTS_VPATH] = { content: buildExpoConstantsShim(fm['/app.json']?.content), isExternal: false };
+  fm[REANIMATED_VPATH] = { content: REANIMATED_SHIM, isExternal: false };
+  fm[WORKLETS_VPATH] = { content: 'module.exports = {};', isExternal: false };
+  fm[WEBVIEW_VPATH] = { content: WEBVIEW_SHIM, isExternal: false };
+  return fm;
+}
+
+function publicEnv(env: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) if (/^(EXPO_PUBLIC_|NEXT_PUBLIC_)/.test(k)) out[k] = v;
+  return out;
+}
+
+function pageHtml(): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<style>html,body{height:100%;margin:0}body{overflow:hidden}#root{display:flex;height:100%;flex:1}</style>
+<script src="https://cdn.tailwindcss.com"></script>
+<script>(function(){var v;function p(){fetch('/__bmver',{cache:'no-store'}).then(function(r){return r.text();}).then(function(t){if(v===undefined)v=t;else if(t!==v)location.reload();setTimeout(p,1000);}).catch(function(){setTimeout(p,1500);});}p();})();</script>
+</head><body><div id="root"></div><script src="/index.bundle"></script></body></html>`;
+}
+
+export function createBrowserMetroCommand(kernel: Kernel): Command {
+  return async (ctx) => {
+    const rest = ctx.args.slice(1);
+    if (rest.includes('--help') || rest.includes('-h')) {
+      ctx.stdout.write('Usage: browser-metro [projectDir] [--port <n>]\n\nBundle an Expo web app with browser-metro (light Metro replacement) and serve it.\n');
+      return 0;
+    }
+    const pIdx = rest.indexOf('--port');
+    const port = Number(pIdx >= 0 ? rest[pIdx + 1] : 8081) || 8081;
+    const dirArg = rest.find((a) => !a.startsWith('-') && a !== String(port)) || '.';
+    const dir = resolve(ctx.cwd, dirArg);
+    if (!kernel.vfs.exists(dir)) { ctx.stderr.write(`browser-metro: no such directory: ${dir}\n`); return 1; }
+
+    const config: BundlerConfig = {
+      resolver: { sourceExts: SOURCE_EXTS },
+      transformer: createReactRefreshTransformer(typescriptTransformer),
+      server: { packageServerUrl: PACKAGE_SERVER },
+      plugins: [createDataBxPathPlugin(), makeExpoWebPlugin(), createExpoWebShimsPlugin(), createUnsupportedWebPackagesPlugin()],
+      routerShim: true,
+      assetPublicPath: ASSET_PREFIX,
+      env: publicEnv(ctx.env),
+    };
+
+    let currentBundle = '';
+    let version = 0;
+    let building = false;
+
+    // Assets live in the VFS (not on any HTTP origin like RapidNative's Supabase
+    // Storage), so we can't just point assetPublicPath at a URL. In the browser
+    // we read the bytes and materialize each asset as a blob: URL, then rewrite
+    // the bundle's `${ASSET_PREFIX}/…` URIs to those blobs — the preview iframe
+    // (same-origin) uses them directly, no per-request serving. In Node (no
+    // createObjectURL) we keep the paths and serve bytes via the port route.
+    const canBlob = typeof URL !== 'undefined' && typeof URL.createObjectURL === 'function' && typeof Blob !== 'undefined';
+    let assetBlobs: string[] = [];
+    const revokeAssetBlobs = () => { for (const u of assetBlobs) { try { URL.revokeObjectURL(u); } catch { /* ignore */ } } assetBlobs = []; };
+    const ASSET_URI_RE = new RegExp(ASSET_PREFIX.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '/[^"\'`\\s)]+', 'g');
+    const materializeAssets = (bundle: string): string => {
+      if (!canBlob) return bundle;
+      revokeAssetBlobs();
+      const uris = new Set(bundle.match(ASSET_URI_RE) || []);
+      for (const uri of uris) {
+        const full = dir + uri.slice(ASSET_PREFIX.length);
+        try {
+          const bytes = kernel.vfs.readFile(full) as Uint8Array;
+          const blobUrl = URL.createObjectURL(new Blob([bytes as BlobPart], { type: mimeOf(uri) }));
+          assetBlobs.push(blobUrl);
+          bundle = bundle.split(uri).join(blobUrl);
+        } catch { /* leave the path; port route serves it as a fallback */ }
+      }
+      return bundle;
+    };
+
+    const rebuild = async (): Promise<boolean> => {
+      const vfs = new VirtualFS(readFileMap(kernel.vfs, dir));
+      const entry = ensureEntry(vfs);
+      if (!entry) { ctx.stderr.write('browser-metro: no entry file (index/App or expo-router/entry) found\n'); return false; }
+      const bundle = await new Bundler(vfs, config).bundle(entry);
+      currentBundle = materializeAssets(bundle);
+      version++;
+      return true;
+    };
+
+    ctx.stdout.write(`browser-metro: bundling ${dir} (packages from ${PACKAGE_SERVER})…\n`);
+    const t0 = Date.now();
+    try {
+      if (!(await rebuild())) return 1;
+    } catch (e) {
+      ctx.stderr.write(`browser-metro: bundle failed: ${e instanceof Error ? e.message : String(e)}\n`);
+      return 1;
+    }
+    ctx.stdout.write(`browser-metro: bundled in ${((Date.now() - t0) / 1000).toFixed(1)}s (${(currentBundle.length / 1048576).toFixed(2)} MB). Serving on port ${port}.\n`);
+
+    const handler = (req: VirtualRequest, res: VirtualResponse): void => {
+      const path = req.url.split('?')[0];
+      if (path === '/index.bundle' || path.endsWith('/index.bundle')) {
+        res.statusCode = 200; res.headers['content-type'] = 'application/javascript; charset=utf-8'; res.body = currentBundle;
+      } else if (path === '/__bmver') {
+        res.statusCode = 200; res.headers['content-type'] = 'text/plain'; res.body = String(version);
+      } else if (path.startsWith(ASSET_PREFIX + '/')) {
+        // Serve an external asset's raw bytes from the VFS (binary-safe).
+        const full = dir + path.slice(ASSET_PREFIX.length);
+        try {
+          const bytes = kernel.vfs.readFile(full) as Uint8Array;
+          res.statusCode = 200;
+          res.headers['content-type'] = mimeOf(path);
+          res.headers['cache-control'] = 'no-cache';
+          res.bodyBytes = bytes;
+        } catch {
+          res.statusCode = 404; res.headers['content-type'] = 'text/plain'; res.body = `asset not found: ${path}`;
+        }
+      } else {
+        res.statusCode = 200; res.headers['content-type'] = 'text/html; charset=utf-8'; res.body = pageHtml();
+      }
+    };
+    kernel.portRegistry.set(port, handler);
+
+    // Rebuild on file change (debounced), full reload via the version poller.
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const unwatch = kernel.vfs.watch(() => {
+      if (building) return;
+      clearTimeout(timer);
+      timer = setTimeout(async () => {
+        building = true;
+        try { await rebuild(); ctx.stdout.write(`browser-metro: rebuilt (v${version}).\n`); }
+        catch (e) { ctx.stderr.write(`browser-metro: rebuild failed: ${e instanceof Error ? e.message : String(e)}\n`); }
+        finally { building = false; }
+      }, 250);
+    });
+
+    // Run until the command is aborted (Ctrl-C / kill).
+    await new Promise<void>((r) => {
+      if (ctx.signal.aborted) return r();
+      ctx.signal.addEventListener('abort', () => r(), { once: true });
+    });
+    clearTimeout(timer);
+    unwatch();
+    revokeAssetBlobs();
+    kernel.portRegistry.delete(port);
+    return 0;
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,6 +64,8 @@ export type { VfsChange, SyncOptions } from './kernel/vfs/sync.js';
 
 // VFS snapshot (tar.gz), operable on any VFS — non-blocking (yields)
 export { exportVfsSnapshot, importVfsSnapshot } from './kernel/vfs/snapshot.js';
+export { pruneExpoModules } from './sandbox/prune.js';
+export type { PruneOptions, PruneResult } from './sandbox/prune.js';
 export type { VfsSnapshotOptions } from './kernel/vfs/snapshot.js';
 
 // Blob storage & content store

--- a/packages/core/src/sandbox/Sandbox.ts
+++ b/packages/core/src/sandbox/Sandbox.ts
@@ -11,6 +11,7 @@ import { createHelpCommand } from '../commands/system/help.js';
 import { createNodeCommand } from '../commands/system/node.js';
 import { createCurlCommand } from '../commands/net/curl.js';
 import { createTunnelCommandV2 } from '../commands/net/tunnel-v2.js';
+import { createBrowserMetroCommand } from '../commands/system/browser-metro.js';
 import { createIfconfigCommand } from '../commands/net/ifconfig.js';
 import { createRouteCommand } from '../commands/net/route.js';
 import { createNetstatCommand } from '../commands/net/netstat.js';
@@ -130,6 +131,7 @@ export class Sandbox {
 		registry.register('node', createNodeCommand(kernel));
 		registry.register('curl', createCurlCommand(kernel));
 		registry.register('tunnel', createTunnelCommandV2(kernel));
+		registry.register('browser-metro', createBrowserMetroCommand(kernel));
 
 		// Register network commands
 		registry.register('ifconfig', createIfconfigCommand(kernel));

--- a/packages/core/src/sandbox/prune.ts
+++ b/packages/core/src/sandbox/prune.ts
@@ -1,0 +1,290 @@
+/**
+ * pruneExpoModules -- shrink an Expo project's node_modules to only what Metro
+ * reads, so a box snapshot is tiny (a blank Expo web app: ~99MB -> ~4-5MB).
+ * Run it right before snapshotting; real Metro still (cold-)bundles from the
+ * pruned tree.
+ *
+ * Deterministic, single pass. Host-side (needs kernel access) because it must
+ * trace the dev server FROM BOOT — the toolchain (Metro/Babel/@expo-cli) is read
+ * at startup, and the app graph while bundling. It:
+ *   1. Instruments the VFS (readFile + exists()).
+ *   2. Cold-starts a scratch `expo start --web -c` and bundles once.
+ *   3. keep = READ files  ∪  exists()-probed-present files (require.resolve
+ *      targets — Metro's crawl uses readdir/stat, not exists())  ∪  every
+ *      package.json  ∪  static relative-import closure of kept JS (catches
+ *      statically-imported-but-unread files like react-native-web/AppContainer).
+ *   4. Deletes every other node_modules file. The scratch bundle also leaves a
+ *      warm Metro cache consistent with the kept files, so restore is instant.
+ */
+
+import type { Sandbox } from './Sandbox.js';
+import type { Kernel } from '../kernel/index.js';
+import { resolve, join, dirname } from '../utils/path.js';
+
+export interface PruneOptions {
+  /** Project dir (default: sandbox cwd). */
+  projectDir?: string;
+  /** Scratch port for the trace server (default 8091). */
+  port?: number;
+  /** Progress callback. */
+  onLog?: (msg: string) => void;
+}
+
+export interface PruneResult {
+  before: number;
+  after: number;
+  deleted: number;
+  freedBytes: number;
+}
+
+const isNM = (f: string) => f.includes('/node_modules/');
+const isPkgJson = (f: string) => f.endsWith('/package.json');
+const JS_RE = /\.(js|jsx|ts|tsx|cjs|mjs)$/;
+const EXTS = ['', '.js', '.jsx', '.ts', '.tsx', '.json', '.cjs', '.mjs',
+  '.web.js', '.web.jsx', '.web.ts', '.web.tsx',
+  '/index.js', '/index.jsx', '/index.ts', '/index.tsx', '/index.web.js'];
+// Any import/require specifier (relative OR bare package).
+const SPEC_RE = /(?:require\(|import\s+[^'"]*?from\s+|import\(|export\s+[^'"]*?from\s+)\s*['"]([^'"]+)['"]/g;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+// Node builtins (never in node_modules) + web-aliased packages we must NOT
+// follow: `react-native` resolves to react-native-web on web, so chasing its
+// static graph would drag in unused native code.
+const SKIP_BARE = new Set([
+  'react-native',
+  'fs', 'path', 'os', 'util', 'events', 'stream', 'crypto', 'http', 'https',
+  'net', 'tls', 'zlib', 'url', 'assert', 'buffer', 'child_process', 'module',
+  'process', 'tty', 'readline', 'vm', 'dns', 'dgram', 'querystring', 'string_decoder',
+  'worker_threads', 'perf_hooks', 'async_hooks', 'inspector', 'v8', 'timers', 'console',
+]);
+const isBuiltinish = (spec: string) =>
+  SKIP_BARE.has(spec) || spec.startsWith('node:') || spec.startsWith('react-native/');
+// Packages whose bare imports we DO chase (conditional/dynamic require()s live
+// in the CLI + dev-server + bundler); elsewhere the runtime trace already read
+// what's needed, so chasing bare imports just adds unused code.
+const FOLLOW_BARE_FROM = /\/node_modules\/(@expo\/|expo\/|@react-native\/|metro[^/]*\/|@react-native-community\/)/;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function allFiles(vfs: any, dir: string, acc: string[] = []): string[] {
+  let entries;
+  try { entries = vfs.readdir(dir); } catch { return acc; }
+  for (const e of entries) {
+    const full = dir.endsWith('/') ? dir + e.name : dir + '/' + e.name;
+    let st;
+    try { st = vfs.stat(full); } catch { continue; }
+    if (st.type === 'directory') allFiles(vfs, full, acc);
+    else acc.push(full);
+  }
+  return acc;
+}
+
+function normJoin(dir: string, spec: string): string {
+  const stack: string[] = [];
+  for (const p of (dir + '/' + spec).split('/')) {
+    if (p === '..') stack.pop();
+    else if (p && p !== '.') stack.push(p);
+  }
+  return '/' + stack.join('/');
+}
+
+/** The `.../node_modules/<pkg>` root for a file, or '' if not under one. */
+function pkgRootOf(f: string): string {
+  const i = f.lastIndexOf('/node_modules/');
+  if (i < 0) return '';
+  const rest = f.slice(i + '/node_modules/'.length).split('/');
+  const pkg = rest[0]?.startsWith('@') ? `${rest[0]}/${rest[1]}` : rest[0];
+  return f.slice(0, i) + '/node_modules/' + pkg;
+}
+
+/**
+ * Resolve a BARE import (`toqr`, `@scope/pkg/sub`) from `fromFile` to the files
+ * it needs — walks up node_modules, resolves the subpath or the package's `main`
+ * / index. Returns existing files (may be several: entry + package.json).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function resolveBare(vfs: any, nmSet: Set<string>, fromFile: string, spec: string): string[] {
+  const seg = spec.split('/');
+  const pkg = spec.startsWith('@') ? `${seg[0]}/${seg[1]}` : seg[0];
+  const sub = spec.slice(pkg.length).replace(/^\//, '');
+  // walk up dirs looking for node_modules/<pkg>
+  let dir = fromFile.slice(0, fromFile.lastIndexOf('/'));
+  let pkgDir = '';
+  while (dir.length > 0) {
+    const cand = `${dir}/node_modules/${pkg}`;
+    if (nmSet.has(`${cand}/package.json`) || vfs.exists(cand)) { pkgDir = cand; break; }
+    const up = dir.slice(0, dir.lastIndexOf('/'));
+    if (up === dir) break;
+    dir = up;
+  }
+  if (!pkgDir) return [];
+  const out: string[] = [];
+  const isFile = (p: string) => { try { return vfs.stat(p).type === 'file'; } catch { return false; } };
+  const pj = `${pkgDir}/package.json`;
+  if (nmSet.has(pj)) out.push(pj);
+  const tryResolve = (base: string) => {
+    for (const e of EXTS) { const c = base + e; if (nmSet.has(c) && isFile(c)) { out.push(c); return true; } }
+    return false;
+  };
+  if (sub) {
+    tryResolve(`${pkgDir}/${sub}`);
+  } else {
+    let main = '';
+    try { main = JSON.parse(new TextDecoder().decode(vfs.readFile(pj) as Uint8Array)).main || ''; } catch { /* ignore */ }
+    if (!main || !tryResolve(`${pkgDir}/${main.replace(/^\.\//, '')}`)) tryResolve(`${pkgDir}/index`);
+  }
+  return out;
+}
+
+/** Fire a virtual HTTP GET into an in-VM port and await the response. */
+function vmRequest(kernel: Kernel, port: number, url: string, timeoutMs = 120000): Promise<void> {
+  const handler = kernel.portRegistry.get(port);
+  if (!handler) return Promise.reject(new Error(`no handler on port ${port}`));
+  const vRes: {
+    statusCode: number; headers: Record<string, string>; body: string;
+    bodyBytes?: Uint8Array; _donePromise?: Promise<unknown>;
+  } = { statusCode: 200, headers: {}, body: '' };
+  handler({ method: 'GET', url, headers: { host: `localhost:${port}` }, body: '' }, vRes);
+  if (vRes._donePromise) {
+    return Promise.race([
+      vRes._donePromise.then(() => undefined),
+      new Promise<void>((_, rej) => setTimeout(() => rej(new Error('bundle timeout')), timeoutMs)),
+    ]);
+  }
+  return Promise.resolve();
+}
+
+export async function pruneExpoModules(sandbox: Sandbox, opts: PruneOptions = {}): Promise<PruneResult> {
+  const kernel = sandbox.kernel;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const vfs = kernel.vfs as any;
+  const log = opts.onLog ?? (() => {});
+  const port = opts.port ?? 8091;
+  const isExpo = (d: string) => vfs.exists(join(d, 'node_modules/@expo/cli/build/bin/cli'));
+  // Resolve the project dir: explicit opt, else the sandbox cwd, else scan the
+  // cwd's immediate subdirs (the common "box at /home/user, app in ./my-app").
+  let dir = resolve(sandbox.cwd, opts.projectDir ?? '.');
+  if (!isExpo(dir)) {
+    const candidates: string[] = [];
+    try {
+      for (const e of vfs.readdir(sandbox.cwd)) {
+        if (e.type === 'directory') candidates.push(join(sandbox.cwd, e.name));
+      }
+    } catch { /* ignore */ }
+    const found = candidates.find(isExpo);
+    if (found) dir = found;
+  }
+  const nm = join(dir, 'node_modules');
+  // Trace via the `expo` package's bin wrapper — the SAME entry `npm run web` /
+  // `npx expo` resolve to. Tracing @expo/cli directly would prune expo/bin/cli.
+  const expoBin = join(dir, 'node_modules/expo/bin/cli');
+  const cli = vfs.exists(expoBin) ? expoBin : join(dir, 'node_modules/@expo/cli/build/bin/cli');
+  if (!vfs.exists(nm)) throw new Error(`pruneExpoModules: no node_modules found (looked in ${dir})`);
+  if (!vfs.exists(cli)) throw new Error(`pruneExpoModules: not an Expo project (missing expo/@expo cli) in ${dir}`);
+  log(`Project: ${dir}`);
+
+  const reads = new Set<string>();
+  const existsHits = new Set<string>();
+  const savedRead = vfs.readFile;
+  const savedExists = vfs.exists;
+  vfs.readFile = function (p: string, ...a: unknown[]) {
+    if (typeof p === 'string') reads.add(p);
+    return savedRead.call(this, p, ...a);
+  };
+  vfs.exists = function (p: string, ...a: unknown[]) {
+    const r = savedExists.call(this, p, ...a);
+    if (r && typeof p === 'string' && isNM(p)) existsHits.add(p);
+    return r;
+  };
+
+  try {
+    log(`Cold-starting a scratch web dev server on :${port} to trace…`);
+    // Fire the dev server; do NOT await (long-running). -c clears the transform
+    // cache so the trace is cold (captures every file Metro needs).
+    void sandbox.shell
+      .execute(`node ${cli} start --web --port ${port} -c ${dir}`, {
+        cwd: dir,
+        env: { ...sandbox.env, EXPO_OFFLINE: '1' },
+      })
+      .catch(() => {});
+
+    const deadline = Date.now() + 120000;
+    let bound = false;
+    while (Date.now() < deadline) {
+      if (kernel.portRegistry.has(port)) { bound = true; break; }
+      await sleep(300);
+    }
+    if (!bound) throw new Error('pruneExpoModules: dev server did not bind in time');
+
+    log('Bundling (cold) to trace the critical path…');
+    await vmRequest(kernel, port, '/').catch(() => {});
+    await vmRequest(kernel, port, `/index.bundle?platform=web&dev=true&hot=false`);
+  } finally {
+    vfs.readFile = savedRead;
+    vfs.exists = savedExists;
+  }
+
+  // ── keep-set ──────────────────────────────────────────────────────────────
+  const nmFiles = allFiles(vfs, nm);
+  const nmSet = new Set(nmFiles);
+  const keep = new Set<string>();
+  for (const f of reads) if (isNM(f) && nmSet.has(f)) keep.add(f);
+  for (const f of existsHits) if (nmSet.has(f)) keep.add(f);
+  for (const f of nmFiles) {
+    if (isPkgJson(f)) keep.add(f);                 // resolution reads these
+    if (f.includes('/node_modules/.bin/')) keep.add(f); // bin shims npm/`run` use
+  }
+
+  // static import closure over kept JS files. Relative imports are always
+  // followed. Bare (package) imports are chased only out of the CLI/bundler
+  // packages — where conditional require()s live (@expo/cli/qr.js -> 'toqr') —
+  // and transitively out of any package we pull in that way, so those are fully
+  // closed too. We do NOT chase bare imports elsewhere (e.g. babel), whose
+  // runtime-needed files the trace already read; following them adds dead code.
+  const decoder = new TextDecoder();
+  const isFile = (p: string) => { try { return vfs.stat(p).type === 'file'; } catch { return false; } };
+  const followRoots = new Set<string>(); // extra package roots to chase bare from
+  let frontier = [...keep].filter((f) => JS_RE.test(f));
+  while (frontier.length) {
+    const next: string[] = [];
+    for (const f of frontier) {
+      let src: string;
+      try { src = decoder.decode(vfs.readFile(f) as Uint8Array); } catch { continue; }
+      const fdir = dirname(f);
+      const chaseBare = FOLLOW_BARE_FROM.test(f) || followRoots.has(pkgRootOf(f));
+      for (const m of src.matchAll(SPEC_RE)) {
+        const spec = m[1];
+        let targets: string[];
+        let bare = false;
+        if (spec.startsWith('.')) {
+          targets = [];
+          const base = normJoin(fdir, spec);
+          for (const e of EXTS) { const c = base + e; if (nmSet.has(c) && isFile(c)) targets.push(c); }
+        } else if (isBuiltinish(spec) || !chaseBare) {
+          continue;
+        } else {
+          targets = resolveBare(vfs, nmSet, f, spec);
+          bare = true;
+        }
+        for (const cand of targets) {
+          if (bare) followRoots.add(pkgRootOf(cand)); // fully close pulled-in pkgs
+          if (!keep.has(cand)) {
+            keep.add(cand);
+            if (JS_RE.test(cand)) next.push(cand);
+          }
+        }
+      }
+    }
+    frontier = next;
+  }
+
+  // ── prune ─────────────────────────────────────────────────────────────────
+  let deleted = 0, freed = 0;
+  for (const f of nmFiles) {
+    if (keep.has(f)) continue;
+    try { freed += vfs.stat(f).size ?? 0; } catch { /* ignore */ }
+    try { vfs.unlink(f); deleted++; } catch { /* ignore */ }
+  }
+
+  const mb = (freed / 1048576).toFixed(1);
+  log(`Kept ${keep.size} / ${nmFiles.length} node_modules files, deleted ${deleted} (~${mb} MB freed). Snapshot now.`);
+  return { before: nmFiles.length, after: keep.size, deleted, freedBytes: freed };
+}

--- a/packages/core/src/shell/Shell.ts
+++ b/packages/core/src/shell/Shell.ts
@@ -879,7 +879,22 @@ export class Shell {
     this.redrawLine();
   }
 
+  /**
+   * Mirror the live terminal dimensions into LINES/COLUMNS so full-screen
+   * commands (nano, less, fastfetch, …) render to the real viewport. Without
+   * this they fall back to 24×80, so on a shorter pane the content overflows
+   * and scrolling kicks in ~(24 - realRows) lines too late.
+   */
+  private syncTerminalSize(): void {
+    const rows = this.terminal?.rows;
+    const cols = this.terminal?.cols;
+    if (typeof rows === 'number' && rows > 0) this.env['LINES'] = String(rows);
+    if (typeof cols === 'number' && cols > 0) this.env['COLUMNS'] = String(cols);
+  }
+
   private async executeLine(line: string): Promise<void> {
+    this.syncTerminalSize();
+
     // History expansion
     const expanded = this.historyManager.expand(line);
     const actualLine = expanded ?? line;

--- a/packages/core/src/shell/completer.ts
+++ b/packages/core/src/shell/completer.ts
@@ -139,30 +139,54 @@ function completeDirectory(word: string, ctx: CompletionContext): string[] {
   return listEntries(word, ctx, true);
 }
 
+// Characters the lexer treats as special outside quotes. They must be
+// backslash-escaped in a completion, or the completed command won't parse
+// (e.g. a dir named "(archive)" -> `cd \(archive\)/`). '/' and '~' are left
+// alone so path separators and the tilde prefix keep working.
+const SHELL_SPECIAL = /[\s()|;&<>#$`"'\\*?!{}[\]]/g;
+
+function shellEscape(s: string): string {
+  return s.replace(SHELL_SPECIAL, (c) => '\\' + c);
+}
+
+// Strip shell quoting/escaping from a typed word so it matches real filenames.
+function shellUnescape(word: string): string {
+  if (word.startsWith("'")) {
+    // single quotes are literal; drop the (possibly unclosed) quotes
+    return word.replace(/'/g, '');
+  }
+  let s = word;
+  if (s.startsWith('"')) s = s.slice(1).replace(/"$/, '');
+  return s.replace(/\\(.)/g, '$1');
+}
+
 function listEntries(word: string, ctx: CompletionContext, dirsOnly: boolean): string[] {
+  // Work on the unescaped/unquoted form for matching; re-escape on output.
+  const logical = shellUnescape(word);
+
   // Handle tilde
-  let expandedWord = word;
-  let tildePrefix = '';
-  if (word.startsWith('~/')) {
+  let expandedWord = logical;
+  if (logical.startsWith('~/')) {
     const home = ctx.env['HOME'] ?? '/home/user';
-    expandedWord = home + word.slice(1);
-    tildePrefix = '~/';
-  } else if (word === '~') {
+    expandedWord = home + logical.slice(1);
+  } else if (logical === '~') {
     const home = ctx.env['HOME'] ?? '/home/user';
     expandedWord = home;
-    tildePrefix = '~';
   }
 
   let dir: string;
   let prefix: string;
+  let logicalPathPrefix: string; // the dir portion of the typed word, unescaped
 
   if (expandedWord.includes('/')) {
     const lastSlash = expandedWord.lastIndexOf('/');
     dir = resolve(ctx.cwd, expandedWord.slice(0, lastSlash + 1));
     prefix = expandedWord.slice(lastSlash + 1);
+    logicalPathPrefix = logical.slice(0, logical.lastIndexOf('/') + 1);
   } else {
     dir = ctx.cwd;
     prefix = expandedWord;
+    logicalPathPrefix = '';
   }
 
   try {
@@ -174,15 +198,11 @@ function listEntries(word: string, ctx: CompletionContext, dirsOnly: boolean): s
     }
 
     return filtered.map((e) => {
-      const pathPrefix = word.includes('/') ? word.slice(0, word.lastIndexOf('/') + 1) : '';
       const suffix = e.type === 'directory' ? '/' : '';
-
-      // Use tilde prefix if applicable
-      if (tildePrefix && pathPrefix.startsWith(tildePrefix)) {
-        return pathPrefix + e.name + suffix;
-      }
-
-      return pathPrefix + e.name + suffix;
+      // Keep the leading ~ (tilde prefix) unescaped so it still expands.
+      const tilde = logicalPathPrefix.startsWith('~') ? '~' : '';
+      const restPrefix = tilde ? logicalPathPrefix.slice(1) : logicalPathPrefix;
+      return tilde + shellEscape(restPrefix) + shellEscape(e.name) + suffix;
     }).sort();
   } catch {
     return [];

--- a/packages/core/tests/shell/completer.test.ts
+++ b/packages/core/tests/shell/completer.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { lex } from '../../src/shell/lexer.js';
+import { TokenKind } from '../../src/shell/types.js';
+import { complete, type CompletionContext } from '../../src/shell/completer.js';
+
+function mockCtx(line: string): CompletionContext {
+  const vfs = {
+    readdir: () => [
+      { name: '(archive)', type: 'directory' as const },
+      { name: 'my project', type: 'directory' as const },
+      { name: 'readme.md', type: 'file' as const },
+      { name: 'src', type: 'directory' as const },
+    ],
+  };
+  return {
+    line, cursorPos: line.length, cwd: '/home/user', env: { HOME: '/home/user' },
+    vfs: vfs as never, registry: { list: () => ['cd', 'ls', 'echo'] } as never,
+    builtinNames: ['cd', 'ls'],
+  };
+}
+
+// word values the execution lexer produces (drops EOF)
+function words(input: string): string[] {
+  return lex(input).filter((t) => t.kind === TokenKind.Word).map((t) => t.value);
+}
+
+describe('completer — special chars are escaped', () => {
+  it('completes a "(" dir into a shell-escaped, runnable path', () => {
+    const r = complete(mockCtx('cd ('));
+    expect(r.completions).toEqual(['\\(archive\\)/']);
+    expect(r.replacementStart).toBe(3);
+  });
+
+  it('matches when the user pre-escaped the paren (cd \\()', () => {
+    const r = complete(mockCtx('cd \\('));
+    expect(r.completions).toEqual(['\\(archive\\)/']);
+  });
+
+  it('escapes spaces in names too', () => {
+    const r = complete(mockCtx('cd my'));
+    expect(r.completions).toEqual(['my\\ project/']);
+  });
+
+  it('escapes special chars even in a bare directory listing', () => {
+    const r = complete(mockCtx('cd '));
+    expect(r.completions).toContain('\\(archive\\)/');
+    expect(r.completions).toContain('src/');
+  });
+
+  it('leaves ordinary names untouched', () => {
+    const r = complete(mockCtx('ls read'));
+    expect(r.completions).toEqual(['readme.md']);
+  });
+});
+
+describe('completer — lexer round-trip', () => {
+  // The escaped completion must lex back to the real filename (not a subshell).
+  it('cd \\(archive\\)/ lexes to the (archive)/ path', () => {
+    expect(words('cd \\(archive\\)/')).toEqual(['cd', '(archive)/']);
+  });
+
+  it('cd my\\ project/ lexes to the "my project/" path', () => {
+    expect(words('cd my\\ project/')).toEqual(['cd', 'my project/']);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       acorn:
         specifier: ^8.17.0
         version: 8.17.0
+      browser-metro:
+        specifier: 1.0.31
+        version: 1.0.31
       ws:
         specifier: ^8.19.0
         version: 8.19.0
@@ -1997,6 +2000,11 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@sveltejs/acorn-typescript@1.0.11':
+    resolution: {integrity: sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==}
+    peerDependencies:
+      acorn: ^8.9.0
+
   '@tailwindcss/node@4.2.0':
     resolution: {integrity: sha512-Yv+fn/o2OmL5fh/Ir62VXItdShnUxfpkMA4Y7jdeC8O81WPB8Kf6TT6GSHvnqgSwDzlB5iT7kDpeXxLsUS0T6Q==}
 
@@ -2367,6 +2375,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  browser-metro@1.0.31:
+    resolution: {integrity: sha512-7H5ruaIw3gI6t/8r/RR+foHdZABoVJZtgW0NKZvnPLSer1VRP4j4P7X6Xj4Wei41GxbegE8F0lItSEfr8ilPCA==}
 
   browserslist@4.28.4:
     resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
@@ -6096,6 +6107,10 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@sveltejs/acorn-typescript@1.0.11(acorn@8.17.0)':
+    dependencies:
+      acorn: 8.17.0
+
   '@tailwindcss/node@4.2.0':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -6470,6 +6485,12 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  browser-metro@1.0.31:
+    dependencies:
+      '@sveltejs/acorn-typescript': 1.0.11(acorn@8.17.0)
+      acorn: 8.17.0
+      sucrase: 3.35.1
 
   browserslist@4.28.4:
     dependencies:


### PR DESCRIPTION
Runs **browser-metro** inside Lifo as a switchable alternative to real Metro — the light/mobile path. Instead of installing `node_modules` and running Metro+Babel in the VM, it sucrase-transforms your files and fetches **pre-built** npm packages from `esm.reactnative.run`: a **~2 MB self-contained bundle, no `node_modules`** (vs the ~23 MB pruned real-Metro snapshot).

> Stacked on the prune + SW-free-preview work (PR #30). Retarget to `main` once that lands.

## Why
browser-metro is proven light on phones precisely because it keeps the expensive bundling off the device (packages pre-bundled server-side; only user files transformed on-device). This brings that path into Lifo while keeping real Metro (and real Node/backends) as the power tier.

## Command — `browser-metro`
`packages/core/src/commands/system/browser-metro.ts` (registered in the VM). Run `browser-metro` instead of `npx expo start --web`.
- Lifo VFS → browser-metro `VirtualFS`; bundles with the ported **expo-web plugin** (`react-native → react-native-web` alias, React auto-import, className patch), **vendored runtime shims** (`browser-metro-shims.ts`), and **expo-router** synthetic entry. Packages from `https://esm.reactnative.run`.
- Serves `GET /` + `/index.bundle` on a virtual port with **file-watch rebuild + live-reload**; the existing preview (SW or SW-free) shows it.
- **Assets** are materialized as browser **`blob:` URLs** from the VFS bytes — Lifo's assets live in the VFS, not on an HTTP origin like RapidNative's Supabase Storage, so we pull the bytes into a blob and rewrite the bundle's asset URIs (Node port-route fallback kept). Icon fonts come inlined from the package server.
- Added `useScrollViewOffset`/`useScrollOffset` to the reanimated shim — the Expo tabs template's `ParallaxScrollView` imports it; missing it crashed the screen (`X.useScrollViewOffset.call(void 0, …)` → `.call` on `undefined`).

`browser-metro@1.0.31` added as a dependency (can become a lifo plugin later).

## Playground
A **"browser-metro (light)"** example — a lean ~2 MB `.tsx` Expo app — registered with a code snippet.

## Testing
- Core + playground typecheck clean.
- Headless harnesses (`bench/`): `test-browser-metro` (VFS → 1.98 MB bundle via the real package server), `test-bm-command` (command → serve on port), `test-bm-assets` (asset → `blob:` URL from VFS bytes).
- Render verified via a jsdom harness (not committed — depends on a local jsdom): the example app and a `ParallaxScrollView` repro render without errors.
- Manual: playground → "browser-metro (light)" → run `browser-metro` → renders + edit-reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)