### PR TITLE
fix(node): surface real unhandled-rejection reasons; document tinbase engines

### DIFF
--- a/apps/playground/src/data/templates/expo-supabase.ts
+++ b/apps/playground/src/data/templates/expo-supabase.ts
@@ -299,8 +299,11 @@ Then open the preview tabs:
 The backend
 -----------
 \`npx tinbase\` is the Supabase-compatible backend CLI (REST, auth, realtime,
-Studio). \`--engine pgmem\` uses a pure-JS Postgres engine (instant boot, no wasm);
-drop it for the default PGlite (Postgres/wasm) engine.
+Studio). Engine choices in Lifo:
+  --engine pgmem           pure-JS Postgres — instant, recommended (used here)
+  --engine wasm --memory   real Postgres (PGlite/wasm), in-memory
+\`--engine wasm\` with on-disk persistence isn't supported in the VM yet (it
+preallocates Postgres files the in-memory filesystem can't back).
 
 Schema + seed live in a standard supabase/ folder, applied like \`supabase db reset\`:
   supabase/config.toml   — project config

--- a/apps/playground/src/data/templates/tinbase.ts
+++ b/apps/playground/src/data/templates/tinbase.ts
@@ -220,8 +220,11 @@ Then open the preview tabs:
 The backend
 -----------
 \`npx tinbase\` is the Supabase-compatible backend CLI (REST, auth, realtime,
-Studio). \`--engine pgmem\` uses a pure-JS Postgres engine (instant boot, no wasm);
-drop it for the default PGlite (Postgres/wasm) engine.
+Studio). Engine choices in Lifo:
+  --engine pgmem           pure-JS Postgres — instant, recommended (used here)
+  --engine wasm --memory   real Postgres (PGlite/wasm), in-memory
+\`--engine wasm\` with on-disk persistence isn't supported in the VM yet (it
+preallocates Postgres files the in-memory filesystem can't back).
 
 Schema + seed live in a standard supabase/ folder, applied like \`supabase db reset\`:
   supabase/config.toml   — project config

--- a/packages/core/src/commands/system/node.ts
+++ b/packages/core/src/commands/system/node.ts
@@ -1847,13 +1847,33 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 		// long-lived server race below would never notice and the run would hang.
 		let signalExit: () => void = () => {};
 		const exitPromise = new Promise<void>((r) => { signalExit = r; });
+		// Turn a rejection reason into something useful. Plain objects and errors
+		// that carry codes but no message/stack (e.g. Emscripten `ErrnoError`
+		// {name, errno} from PGlite/wasm) otherwise stringify to "[object Object]"
+		// or an empty stack.
+		const describeRejection = (reason: unknown): string => {
+			const r = reason as Record<string, unknown> | null;
+			if (r && typeof r === 'object') {
+				const extra: string[] = [];
+				for (const k of ['code', 'errno', 'syscall', 'path']) {
+					if (r[k] != null) extra.push(`${k}=${String(r[k])}`);
+				}
+				const tag = extra.length ? ` (${extra.join(', ')})` : '';
+				if (typeof r.stack === 'string' && r.stack) return r.stack + tag;
+				if (r.message != null) return `${String(r.name ?? 'Error')}: ${String(r.message)}${tag}`;
+				if (r.name != null || extra.length) return `${String(r.name ?? 'Error')}${tag}`;
+				try { return JSON.stringify(reason); } catch { /* circular */ }
+			}
+			return String(reason);
+		};
+
 		const rejectionHandler = (event: PromiseRejectionEvent) => {
 			pendingRejection = event.reason;
 			event.preventDefault(); // prevent browser default logging
 			if (event.reason instanceof ProcessExitError) {
 				signalExit();
 			} else {
-				ctx.stderr.write(`[unhandledRejection] ${event.reason instanceof Error ? event.reason.stack || event.reason.message : String(event.reason)}\n`);
+				ctx.stderr.write(`[unhandledRejection] ${describeRejection(event.reason)}\n`);
 			}
 		};
 		if (typeof globalThis.addEventListener === 'function') {


### PR DESCRIPTION
## Why
`npx tinbase --engine wasm` printed `[unhandledRejection] [object Object]` — unhelpful. The real cause is an Emscripten `ErrnoError {name, errno: 28}` (ENOSPC): PGlite's wasm filesystem preallocates Postgres files (WAL segments) that Lifo's in-memory VFS can't back, so **on-disk `--engine wasm` isn't supported in the VM**. `--engine pgmem` and `--engine wasm --memory` both work.

## What
- `node`'s unhandledRejection handler now extracts `name/message/code/errno/syscall/path` from non-Error reasons instead of `String(reason)` → shows `ErrnoError (errno=28)`. General improvement for any POJO/wasm rejection.
- Both Supabase example READMEs now document the engine choices:
  ```
  --engine pgmem           pure-JS Postgres — instant, recommended (default here)
  --engine wasm --memory   real Postgres (PGlite/wasm), in-memory
  ```
  and note persistent `--engine wasm` isn't supported in the VM yet.

## Verified
- Repro: `npx tinbase --engine wasm` → `ErrnoError (errno=28)`; `--engine wasm --memory` and `--engine pgmem` both boot and bind :54321.
- `describeRejection` logic checked across Error/POJO/ErrnoError/string. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)