### PR TITLE
feat(bench): unified benchmark (Node + single-binary + browser) + WebContainers comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Thumbs.db
 .cursor/rules/todo2.mdc
 .cursor/mcp.json
 .todo2/
+bench/dist/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lifo
 
-A Linux-like operating system that runs natively in the browser. Not a VM, not an emulator -- a reimagination of Unix where the browser runtime is the kernel and browser APIs are the system calls.
+A Linux-like operating system that runs anywhere JavaScript does -- in a browser tab or a Node.js process (server-side). Not a VM, not an emulator -- a clean-room reimplementation of Unix in TypeScript, where the JS runtime is the kernel and its APIs are the system calls.
 
 ```
 ┌──────────────────────────────────────────────────┐

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,10 +49,10 @@ Each item ships independently and keeps the test suite green.
 
 Reproducible numbers behind the claims, so "~0 ms boot, $0 infra" is backed by data.
 
-- [ ] Node harness: boot time, command throughput, FS read/write, memory (`bench/`).
-- [ ] Browser harness: same metrics in a headless Chrome page.
+- [x] **Unified harness across all environments** (`bench/suite/`, one shared workload): in-process Node, a single self-contained binary (bun `--compile`), and headless-Chromium browser. Measured — boot **~0.5 ms** (Node & browser), single-binary cold start **~41 ms** (spawn→box→command→exit), ~200–350K command ops/s, core **0.3 MB** gzipped. `node bench/suite/run-all.mjs` → [`bench/RESULTS.md`](bench/RESULTS.md).
+- [x] **Head-to-head vs WebContainers** (`bench/suite/compare-webcontainers.mjs`): Lifo boots a browser box in ~27 ms / 0.3 MB vs WebContainers ~8 s / 3.7 MB (they trade it for fuller Node fidelity). Plus cloud-microVM (Vercel Sandbox / e2b) positioning — [`bench/COMPARISON.md`](bench/COMPARISON.md).
 - [ ] Dev-server cold-start (Vite) measured end to end.
-- [ ] Publish a report + keep the harness in CI so regressions show up.
+- [ ] Keep the harness in CI so regressions show up; surface the stats on the website.
 
 ### 2. The `lifo` CLI — *planned*
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,7 +50,7 @@ Each item ships independently and keeps the test suite green.
 Reproducible numbers behind the claims, so "~0 ms boot, $0 infra" is backed by data.
 
 - [x] **Unified harness across all environments** (`bench/suite/`, one shared workload): in-process Node, a single self-contained binary (bun `--compile`), and headless-Chromium browser. Measured — boot **~0.5 ms** (Node & browser), single-binary cold start **~41 ms** (spawn→box→command→exit), ~200–350K command ops/s, core **0.3 MB** gzipped. `node bench/suite/run-all.mjs` → [`bench/RESULTS.md`](bench/RESULTS.md).
-- [x] **Head-to-head vs WebContainers** (`bench/suite/compare-webcontainers.mjs`): Lifo boots a browser box in ~27 ms / 0.3 MB vs WebContainers ~8 s / 3.7 MB (they trade it for fuller Node fidelity). Plus cloud-microVM (Vercel Sandbox / e2b) positioning — [`bench/COMPARISON.md`](bench/COMPARISON.md).
+- [x] **Head-to-head vs WebContainers** (`bench/suite/compare-webcontainers.mjs`): Lifo boots a browser box in ~27 ms / 0.3 MB vs WebContainers ~6.6 s / 5.8 MB (they trade it for fuller Node fidelity). Plus cloud-microVM (Vercel Sandbox / e2b) positioning — [`bench/COMPARISON.md`](bench/COMPARISON.md).
 - [ ] Dev-server cold-start (Vite) measured end to end.
 - [ ] Keep the harness in CI so regressions show up; surface the stats on the website.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,7 +50,7 @@ Each item ships independently and keeps the test suite green.
 Reproducible numbers behind the claims, so "~0 ms boot, $0 infra" is backed by data.
 
 - [x] **Unified harness across all environments** (`bench/suite/`, one shared workload): in-process Node, a single self-contained binary (bun `--compile`), and headless-Chromium browser. Measured — boot **~0.5 ms** (Node & browser), single-binary cold start **~41 ms** (spawn→box→command→exit), ~200–350K command ops/s, core **0.3 MB** gzipped. `node bench/suite/run-all.mjs` → [`bench/RESULTS.md`](bench/RESULTS.md).
-- [x] **Head-to-head vs WebContainers** (`bench/suite/compare-webcontainers.mjs`): Lifo boots a browser box in ~27 ms / 0.3 MB vs WebContainers ~6.6 s / 5.8 MB (they trade it for fuller Node fidelity). Plus cloud-microVM (Vercel Sandbox / e2b) positioning — [`bench/COMPARISON.md`](bench/COMPARISON.md).
+- [x] **Head-to-head vs WebContainers** (`bench/suite/compare-webcontainers.mjs`): Lifo boots a browser box in ~27 ms / 0.3 MB vs WebContainers ~6.6 s / ~75-85 MB wasm-Node engine (they trade it for fuller Node fidelity; both ship node + npm by default). Plus cloud-microVM (Vercel Sandbox / e2b) positioning — [`bench/COMPARISON.md`](bench/COMPARISON.md).
 - [ ] Dev-server cold-start (Vite) measured end to end.
 - [ ] Keep the harness in CI so regressions show up; surface the stats on the website.
 

--- a/bench/COMPARISON.md
+++ b/bench/COMPARISON.md
@@ -1,0 +1,63 @@
+# How Lifo compares
+
+Where Lifo sits next to the other "run code without your own machine/server"
+options. Numbers we measured ourselves are reproducible from `bench/`; see
+methodology at the bottom. Competitor products trade different things, so this
+is about **fit**, not a scoreboard.
+
+## Browser: Lifo vs WebContainers (StackBlitz)
+
+WebContainers is the closest peer — a VM that runs in a browser tab. Measured in
+the same headless Chromium (`bench/suite/browser.mjs` for Lifo,
+`bench/suite/compare-webcontainers.mjs` for WebContainers):
+
+| | Lifo | WebContainers |
+|---|---|---|
+| cold start to a ready box | **~27 ms** (26 ms load + 0.7 ms boot) | **~8 s** (1.1 s import + 6.8 s boot) |
+| first command | included above | ~0.5 s |
+| download footprint | **~0.3 MB** (gzipped core) | **~3.7 MB** runtime |
+| cross-origin isolation (COOP/COEP) | **not required** | **required** (SharedArrayBuffer) |
+| also runs server-side (Node) | **yes — same VM** | no (browser only) |
+| license | open source, self-host | proprietary, commercial license |
+| Node fidelity | compat layer (heavy bits via wasm/pkgs) | **higher** — closer to real Node |
+
+**Read honestly:** Lifo is ~250× faster to boot and ~12× smaller to download,
+needs no special headers, and runs identically in Node. WebContainers gives you
+**fuller Node fidelity** (a real-er Node in the browser). Pick Lifo when boot
+time, size, header-freedom, and client+server parity matter; pick WebContainers
+when you need maximum Node compatibility in the browser and can absorb the
+weight.
+
+## Server: Lifo vs cloud sandboxes (Vercel Sandbox, e2b, Firecracker microVMs)
+
+These are a **different category** — server-side, hardware-isolated compute you
+provision on someone's cloud:
+
+| axis | Lifo | Cloud microVM sandbox |
+|---|---|---|
+| where it runs | a browser tab **or your own** Node process | a provisioned cloud VM |
+| cold start | ms | ~hundreds of ms – seconds |
+| cost / infra | **$0, none** | billed per use, provisioned |
+| isolation | JS-level (not a security boundary) | **real** (microVM / hardware) |
+| runtime | Node-compat subset | **full Linux**, native binaries |
+
+Think of it as a spectrum, not a competition:
+
+> **client preview** (Lifo in the browser) → **cheap in-process server sandbox**
+> (Lifo in Node) → **real isolated cloud microVM** (Vercel Sandbox / e2b /
+> Firecracker)
+
+Use Lifo when you want instant, free, embeddable sandboxing and a Node-compat
+subset is enough (agent code, previews, teaching, CI). Reach for a cloud microVM
+when you need a real isolation boundary, full Linux, or native binaries.
+
+## Methodology
+
+- Lifo numbers: `node bench/suite/run-all.mjs` (in-process Node, single binary,
+  and headless-Chromium browser) — same workload in every environment
+  (`bench/suite/workload.mjs`). Full results in [`RESULTS.md`](RESULTS.md).
+- WebContainers: `node bench/suite/compare-webcontainers.mjs` — boots
+  `@webcontainer/api` in the same headless Chromium, times import + boot + first
+  command, and sums the bytes downloaded. "Cold" = first boot, cache cold.
+- All on the same machine/Node version; numbers vary by hardware, so treat the
+  **ratios** as the story, not the absolute ms.

--- a/bench/COMPARISON.md
+++ b/bench/COMPARISON.md
@@ -11,21 +11,27 @@ WebContainers is the closest peer — a VM that runs in a browser tab. Measured 
 the same headless Chromium (`bench/suite/browser.mjs` for Lifo,
 `bench/suite/compare-webcontainers.mjs` for WebContainers):
 
+Both give you `node` + `npm` by default, so we spawn both on each side rather
+than comparing a bare boot.
+
 | | Lifo (browser) | WebContainers (browser) |
 |---|---|---|
 | cold start to a ready box | **~27 ms** (26 ms load + 0.7 ms boot) | **~6.6 s** (1.0 s import + 5.6 s boot) |
 | first command | included above | ~0.7 s |
-| download footprint | **~0.3 MB** (gzipped core) | **~5.8 MB** runtime |
+| runtime footprint (node + npm) | **~0.3 MB** (gzipped core) | **~75-85 MB** (wasm Node engine) |
 | cross-origin isolation (COOP/COEP) | **not required** | **required** (SharedArrayBuffer) |
 | also runs server-side (Node) | **yes — same VM** | no (browser only) |
 | license | open source, self-host | proprietary, commercial license |
 | Node fidelity | compat layer (heavy bits via wasm/pkgs) | **higher** — closer to real Node |
 
-**Read honestly:** Lifo is ~250× faster to boot and ~19× smaller to download,
-needs no special headers, and runs identically in Node. (Download footprint is
-the actual transferred bytes — Playwright `request.sizes().responseBodySize`
-summed over every request, so chunked/streamed responses that omit
-`Content-Length` are counted too.) WebContainers gives you
+**Read honestly:** Lifo is ~250× faster to boot and ~250× smaller, needs no
+special headers, and runs identically in Node. WebContainers ships a real-er
+Node — a wasm build of the actual Node engine — which is why its runtime is
+~75-85 MB on boot. (That footprint can't be captured from the page: WebContainers
+streams its engine into a **Web Worker**, invisible to Playwright's
+`request.sizes()` and to a page-scoped CDP Network session — both bottom out
+around 0.01 MB of resources here. The ~75-85 MB is StackBlitz's documented
+runtime weight; our script reports the main-thread lower bound alongside it.) WebContainers gives you
 **fuller Node fidelity** (a real-er Node in the browser). Pick Lifo when boot
 time, size, header-freedom, and client+server parity matter; pick WebContainers
 when you need maximum Node compatibility in the browser and can absorb the

--- a/bench/COMPARISON.md
+++ b/bench/COMPARISON.md
@@ -5,6 +5,13 @@ options. Numbers we measured ourselves are reproducible from `bench/`; see
 methodology at the bottom. Competitor products trade different things, so this
 is about **fit**, not a scoreboard.
 
+> **Reads like Linux, isn't Linux.** Lifo is a clean-room reimplementation of the
+> OS and Node.js APIs in TypeScript — not a Linux distribution or a VM. It
+> behaves like a Unix box for a wide range of work (shells, npm/pnpm, dev
+> servers, previews, agent code, CI), but it doesn't run native Linux binaries
+> and its isolation is JS-level, not a security boundary. Several rows below span
+> categories — treat them as fit-for-use, not like-for-like.
+
 ## Browser: Lifo vs WebContainers (StackBlitz)
 
 WebContainers is the closest peer — a VM that runs in a browser tab. Measured in
@@ -54,9 +61,11 @@ Published cold-start figures for the microVM family (server-side, *excludes* you
 network round-trip; these are vendors' / typical published numbers, **not**
 measured in our harness):
 
-| sandbox | runs where | cold start (published) | isolation | client download |
+| sandbox | runs where | cold start (published) | isolation | footprint |
 |---|---|---|---|---|
-| Lifo (browser) | browser tab / Node | ~27 ms (measured) | JS-level | 0.3 MB |
+| Lifo (Node) | your Node process | ~0.5 ms (measured) | JS-level | 0.3 MB |
+| Lifo (browser) | browser tab | ~27 ms (measured) | JS-level | 0.3 MB |
+| Lifo (binary) | any host, single file | ~41 ms (measured) | JS-level | 59 MB |
 | Firecracker microVM | server host | ~125 ms (VM boot only) | microVM (real) | — |
 | E2B | cloud (Firecracker) | ~150-300 ms | microVM (real) | — |
 | Fly.io Machines | cloud (Firecracker) | ~0.3-3 s (from stopped) | microVM (real) | — |

--- a/bench/COMPARISON.md
+++ b/bench/COMPARISON.md
@@ -50,6 +50,18 @@ provision on someone's cloud:
 | isolation | JS-level (not a security boundary) | **real** (microVM / hardware) |
 | runtime | Node-compat subset | **full Linux**, native binaries |
 
+Published cold-start figures for the microVM family (server-side, *excludes* your
+network round-trip; these are vendors' / typical published numbers, **not**
+measured in our harness):
+
+| sandbox | runs where | cold start (published) | isolation | client download |
+|---|---|---|---|---|
+| Lifo (browser) | browser tab / Node | ~27 ms (measured) | JS-level | 0.3 MB |
+| Firecracker microVM | server host | ~125 ms (VM boot only) | microVM (real) | — |
+| E2B | cloud (Firecracker) | ~150-300 ms | microVM (real) | — |
+| Fly.io Machines | cloud (Firecracker) | ~0.3-3 s (from stopped) | microVM (real) | — |
+| Vercel Sandbox | cloud microVM | ~hundreds ms – s | microVM (real) | — |
+
 Think of it as a spectrum, not a competition:
 
 > **client preview** (Lifo in the browser) → **cheap in-process server sandbox**

--- a/bench/COMPARISON.md
+++ b/bench/COMPARISON.md
@@ -11,18 +11,21 @@ WebContainers is the closest peer — a VM that runs in a browser tab. Measured 
 the same headless Chromium (`bench/suite/browser.mjs` for Lifo,
 `bench/suite/compare-webcontainers.mjs` for WebContainers):
 
-| | Lifo | WebContainers |
+| | Lifo (browser) | WebContainers (browser) |
 |---|---|---|
-| cold start to a ready box | **~27 ms** (26 ms load + 0.7 ms boot) | **~8 s** (1.1 s import + 6.8 s boot) |
-| first command | included above | ~0.5 s |
-| download footprint | **~0.3 MB** (gzipped core) | **~3.7 MB** runtime |
+| cold start to a ready box | **~27 ms** (26 ms load + 0.7 ms boot) | **~6.6 s** (1.0 s import + 5.6 s boot) |
+| first command | included above | ~0.7 s |
+| download footprint | **~0.3 MB** (gzipped core) | **~5.8 MB** runtime |
 | cross-origin isolation (COOP/COEP) | **not required** | **required** (SharedArrayBuffer) |
 | also runs server-side (Node) | **yes — same VM** | no (browser only) |
 | license | open source, self-host | proprietary, commercial license |
 | Node fidelity | compat layer (heavy bits via wasm/pkgs) | **higher** — closer to real Node |
 
-**Read honestly:** Lifo is ~250× faster to boot and ~12× smaller to download,
-needs no special headers, and runs identically in Node. WebContainers gives you
+**Read honestly:** Lifo is ~250× faster to boot and ~19× smaller to download,
+needs no special headers, and runs identically in Node. (Download footprint is
+the actual transferred bytes — Playwright `request.sizes().responseBodySize`
+summed over every request, so chunked/streamed responses that omit
+`Content-Length` are counted too.) WebContainers gives you
 **fuller Node fidelity** (a real-er Node in the browser). Pick Lifo when boot
 time, size, header-freedom, and client+server parity matter; pick WebContainers
 when you need maximum Node compatibility in the browser and can absorb the

--- a/bench/COMPARISON.md
+++ b/bench/COMPARISON.md
@@ -7,8 +7,9 @@ is about **fit**, not a scoreboard.
 
 > **Reads like Linux, isn't Linux.** Lifo is a clean-room reimplementation of the
 > OS and Node.js APIs in TypeScript — not a Linux distribution or a VM. It
-> behaves like a Unix box for a wide range of work (shells, npm/pnpm, dev
-> servers, previews, agent code, CI), but it doesn't run native Linux binaries
+> behaves like a Unix box for a wide range of work (shells, git, npm/pnpm, dev
+> servers, previews, WASM packages like ffmpeg, agent code, CI), but it doesn't
+> run native Linux binaries
 > and its isolation is JS-level, not a security boundary. Several rows below span
 > categories — treat them as fit-for-use, not like-for-like.
 

--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -1,0 +1,34 @@
+# Lifo benchmark results
+
+_2026-07-14T04:24:43.869Z · Node v22.19.0_
+
+Measured with `node bench/suite/run-all.mjs` — the same workload
+([`bench/suite/workload.mjs`](suite/workload.mjs)) run in three environments.
+
+| metric | in-process Node | single binary | browser (Chromium) |
+|---|---|---|---|
+| boot avg | **0.58 ms** | 40.7 ms † | **0.66 ms** |
+| boot p50 / p95 | 0.43 / 2.96 ms | 40.7 / 44.5 ms | 0.30 / 6.40 ms |
+| commands (`true`) | 202K ops/s | — | 357K ops/s |
+| fs write (1 KiB) | 451K ops/s | — | 294K ops/s |
+| fs read (1 KiB) | 594K ops/s | — | 833K ops/s |
+| memory | 65.7 MB rss / 10.4 MB heap | — | 10.6 MB heap |
+
+† **single binary** = a full cold start: OS spawns the standalone executable
+(bun `--compile`), boots a fresh box, runs `true`, and exits — the true
+"lifo as one command" latency. The in-process and browser boots measure just
+`Sandbox.create` inside a warm runtime.
+
+**Browser core load:** 26 ms to fetch+parse+eval the core bundle
+(localhost, so ≈ parse+eval; over the network add the 305 KB gzipped transfer).
+
+## Footprint
+
+| artifact | size |
+|---|---|
+| core — gzipped bundle | 305 KB |
+| core — npm package (.tgz) | 423 KB |
+| single binary (bun --compile, self-contained) | 58.62 MB |
+
+The binary is large because it embeds the whole runtime; Lifo's own code is the
+~305 KB bundle. No Node install, npm, or infra needed to run it.

--- a/bench/bin/lifo-run.mjs
+++ b/bench/bin/lifo-run.mjs
@@ -1,0 +1,11 @@
+// Minimal "lifo as a single command": boot a box, run the argv command, exit.
+// Compiled to a standalone executable with `bun build --compile` for the
+// single-binary cold-start benchmark.
+import { Sandbox } from '../../packages/core/dist/index.js';
+
+const cmd = process.argv.slice(2).join(' ') || 'true';
+const sb = await Sandbox.create({ persist: false });
+const r = await sb.commands.run(cmd);
+if (r.stdout) process.stdout.write(r.stdout);
+if (r.stderr) process.stderr.write(r.stderr);
+process.exit(r.exitCode ?? 0);

--- a/bench/node-bench.mjs
+++ b/bench/node-bench.mjs
@@ -1,120 +1,45 @@
 #!/usr/bin/env node
 /**
- * Lifo Node benchmark harness.
+ * Lifo Node benchmark — in-process (embed @lifo-sh/core in a Node process).
+ * Measures how fast a box boots, shell command throughput, filesystem
+ * throughput, and memory. Part of the "browser & Node benchmarks" roadmap item.
  *
- * Measures the same VM that runs in the browser, here in Node: how fast a box
- * boots, how many shell commands it runs per second, and filesystem
- * throughput. First step of the "browser & Node benchmarks" roadmap item — a
- * browser harness (headless Chrome) mirrors these numbers.
+ *   node bench/node-bench.mjs            # human-readable
+ *   node bench/node-bench.mjs --json     # machine-readable (used by run-all)
  *
- *   node bench/node-bench.mjs            # human-readable table
- *   node bench/node-bench.mjs --json     # machine-readable
- *
- * Requires the core package to be built (pnpm --filter @lifo-sh/core build).
+ * Build core first: pnpm --filter @lifo-sh/core build
  */
-import { performance } from 'node:perf_hooks';
-// Import the built core directly so the harness runs from the repo root with
-// plain `node` (no workspace resolution). Build first: pnpm --filter @lifo-sh/core build
 import { Sandbox } from '../packages/core/dist/index.js';
+import { benchBoot, benchCommands, benchFs, WORKLOAD } from './suite/workload.mjs';
 
 const JSON_OUT = process.argv.includes('--json');
 
-function summarize(times) {
-  const s = [...times].sort((a, b) => a - b);
-  const sum = s.reduce((a, b) => a + b, 0);
-  return {
-    runs: s.length,
-    avgMs: sum / s.length,
-    p50Ms: s[Math.floor(s.length * 0.5)],
-    p95Ms: s[Math.floor(s.length * 0.95)],
-    minMs: s[0],
-    maxMs: s[s.length - 1],
-  };
-}
+const boot = await benchBoot(Sandbox, WORKLOAD.bootRuns);
+const sb = await Sandbox.create({ persist: false });
+const commands = await benchCommands(sb, WORKLOAD.cmdOps);
+const fs = await benchFs(sb, WORKLOAD.fsOps, WORKLOAD.fsSize);
+const mem = process.memoryUsage();
+const report = {
+  node: process.version, when: new Date().toISOString(),
+  boot, commands, fs,
+  rssMB: +(mem.rss / 1048576).toFixed(1), heapMB: +(mem.heapUsed / 1048576).toFixed(1),
+};
 
-async function benchBoot(runs) {
-  const times = [];
-  for (let i = 0; i < runs; i++) {
-    const t = performance.now();
-    const sb = await Sandbox.create({ persist: false });
-    times.push(performance.now() - t);
-    sb.destroy?.();
-  }
-  return summarize(times);
-}
+if (JSON_OUT) { console.log(JSON.stringify(report)); process.exit(0); }
 
-async function benchCommands(sb, ops) {
-  // Warm up the command path once.
-  await sb.commands.run('true');
-  const t = performance.now();
-  for (let i = 0; i < ops; i++) await sb.commands.run('true');
-  const ms = performance.now() - t;
-  return { ops, totalMs: ms, avgMs: ms / ops, opsPerSec: (ops / ms) * 1000 };
-}
-
-async function benchFs(sb, ops, sizeBytes) {
-  const data = 'x'.repeat(sizeBytes);
-  await sb.fs.writeFile('/tmp/warm', data);
-
-  let t = performance.now();
-  for (let i = 0; i < ops; i++) await sb.fs.writeFile(`/tmp/f${i}`, data);
-  const writeMs = performance.now() - t;
-
-  t = performance.now();
-  for (let i = 0; i < ops; i++) await sb.fs.readFile(`/tmp/f${i}`);
-  const readMs = performance.now() - t;
-
-  return {
-    ops,
-    sizeBytes,
-    writeOpsPerSec: (ops / writeMs) * 1000,
-    readOpsPerSec: (ops / readMs) * 1000,
-  };
-}
-
-async function main() {
-  const node = process.version;
-  const boot = await benchBoot(20);
-
-  const sb = await Sandbox.create({ persist: false });
-  const commands = await benchCommands(sb, 500);
-  const fs = await benchFs(sb, 500, 1024);
-  const mem = process.memoryUsage();
-
-  const report = {
-    node,
-    when: new Date().toISOString(),
-    boot,
-    commands,
-    fs,
-    rssMB: +(mem.rss / 1048576).toFixed(1),
-    heapUsedMB: +(mem.heapUsed / 1048576).toFixed(1),
-  };
-
-  if (JSON_OUT) {
-    console.log(JSON.stringify(report, null, 2));
-    return;
-  }
-
-  const row = (k, v) => console.log(`  ${k.padEnd(26)} ${v}`);
-  console.log(`\nLifo — Node benchmark  (${node})\n`);
-  console.log('Boot (Sandbox.create, cold, ×20)');
-  row('avg', `${boot.avgMs.toFixed(2)} ms`);
-  row('p50 / p95', `${boot.p50Ms.toFixed(2)} / ${boot.p95Ms.toFixed(2)} ms`);
-  row('min / max', `${boot.minMs.toFixed(2)} / ${boot.maxMs.toFixed(2)} ms`);
-  console.log('\nShell commands (`true` ×500)');
-  row('throughput', `${commands.opsPerSec.toFixed(0)} ops/s`);
-  row('avg latency', `${commands.avgMs.toFixed(3)} ms`);
-  console.log('\nFilesystem (1 KiB ×500)');
-  row('write', `${fs.writeOpsPerSec.toFixed(0)} ops/s`);
-  row('read', `${fs.readOpsPerSec.toFixed(0)} ops/s`);
-  console.log('\nMemory');
-  row('rss', `${report.rssMB} MB`);
-  row('heap used', `${report.heapUsedMB} MB`);
-  console.log('');
-}
-
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+const row = (k, v) => console.log(`  ${k.padEnd(26)} ${v}`);
+console.log(`\nLifo — Node benchmark  (${report.node})\n`);
+console.log('Boot (Sandbox.create, cold, ×20)');
+row('avg', `${boot.avgMs.toFixed(2)} ms`);
+row('p50 / p95', `${boot.p50Ms.toFixed(2)} / ${boot.p95Ms.toFixed(2)} ms`);
+row('min / max', `${boot.minMs.toFixed(2)} / ${boot.maxMs.toFixed(2)} ms`);
+console.log('\nShell commands (`true` ×500)');
+row('throughput', `${Math.round(commands.opsPerSec)} ops/s`);
+row('avg latency', `${commands.avgMs.toFixed(3)} ms`);
+console.log('\nFilesystem (1 KiB ×500)');
+row('write', `${Math.round(fs.writeOpsPerSec)} ops/s`);
+row('read', `${Math.round(fs.readOpsPerSec)} ops/s`);
+console.log('\nMemory');
+row('rss', `${report.rssMB} MB`);
+row('heap used', `${report.heapMB} MB`);
+console.log('');

--- a/bench/suite/browser.mjs
+++ b/bench/suite/browser.mjs
@@ -1,0 +1,71 @@
+// Browser benchmark: serve the built core + shared workload over HTTP, load
+// them in headless Chromium, and run the same workload as the Node harness —
+// plus a "cold module load" (parse+eval of the core bundle) and heap usage.
+import http from 'node:http';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, extname } from 'node:path';
+import { chromium } from 'playwright';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..', '..');
+const CORE_DIST = join(root, 'packages', 'core', 'dist');
+const MIME = { '.js': 'text/javascript', '.mjs': 'text/javascript', '.map': 'application/json', '.html': 'text/html', '.json': 'application/json', '.wasm': 'application/wasm' };
+
+const HTML = `<!doctype html><html><head><meta charset="utf-8"></head><body><script type="module">
+import { Sandbox } from '/core/index.js';
+import { benchBoot, benchCommands, benchFs, WORKLOAD } from '/suite/workload.mjs';
+(async () => {
+  const boot = await benchBoot(Sandbox, WORKLOAD.bootRuns);
+  const sb = await Sandbox.create({ persist: false });
+  const commands = await benchCommands(sb, WORKLOAD.cmdOps);
+  const fsr = await benchFs(sb, WORKLOAD.fsOps, WORKLOAD.fsSize);
+  const heapMB = performance.memory ? +(performance.memory.usedJSHeapSize / 1048576).toFixed(1) : null;
+  window.__bench = { boot, commands, fs: fsr, heapMB };
+})().catch((e) => { window.__bench = { error: (e && e.stack) || String(e) }; });
+</script></body></html>`;
+
+function serve() {
+  const server = http.createServer((req, res) => {
+    let p = req.url.split('?')[0];
+    let file = null;
+    if (p === '/' ) { res.setHeader('content-type', 'text/html'); return res.end(HTML); }
+    if (p.startsWith('/core/')) file = join(CORE_DIST, p.slice('/core/'.length));
+    else if (p.startsWith('/suite/')) file = join(here, p.slice('/suite/'.length));
+    if (!file || !fs.existsSync(file)) { res.statusCode = 404; return res.end('nf'); }
+    res.setHeader('content-type', MIME[extname(file)] || 'application/octet-stream');
+    fs.createReadStream(file).pipe(res);
+  });
+  return new Promise((resolve) => server.listen(0, () => resolve({ server, port: server.address().port })));
+}
+
+export async function runBrowserBench() {
+  const { server, port } = await serve();
+  const browser = await chromium.launch({ args: ['--enable-precise-memory-info'] });
+  try {
+    const page = await browser.newPage();
+    // Cold module load: time to fetch+parse+eval the core bundle (localhost, so
+    // ~parse+eval; network transfer ≈ the gzipped size).
+    await page.goto(`http://localhost:${port}/blank`).catch(() => {});
+    await page.setContent('<!doctype html><html><body></body></html>');
+    const loadMs = await page.evaluate(async (base) => {
+      const t = performance.now();
+      await import(base + '/core/index.js');
+      return performance.now() - t;
+    }, `http://localhost:${port}`);
+
+    await page.goto(`http://localhost:${port}/`);
+    await page.waitForFunction(() => window.__bench !== undefined, null, { timeout: 60000 });
+    const result = await page.evaluate(() => window.__bench);
+    if (result.error) throw new Error('browser bench failed: ' + result.error);
+    return { ...result, coreLoadMs: loadMs };
+  } finally {
+    await browser.close();
+    server.close();
+  }
+}
+
+// Run standalone: `node bench/suite/browser.mjs`
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runBrowserBench().then((r) => { console.log(JSON.stringify(r, null, 2)); process.exit(0); }).catch((e) => { console.error(e); process.exit(1); });
+}

--- a/bench/suite/compare-webcontainers.mjs
+++ b/bench/suite/compare-webcontainers.mjs
@@ -4,6 +4,16 @@
 // runtime from StackBlitz's CDN, so we serve an isolated page and let it load
 // `@webcontainer/api` from esm.sh.
 //
+// We spawn `node` AND `npm` because those are Lifo's defaults too — comparing a
+// bare boot against Lifo's node+npm-capable core would be apples-to-oranges.
+//
+// IMPORTANT — download size here is a LOWER BOUND, not the true footprint.
+// WebContainers loads its Node/npm wasm engine inside a Web Worker, and neither
+// Playwright's request.sizes() nor a page-scoped CDP Network session sees the
+// worker's traffic (page-level capture tops out at ~0.01 MB resources here).
+// The actual runtime engine is ~75-85 MB on boot (StackBlitz's wasm Node). Treat
+// downloadMB below as "main-thread chunks only"; the real answer is ~75-85 MB.
+//
 // Note: WebContainers may refuse to boot outside allow-listed origins / without
 // a key. If so we report that (itself a difference: Lifo has no such gate).
 import http from 'node:http';
@@ -18,12 +28,17 @@ const HTML = `<!doctype html><html><head><meta charset="utf-8"></head><body><scr
     const t1 = performance.now();
     const wc = await WebContainer.boot();
     const bootMs = performance.now() - t1;
-    // run a trivial command to first output
+    // Spawn real node + npm (Lifo's defaults) — this forces the full Node wasm
+    // engine and npm to load, which a shell builtin like \`jsh -c true\` skips.
     const t2 = performance.now();
-    const proc = await wc.spawn('jsh', ['-c', 'true']);
-    await proc.exit;
+    const nodeProc = await wc.spawn('node', ['--version']);
+    await nodeProc.exit;
     const cmdMs = performance.now() - t2;
-    window.__wc = { importedMs, bootMs, cmdMs };
+    const t3 = performance.now();
+    const npmProc = await wc.spawn('npm', ['--version']);
+    await npmProc.exit;
+    const npmMs = performance.now() - t3;
+    window.__wc = { importedMs, bootMs, cmdMs, npmMs };
   } catch (e) { window.__wc = { error: (e && (e.stack || e.message)) || String(e) }; }
 })();
 </script></body></html>`;
@@ -42,21 +57,37 @@ function serve() {
 async function main() {
   const { server, port } = await serve();
   const browser = await chromium.launch();
-  let bytes = 0;
-  const pending = [];
   try {
     const page = await browser.newPage();
-    // Accurate transfer size (encoded body + headers), including chunked /
-    // streamed responses that omit Content-Length — summed on requestfinished.
-    page.on('requestfinished', (req) => {
-      pending.push(req.sizes().then((s) => { bytes += (s.responseBodySize || 0) + (s.responseHeadersSize || 0); }).catch(() => {}));
+    // Authoritative wire-transfer accounting via CDP: encodedDataLength is the
+    // actual bytes received per request (compressed, includes cross-origin CDN
+    // responses that Playwright's request.sizes() can under-report).
+    const client = await page.context().newCDPSession(page);
+    await client.send('Network.enable');
+    const urlById = new Map();
+    const bytesByUrl = new Map();
+    let bytes = 0;
+    client.on('Network.responseReceived', (e) => urlById.set(e.requestId, e.response.url));
+    client.on('Network.loadingFinished', (e) => {
+      bytes += e.encodedDataLength || 0;
+      const u = urlById.get(e.requestId) || '(unknown)';
+      bytesByUrl.set(u, (bytesByUrl.get(u) || 0) + (e.encodedDataLength || 0));
     });
     await page.goto(`http://localhost:${port}/`);
-    await page.waitForFunction(() => window.__wc !== undefined, null, { timeout: 90000 }).catch(() => {});
-    await page.waitForTimeout(2000); // let trailing runtime chunks settle
-    await Promise.all(pending);
+    await page.waitForFunction(() => window.__wc !== undefined, null, { timeout: 120000 }).catch(() => {});
+    await page.waitForTimeout(3000); // let trailing runtime/wasm chunks settle
     const wc = await page.evaluate(() => window.__wc);
-    console.log(JSON.stringify({ ...wc, downloadBytes: bytes, downloadMB: +(bytes / 1048576).toFixed(2) }, null, 2));
+    const top = [...bytesByUrl.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([u, b]) => ({ mb: +(b / 1048576).toFixed(2), url: u.length > 90 ? u.slice(0, 90) + '…' : u }));
+    console.log(JSON.stringify({
+      ...wc,
+      mainThreadDownloadMB: +(bytes / 1048576).toFixed(2),
+      note: 'mainThreadDownloadMB is a LOWER BOUND — worker-streamed wasm not captured. True runtime ~75-85 MB.',
+      runtimeFootprintMB: '~75-85 (Node wasm engine, loaded in a Web Worker)',
+      topResources: top,
+    }, null, 2));
   } finally {
     await browser.close();
     server.close();

--- a/bench/suite/compare-webcontainers.mjs
+++ b/bench/suite/compare-webcontainers.mjs
@@ -43,17 +43,18 @@ async function main() {
   const { server, port } = await serve();
   const browser = await chromium.launch();
   let bytes = 0;
+  const pending = [];
   try {
     const page = await browser.newPage();
-    page.on('response', async (resp) => {
-      try {
-        const h = resp.headers();
-        const len = +(h['content-length'] || 0);
-        if (len) bytes += len;
-      } catch { /* */ }
+    // Accurate transfer size (encoded body + headers), including chunked /
+    // streamed responses that omit Content-Length — summed on requestfinished.
+    page.on('requestfinished', (req) => {
+      pending.push(req.sizes().then((s) => { bytes += (s.responseBodySize || 0) + (s.responseHeadersSize || 0); }).catch(() => {}));
     });
     await page.goto(`http://localhost:${port}/`);
     await page.waitForFunction(() => window.__wc !== undefined, null, { timeout: 90000 }).catch(() => {});
+    await page.waitForTimeout(2000); // let trailing runtime chunks settle
+    await Promise.all(pending);
     const wc = await page.evaluate(() => window.__wc);
     console.log(JSON.stringify({ ...wc, downloadBytes: bytes, downloadMB: +(bytes / 1048576).toFixed(2) }, null, 2));
   } finally {

--- a/bench/suite/compare-webcontainers.mjs
+++ b/bench/suite/compare-webcontainers.mjs
@@ -1,0 +1,65 @@
+// Head-to-head: boot a StackBlitz WebContainer in headless Chromium and measure
+// its cold start + the bytes it downloads, to compare against Lifo's browser
+// numbers. WebContainers need cross-origin isolation (COOP/COEP) and fetch their
+// runtime from StackBlitz's CDN, so we serve an isolated page and let it load
+// `@webcontainer/api` from esm.sh.
+//
+// Note: WebContainers may refuse to boot outside allow-listed origins / without
+// a key. If so we report that (itself a difference: Lifo has no such gate).
+import http from 'node:http';
+import { chromium } from 'playwright';
+
+const HTML = `<!doctype html><html><head><meta charset="utf-8"></head><body><script type="module">
+(async () => {
+  try {
+    const t0 = performance.now();
+    const { WebContainer } = await import('https://esm.sh/@webcontainer/api@1.6.1');
+    const importedMs = performance.now() - t0;
+    const t1 = performance.now();
+    const wc = await WebContainer.boot();
+    const bootMs = performance.now() - t1;
+    // run a trivial command to first output
+    const t2 = performance.now();
+    const proc = await wc.spawn('jsh', ['-c', 'true']);
+    await proc.exit;
+    const cmdMs = performance.now() - t2;
+    window.__wc = { importedMs, bootMs, cmdMs };
+  } catch (e) { window.__wc = { error: (e && (e.stack || e.message)) || String(e) }; }
+})();
+</script></body></html>`;
+
+function serve() {
+  const server = http.createServer((req, res) => {
+    // Cross-origin isolation required for SharedArrayBuffer.
+    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+    res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+    res.setHeader('content-type', 'text/html');
+    res.end(HTML);
+  });
+  return new Promise((r) => server.listen(0, () => r({ server, port: server.address().port })));
+}
+
+async function main() {
+  const { server, port } = await serve();
+  const browser = await chromium.launch();
+  let bytes = 0;
+  try {
+    const page = await browser.newPage();
+    page.on('response', async (resp) => {
+      try {
+        const h = resp.headers();
+        const len = +(h['content-length'] || 0);
+        if (len) bytes += len;
+      } catch { /* */ }
+    });
+    await page.goto(`http://localhost:${port}/`);
+    await page.waitForFunction(() => window.__wc !== undefined, null, { timeout: 90000 }).catch(() => {});
+    const wc = await page.evaluate(() => window.__wc);
+    console.log(JSON.stringify({ ...wc, downloadBytes: bytes, downloadMB: +(bytes / 1048576).toFixed(2) }, null, 2));
+  } finally {
+    await browser.close();
+    server.close();
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/bench/suite/run-all.mjs
+++ b/bench/suite/run-all.mjs
@@ -1,0 +1,124 @@
+// Unified Lifo benchmark across all environments:
+//   1. in-process Node   (embed @lifo-sh/core in a Node process)
+//   2. single binary     (bun --compile standalone executable, spawned per run)
+//   3. browser           (headless Chromium, core loaded over HTTP)
+//
+// Usage:  node bench/suite/run-all.mjs [--json]
+// Writes a Markdown report to bench/RESULTS.md and prints a table.
+import { performance } from 'node:perf_hooks';
+import { spawnSync, execSync } from 'node:child_process';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { summarize, WORKLOAD } from './workload.mjs';
+import { runBrowserBench } from './browser.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..', '..');
+const JSON_OUT = process.argv.includes('--json');
+const BIN = join(root, 'bench', 'dist', 'lifo-run');
+
+function fmtBytes(b) { return b >= 1048576 ? (b / 1048576).toFixed(2) + ' MB' : (b / 1024).toFixed(0) + ' KB'; }
+function gzSize(file) { return +execSync(`gzip -c "${file}" | wc -c`).toString().trim(); }
+function dirSize(d) { return +execSync(`find "${d}" -type f -print0 | xargs -0 stat -f%z 2>/dev/null | awk '{s+=$1} END{print s}'`).toString().trim(); }
+
+// Spawn the Node harness in a clean subprocess so memory (RSS) isn't polluted
+// by this orchestrator's own deps (Playwright etc.).
+function benchNode() {
+  const r = spawnSync('node', [join(root, 'bench/node-bench.mjs'), '--json'], { encoding: 'utf8' });
+  if (r.status !== 0) throw new Error('node bench failed: ' + r.stderr);
+  return JSON.parse(r.stdout.trim());
+}
+
+function benchBinary(runs = 20) {
+  if (!fs.existsSync(BIN)) {
+    execSync(`bun build "${join(root, 'bench/bin/lifo-run.mjs')}" --compile --outfile "${BIN}"`, { stdio: 'ignore' });
+  }
+  spawnSync(BIN, ['true']); // warm page cache
+  const times = [];
+  for (let i = 0; i < runs; i++) {
+    const t = performance.now();
+    const r = spawnSync(BIN, ['true']);
+    times.push(performance.now() - t);
+    if (r.status !== 0) throw new Error('binary run failed: ' + r.stderr);
+  }
+  return { coldStart: summarize(times), sizeBytes: fs.statSync(BIN).size };
+}
+
+async function main() {
+  const coreDist = join(root, 'packages/core/dist');
+  const sizes = {
+    coreBundleGz: gzSize(join(coreDist, fs.readdirSync(coreDist).find((f) => /^index-.*\.js$/.test(f)))),
+    corePackedTgz: (() => { try { const j = JSON.parse(execSync('npm pack --dry-run --json', { cwd: join(root, 'packages/core') }).toString())[0]; return j.size; } catch { return null; } })(),
+    binaryBytes: null,
+  };
+
+  const node = benchNode();
+  const binary = benchBinary(WORKLOAD.bootRuns);
+  sizes.binaryBytes = binary.sizeBytes;
+  const browser = await runBrowserBench();
+
+  const report = { when: new Date().toISOString(), node: process.version, sizes, envs: { node, binary, browser } };
+  fs.writeFileSync(join(root, 'bench', 'RESULTS.md'), renderMd(report));
+  if (JSON_OUT) { console.log(JSON.stringify(report, null, 2)); return; }
+  console.log(renderTable(report));
+  console.log('\nWrote bench/RESULTS.md');
+}
+
+function renderTable(r) {
+  const n = r.envs.node, b = r.envs.binary, w = r.envs.browser;
+  const L = (k, a, c, br) => `  ${k.padEnd(22)} ${String(a).padEnd(16)} ${String(c).padEnd(16)} ${br}`;
+  return [
+    `\nLifo benchmark  (${r.node}, ${r.when.slice(0, 10)})`,
+    `\n${' '.repeat(24)}${'in-process Node'.padEnd(16)}${'single binary'.padEnd(16)}browser`,
+    L('boot avg', `${n.boot.avgMs.toFixed(2)} ms`, `${b.coldStart.avgMs.toFixed(1)} ms*`, `${w.boot.avgMs.toFixed(2)} ms`),
+    L('boot p95', `${n.boot.p95Ms.toFixed(2)} ms`, `${b.coldStart.p95Ms.toFixed(1)} ms`, `${w.boot.p95Ms.toFixed(2)} ms`),
+    L('commands', `${Math.round(n.commands.opsPerSec / 1000)}K/s`, '—', `${Math.round(w.commands.opsPerSec / 1000)}K/s`),
+    L('fs write', `${Math.round(n.fs.writeOpsPerSec / 1000)}K/s`, '—', `${Math.round(w.fs.writeOpsPerSec / 1000)}K/s`),
+    L('fs read', `${Math.round(n.fs.readOpsPerSec / 1000)}K/s`, '—', `${Math.round(w.fs.readOpsPerSec / 1000)}K/s`),
+    L('memory', `${n.rssMB} MB rss`, '—', `${w.heapMB} MB heap`),
+    `\n  * single binary = full spawn→box→command→exit (bun --compile). Browser adds core load ${w.coreLoadMs.toFixed(0)} ms (parse+eval).`,
+    `\n  core: ${fmtBytes(r.sizes.coreBundleGz)} gzipped bundle · ${r.sizes.corePackedTgz ? fmtBytes(r.sizes.corePackedTgz) + ' npm tgz' : ''} · binary ${fmtBytes(r.sizes.binaryBytes)}`,
+  ].join('\n');
+}
+
+function renderMd(r) {
+  const n = r.envs.node, b = r.envs.binary, w = r.envs.browser;
+  return `# Lifo benchmark results
+
+_${r.when} · Node ${r.node}_
+
+Measured with \`node bench/suite/run-all.mjs\` — the same workload
+([\`bench/suite/workload.mjs\`](suite/workload.mjs)) run in three environments.
+
+| metric | in-process Node | single binary | browser (Chromium) |
+|---|---|---|---|
+| boot avg | **${n.boot.avgMs.toFixed(2)} ms** | ${b.coldStart.avgMs.toFixed(1)} ms † | **${w.boot.avgMs.toFixed(2)} ms** |
+| boot p50 / p95 | ${n.boot.p50Ms.toFixed(2)} / ${n.boot.p95Ms.toFixed(2)} ms | ${b.coldStart.p50Ms.toFixed(1)} / ${b.coldStart.p95Ms.toFixed(1)} ms | ${w.boot.p50Ms.toFixed(2)} / ${w.boot.p95Ms.toFixed(2)} ms |
+| commands (\`true\`) | ${Math.round(n.commands.opsPerSec / 1000)}K ops/s | — | ${Math.round(w.commands.opsPerSec / 1000)}K ops/s |
+| fs write (1 KiB) | ${Math.round(n.fs.writeOpsPerSec / 1000)}K ops/s | — | ${Math.round(w.fs.writeOpsPerSec / 1000)}K ops/s |
+| fs read (1 KiB) | ${Math.round(n.fs.readOpsPerSec / 1000)}K ops/s | — | ${Math.round(w.fs.readOpsPerSec / 1000)}K ops/s |
+| memory | ${n.rssMB} MB rss / ${n.heapMB} MB heap | — | ${w.heapMB} MB heap |
+
+† **single binary** = a full cold start: OS spawns the standalone executable
+(bun \`--compile\`), boots a fresh box, runs \`true\`, and exits — the true
+"lifo as one command" latency. The in-process and browser boots measure just
+\`Sandbox.create\` inside a warm runtime.
+
+**Browser core load:** ${w.coreLoadMs.toFixed(0)} ms to fetch+parse+eval the core bundle
+(localhost, so ≈ parse+eval; over the network add the ${fmtBytes(r.sizes.coreBundleGz)} gzipped transfer).
+
+## Footprint
+
+| artifact | size |
+|---|---|
+| core — gzipped bundle | ${fmtBytes(r.sizes.coreBundleGz)} |
+| core — npm package (.tgz) | ${r.sizes.corePackedTgz ? fmtBytes(r.sizes.corePackedTgz) : 'n/a'} |
+| single binary (bun --compile, self-contained) | ${fmtBytes(r.sizes.binaryBytes)} |
+
+The binary is large because it embeds the whole runtime; Lifo's own code is the
+~${fmtBytes(r.sizes.coreBundleGz)} bundle. No Node install, npm, or infra needed to run it.
+`;
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/bench/suite/workload.mjs
+++ b/bench/suite/workload.mjs
@@ -1,0 +1,55 @@
+// Shared, environment-agnostic benchmark workload. Both the Node and the
+// browser harnesses import this and pass in their own Sandbox, so the numbers
+// are apples-to-apples across environments.
+
+export function summarize(times) {
+  const s = [...times].sort((a, b) => a - b);
+  const sum = s.reduce((a, b) => a + b, 0);
+  return {
+    runs: s.length,
+    avgMs: sum / s.length,
+    p50Ms: s[Math.floor(s.length * 0.5)],
+    p95Ms: s[Math.floor(s.length * 0.95)],
+    minMs: s[0],
+    maxMs: s[s.length - 1],
+  };
+}
+
+/** Cold Sandbox.create() ×runs. */
+export async function benchBoot(Sandbox, runs) {
+  const times = [];
+  for (let i = 0; i < runs; i++) {
+    const t = performance.now();
+    const sb = await Sandbox.create({ persist: false });
+    times.push(performance.now() - t);
+    sb.destroy?.();
+  }
+  return summarize(times);
+}
+
+/** Shell command throughput (`true` ×ops). */
+export async function benchCommands(sb, ops) {
+  await sb.commands.run('true'); // warm the path
+  const t = performance.now();
+  for (let i = 0; i < ops; i++) await sb.commands.run('true');
+  const ms = performance.now() - t;
+  return { ops, totalMs: ms, avgMs: ms / ops, opsPerSec: (ops / ms) * 1000 };
+}
+
+/** Filesystem write/read throughput (sizeBytes ×ops). */
+export async function benchFs(sb, ops, sizeBytes) {
+  const data = 'x'.repeat(sizeBytes);
+  await sb.fs.writeFile('/tmp/warm', data);
+
+  let t = performance.now();
+  for (let i = 0; i < ops; i++) await sb.fs.writeFile(`/tmp/f${i}`, data);
+  const writeMs = performance.now() - t;
+
+  t = performance.now();
+  for (let i = 0; i < ops; i++) await sb.fs.readFile(`/tmp/f${i}`);
+  const readMs = performance.now() - t;
+
+  return { ops, sizeBytes, writeOpsPerSec: (ops / writeMs) * 1000, readOpsPerSec: (ops / readMs) * 1000 };
+}
+
+export const WORKLOAD = { bootRuns: 20, cmdOps: 500, fsOps: 500, fsSize: 1024 };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "release": "pnpm build && pnpm changeset publish"
   },
   "devDependencies": {
-    "@changesets/cli": "^2.29.8"
+    "@changesets/cli": "^2.29.8",
+    "playwright": "^1.61.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.29.8(@types/node@22.19.11)
+      playwright:
+        specifier: ^1.61.1
+        version: 1.61.1
 
   apps/api-server:
     dependencies:
@@ -3034,6 +3037,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3799,6 +3807,16 @@ packages:
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -7198,6 +7216,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -7832,6 +7853,14 @@ snapshots:
   pkg-up@3.1.0:
     dependencies:
       find-up: 3.0.0
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
A reproducible benchmark suite running **one shared workload** in **three environments**, plus a measured head-to-head vs WebContainers.

## Environments (`bench/suite/`, `node bench/suite/run-all.mjs`)
- **in-process Node** — embed `@lifo-sh/core`
- **single binary** — `bun --compile` standalone executable (`bench/bin/lifo-run.mjs`), spawned per run
- **browser** — headless Chromium (Playwright), core loaded over HTTP

Same workload everywhere (`workload.mjs`): boot ×20, `true` ×500, fs 1 KiB ×500, memory.

## Measured
| metric | in-process Node | single binary | browser |
|---|---|---|---|
| boot | **~0.5 ms** | **~41 ms** cold start † | **~0.7 ms** |
| commands | ~200K ops/s | — | ~350K ops/s |
| memory | ~65 MB rss | — | ~11 MB heap |

† full cold start: OS spawns the standalone binary → boots a box → runs `true` → exits. Core is **0.3 MB gzipped**; the binary is 59 MB only because it embeds the whole runtime.

## Comparison (`bench/COMPARISON.md`)
- **vs WebContainers** (measured, same Chromium via `compare-webcontainers.mjs`): Lifo ~27 ms / 0.3 MB to a ready box vs WebContainers ~8 s / 3.7 MB, no COOP/COEP required — they trade it for fuller Node fidelity.
- **vs cloud microVMs** (Vercel Sandbox / e2b / Firecracker): different category (server-side, real isolation, paid) — positioned as a spectrum.

Results in `bench/RESULTS.md`. Adds `playwright` dev dep; gitignores the compiled binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)