### PR TITLE
git: route browser clone/fetch/push through a CORS proxy

### DIFF
--- a/apps/playground/src/lib/shell.ts
+++ b/apps/playground/src/lib/shell.ts
@@ -94,7 +94,21 @@ export async function bootShell(
   if (opts.pkgs?.includes('ffmpeg')) registry.register('ffmpeg', ffmpegCommand);
   bootLifoPackages(kernel.vfs, registry);
 
-  const env = { ...kernel.getDefaultEnv(), ...opts.env };
+  // Browser shells can't fetch hosts that don't send CORS headers, so route them
+  // through proxies. Two separate targets on purpose (caller env still wins):
+  //   - LIFO_CORS_PROXY     → api.expo.dev etc. (tiny JSON) via our same-origin
+  //     /_cors; cheap, keeps expo working with no relay.
+  //   - LIFO_GIT_CORS_PROXY → git pack data (potentially tens of MB per clone)
+  //     via a dedicated public git proxy, so heavy traffic never hits our own
+  //     function bandwidth. Override to self-host (e.g. a Cloudflare Worker).
+  const corsDefault =
+    typeof location !== 'undefined'
+      ? {
+          LIFO_CORS_PROXY: `${location.origin}/_cors?url=`,
+          LIFO_GIT_CORS_PROXY: 'https://cors.isomorphic-git.org',
+        }
+      : {};
+  const env = { ...kernel.getDefaultEnv(), ...corsDefault, ...opts.env };
   if (opts.cwd) env.PWD = opts.cwd;
   const shell = new Shell(terminal, kernel.vfs, registry, env, kernel.processRegistry);
   const processRegistry = shell.getProcessRegistry();

--- a/packages/lifo-pkg-git/src/index.ts
+++ b/packages/lifo-pkg-git/src/index.ts
@@ -233,11 +233,14 @@ async function gitClone(git: Git, ctx: CommandContext, fs: GitFs): Promise<numbe
     await git.clone({
       fs,
       http: createHttpClient(),
+      // Route through a git CORS proxy in the browser (git hosts don't send CORS
+      // headers). Set by the playground to a dedicated proxy so heavy pack data
+      // never hits our own /_cors. Undefined in Node → direct fetch.
+      corsProxy: ctx.env.LIFO_GIT_CORS_PROXY || undefined,
       dir,
       url,
       singleBranch: true,
       depth: 1,
-      corsProxy: undefined,
     });
     ctx.stdout.write('done.\n');
     return 0;
@@ -645,6 +648,7 @@ async function gitPush(git: Git, ctx: CommandContext, fs: GitFs): Promise<number
     const result = await git.push({
       fs,
       http: createHttpClient(),
+      corsProxy: ctx.env.LIFO_GIT_CORS_PROXY || undefined,
       dir,
       remote,
       ref,
@@ -720,6 +724,7 @@ async function gitPull(git: Git, ctx: CommandContext, fs: GitFs): Promise<number
     await git.pull({
       fs,
       http: createHttpClient(),
+      corsProxy: ctx.env.LIFO_GIT_CORS_PROXY || undefined,
       dir,
       remote: remoteName,
       ref: ref || currentBranch,
@@ -781,6 +786,7 @@ async function gitFetch(git: Git, ctx: CommandContext, fs: GitFs): Promise<numbe
     const result = await git.fetch({
       fs,
       http: createHttpClient(),
+      corsProxy: ctx.env.LIFO_GIT_CORS_PROXY || undefined,
       dir,
       remote: remoteName,
       ref,

--- a/packages/lifo-pkg-git/tests/git.test.ts
+++ b/packages/lifo-pkg-git/tests/git.test.ts
@@ -454,4 +454,38 @@ describe('git', () => {
       expect(ctx.out).toContain('Fetching from origin');
     });
   });
+
+  describe('CORS proxy', () => {
+    // Capture the URL git's HTTP client actually fetches, without a network.
+    async function captureCloneFetch(env: Record<string, string>): Promise<string> {
+      const calls: string[] = [];
+      const realFetch = globalThis.fetch;
+      globalThis.fetch = (async (input: unknown) => {
+        calls.push(typeof input === 'string' ? input : (input as { url: string }).url);
+        return new Response(new Uint8Array(), { status: 500 });
+      }) as typeof fetch;
+      try {
+        const ctx = makeCtx(vfs, ['clone', 'https://github.com/foo/bar.git', '/out']);
+        Object.assign(ctx.env, env);
+        await gitCommand(ctx);
+      } finally {
+        globalThis.fetch = realFetch;
+      }
+      expect(calls.length).toBeGreaterThan(0);
+      return calls[0];
+    }
+
+    it('routes remote requests through LIFO_GIT_CORS_PROXY when set', async () => {
+      const first = await captureCloneFetch({ LIFO_GIT_CORS_PROXY: 'https://proxy.test' });
+      // isomorphic-git corsProxy uses path format with the protocol stripped:
+      // `${proxy}/${host}${path}` (which cors.isomorphic-git.org reconstructs).
+      expect(first).toContain('https://proxy.test/github.com/foo/bar.git');
+    });
+
+    it('fetches directly when no proxy is set', async () => {
+      const first = await captureCloneFetch({});
+      expect(first).toContain('https://github.com/foo/bar.git');
+      expect(first).not.toContain('proxy.test');
+    });
+  });
 });


### PR DESCRIPTION
## Problem
`git clone` in the browser playground fails on CORS — git hosts (github.com, …) don't send CORS headers.

## Fix
Wire isomorphic-git's native `corsProxy` (path format) to a **new, separate** `LIFO_GIT_CORS_PROXY` env — deliberately distinct from the expo `/_cors` proxy:

- **Git pack data can be tens of MB per clone.** Routing it through our own same-origin `/api/lifo-cors` function would put that bandwidth (and OOM/timeout risk from buffering) on our Vercel bill. So git gets its own proxy target.
- The playground defaults it to the public **`cors.isomorphic-git.org`** proxy — zero infra, keeps heavy traffic off our function. Override to self-host (e.g. a Cloudflare Worker).
- **Node → direct fetch** (no CORS wall): `corsProxy` is `undefined` when the env isn't set.
- Expo keeps using `/_cors` (tiny JSON metadata, negligible cost).

## Tests
+2: proxy path-rewrite when `LIFO_GIT_CORS_PROXY` set, direct fetch when unset. All 37 pass.

Delivered to the live demo by a follow-up website playground rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)