### PR TITLE
playground: warm up dev transforms + lock heavy deps

### DIFF
--- a/apps/playground/vite.config.ts
+++ b/apps/playground/vite.config.ts
@@ -10,6 +10,25 @@ export default defineConfig(({ command }) => ({
   plugins: [react(), tailwindcss(), portBridgePlugin(), corsProxyPlugin()],
   server: {
     port: 5173,
+    // Pre-transform the entry + example modules at startup so the first time you
+    // open an example it isn't a cold on-demand transform stall. Dev only.
+    warmup: {
+      clientFiles: ['./src/main.tsx', './src/components/app-shell.tsx', './src/examples/*.tsx'],
+    },
+  },
+  // Lock the heavy browser deps into the pre-bundle so Vite never discovers one
+  // mid-session and triggers a full-page reload to re-optimize.
+  optimizeDeps: {
+    include: [
+      'react',
+      'react-dom',
+      'react-dom/client',
+      'monaco-editor',
+      '@xterm/xterm',
+      '@xterm/addon-fit',
+      '@xterm/addon-webgl',
+      'isomorphic-git',
+    ],
   },
   build: {
     rollupOptions: {


### PR DESCRIPTION
Dev-server-only tune for the playground (no production impact).

## Context
Investigated a report of the dev server "getting too slow." Findings: the server is **healthy** — cold start ~170 ms, page load sub-second even on a 16-hour-old server (62 MB RSS), no re-optimization churn. The perceived slowness is inherent **dev-mode VM overhead**: `@lifo-sh/core` is aliased to source (unbundled/unminified), so VM-heavy examples run slower than the minified production bundle. That's why production is fine.

## This change
- `server.warmup` pre-transforms the entry + example modules at startup → opening an example isn't a cold transform stall.
- `optimizeDeps.include` locks the heavy browser deps (monaco, xterm, isomorphic-git) into the pre-bundle → Vite won't discover one mid-session and trigger a full-page reload to re-optimize.

Verified dev starts clean (no pre-transform errors) and loads fast. Does not touch the production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)