### PR TITLE
playground: sidebar menu (theme + clean storage) + focus terminal by default

### DIFF
--- a/apps/playground/src/components/sidebar-nav.tsx
+++ b/apps/playground/src/components/sidebar-nav.tsx
@@ -1,9 +1,34 @@
 import { useState } from 'react';
-import { Moon, Sun, PanelLeftClose, ChevronDown, ChevronRight } from 'lucide-react';
+import { Moon, Sun, MoreVertical, Trash2, PanelLeftClose, ChevronDown, ChevronRight } from 'lucide-react';
 import { exampleGroups, sectionsFor } from '@/examples/registry';
 import { cn } from '@/lib/utils';
 import { useTheme } from '@/lib/theme';
 import { LifoLogo } from '@/components/logo';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu';
+
+/** Delete the box's persisted IndexedDB stores (filesystem + content blobs), then reload. */
+async function cleanOfflineStorage(): Promise<void> {
+  const ok = window.confirm(
+    'Clear this box’s offline storage? Saved files and installed packages will be removed, then the page reloads.',
+  );
+  if (!ok) return;
+  const drop = (name: string) =>
+    new Promise<void>((resolve) => {
+      const req = indexedDB.deleteDatabase(name);
+      req.onsuccess = req.onerror = req.onblocked = () => resolve();
+    });
+  try {
+    await Promise.all([drop('lifo'), drop('lifo-blobs')]);
+  } finally {
+    location.reload();
+  }
+}
 
 interface SidebarNavProps {
   activeId: string;
@@ -47,13 +72,27 @@ export function SidebarNav({ activeId, onSelect, onCollapse }: SidebarNavProps) 
           <LifoLogo className="size-[22px] shrink-0" />
           <h1 className="text-lg font-bold text-tokyo-fg-bright tracking-tight">Lifo</h1>
           <div className="ml-auto flex items-center gap-0.5">
-            <button
-              onClick={toggle}
-              title={mode === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
-              className="w-7 h-7 grid place-items-center rounded-md bg-transparent border-none text-tokyo-comment hover:text-tokyo-fg-bright hover:bg-tokyo-hover cursor-pointer"
-            >
-              {mode === 'dark' ? <Sun size={15} /> : <Moon size={15} />}
-            </button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  title="Menu"
+                  className="w-7 h-7 grid place-items-center rounded-md bg-transparent border-none text-tokyo-comment hover:text-tokyo-fg-bright hover:bg-tokyo-hover cursor-pointer outline-none"
+                >
+                  <MoreVertical size={15} />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onSelect={() => toggle()}>
+                  {mode === 'dark' ? <Sun size={14} /> : <Moon size={14} />}
+                  <span>{mode === 'dark' ? 'Light theme' : 'Dark theme'}</span>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onSelect={() => void cleanOfflineStorage()}>
+                  <Trash2 size={14} />
+                  <span>Clean up offline storage</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
             {onCollapse && (
               <button
                 onClick={onCollapse}

--- a/apps/playground/src/components/terminal-view.tsx
+++ b/apps/playground/src/components/terminal-view.tsx
@@ -33,7 +33,11 @@ export function TerminalView({ className, onReady }: TerminalViewProps) {
       theme: xtermTheme(mode),
     });
     termRef.current = term;
-    void onReady?.(term);
+    // Focus the terminal once its shell is wired up so you can type immediately.
+    // Desktop only — auto-focusing on a phone would pop the on-screen keyboard.
+    void Promise.resolve(onReady?.(term)).then(() => {
+      if (!isMobile) term.focus();
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/apps/playground/src/components/ui/dropdown-menu.tsx
+++ b/apps/playground/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 min-w-[12rem] overflow-hidden rounded-md border border-tokyo-border bg-tokyo-bg-dark p-1 text-tokyo-fg shadow-lg",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item>) {
+  return (
+    <DropdownMenuPrimitive.Item
+      className={cn(
+        "relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-[13px] text-tokyo-muted outline-none transition-colors",
+        "hover:bg-tokyo-hover hover:text-tokyo-fg-bright focus:bg-tokyo-hover focus:text-tokyo-fg-bright",
+        "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      className={cn("my-1 h-px bg-tokyo-border", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+}


### PR DESCRIPTION
Three small playground UX changes.

- **Menu instead of the theme toggle**: the light/dark button becomes a `⋮` menu. The theme toggle moves inside it, and a new **Clean up offline storage** item deletes the box's IndexedDB stores (`lifo` filesystem + `lifo-blobs` content blobs) and reloads — handy after the persistence work.
- **Focus the terminal by default**: the terminal is focused once its shell is wired up, so you can type right away. Desktop only (skipped on phones to avoid popping the on-screen keyboard).
- Adds a minimal `dropdown-menu` (radix-ui), matching the existing tooltip/sheet pattern.

Verified in a headless browser: menu opens with both items; `document.activeElement` is the xterm textarea on load. Typecheck + build pass. Ships to the demo via a follow-up rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)