### PR TITLE
Tailwind v4 in Lifo: oxide Scanner shim + vm module + readlink fix

### DIFF
--- a/packages/core/src/commands/system/node.ts
+++ b/packages/core/src/commands/system/node.ts
@@ -61,6 +61,7 @@ function makeNodeGlobal(overrides: Record<string, unknown>): Record<string, unkn
 }
 
 import { makeProxyingFetch } from '../../node-compat/proxy-fetch.js';
+import { createOxideScanner } from '../../node-compat/tailwind-oxide.js';
 import * as nodeTimers from '../../node-compat/timers.js';
 
 /**
@@ -1033,6 +1034,11 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 		// makeFetchNodeshim. Built per-run so it uses this run's proxying fetch.
 		const fetchNodeshim = typeof nodeFetch === 'function' ? makeFetchNodeshim(nodeFetch) : undefined;
 
+		// @tailwindcss/oxide (Tailwind v4's native Rust Scanner) — served as a JS
+		// shim over the VFS. Its native + threaded-wasm bindings can't load in the
+		// browser VM. See createOxideScanner.
+		const oxideModule = { Scanner: createOxideScanner(ctx.vfs) };
+
 		// process.exit() handling. While the main script is still executing
 		// synchronously, exit() must throw (to abort it). Once we're purely
 		// event-driven (a long-running server is up and we're just awaiting it),
@@ -1128,6 +1134,8 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 			// resolution, since it IS installed (its index.js would load a missing
 			// .node binary). See lightningcssStub.
 			if (name === 'lightningcss') return lightningcssStub;
+			// @tailwindcss/oxide — JS Scanner shim (see oxideModule / createOxideScanner).
+			if (name === '@tailwindcss/oxide') return oxideModule;
 			// fetch-nodeshim: serve the native fetch stack (see makeFetchNodeshim) —
 			// intercept BEFORE node_modules resolution since the package IS installed.
 			if (name === 'fetch-nodeshim' && fetchNodeshim) return fetchNodeshim;
@@ -1585,6 +1593,8 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 			// resolution, since it IS installed (its index.js would load a missing
 			// .node binary). See lightningcssStub.
 			if (name === 'lightningcss') return lightningcssStub;
+			// @tailwindcss/oxide — JS Scanner shim (see oxideModule / createOxideScanner).
+			if (name === '@tailwindcss/oxide') return oxideModule;
 			// fetch-nodeshim: serve the native fetch stack (see makeFetchNodeshim) —
 			// intercept BEFORE node_modules resolution since the package IS installed.
 			if (name === 'fetch-nodeshim' && fetchNodeshim) return fetchNodeshim;

--- a/packages/core/src/node-compat/fs.ts
+++ b/packages/core/src/node-compat/fs.ts
@@ -477,8 +477,19 @@ export function createFs(vfs: VFS, cwd: string) {
   }
 
   function readlinkSync(path: string | URL): string {
-    // Return the path itself since we have no symlinks
-    return resolvePath(cwd, path);
+    // The VFS has no symlinks. Node's readlink throws ENOENT on a missing path
+    // and EINVAL on a non-symlink — returning the path itself (as before) made
+    // resolvers like enhanced-resolve treat every file as a self-symlink and
+    // fail. Mirror Node so those resolvers correctly skip symlink handling.
+    const abs = resolvePath(cwd, path);
+    if (!vfs.exists(abs)) {
+      throw Object.assign(new Error(`ENOENT: no such file or directory, readlink '${abs}'`), {
+        code: 'ENOENT', errno: -2, syscall: 'readlink', path: abs,
+      });
+    }
+    throw Object.assign(new Error(`EINVAL: invalid argument, readlink '${abs}'`), {
+      code: 'EINVAL', errno: -22, syscall: 'readlink', path: abs,
+    });
   }
 
   // ─── Callback API ───

--- a/packages/core/src/node-compat/index.ts
+++ b/packages/core/src/node-compat/index.ts
@@ -25,6 +25,7 @@ import * as diagnosticsChannelModule from './diagnostics_channel.js';
 import * as asyncHooksModule from './async_hooks.js';
 import { createRimraf } from './rimraf.js';
 import { createEsbuild } from './esbuild.js';
+import { createVm } from './vm.js';
 
 // Fake ephemeral port source for net/tls Server stubs (no real TCP in the VM).
 let __fakeEphemeralPort = 49152;
@@ -550,6 +551,7 @@ export function createModuleMap(ctx: NodeContext): Record<string, () => unknown>
   // npm package shims
   map.rimraf = () => createRimraf(ctx.vfs, ctx.cwd);
   map.esbuild = () => createEsbuild({ vfs: ctx.vfs, cwd: ctx.cwd });
+  map.vm = () => createVm();
 
   return map;
 }

--- a/packages/core/src/node-compat/tailwind-oxide.ts
+++ b/packages/core/src/node-compat/tailwind-oxide.ts
@@ -1,0 +1,172 @@
+/**
+ * JS shim for `@tailwindcss/oxide` — Tailwind v4's Rust class-name Scanner.
+ *
+ * The native binding is a `.node` and its wasm fallback is a threaded
+ * (`wasm32-wasip1-threads`) build that needs SharedArrayBuffer → COOP/COEP,
+ * which Lifo deliberately doesn't require. So we reimplement ONLY the Scanner
+ * (the file → candidate extractor) in JS. Everything else in Tailwind v4
+ * (`@tailwindcss/node` compile/optimize, Features) is already plain JS, and
+ * `lightningcss` is stubbed elsewhere — so this is the single missing piece.
+ *
+ * `@tailwindcss/vite` uses `new Scanner({sources}).scan()` plus `.files` /
+ * `.globs` (for watch). We walk each source base over the VFS, skip
+ * node_modules / VCS / build dirs, read text files, and extract candidates with
+ * a permissive tokenizer. Over-extraction is safe: Tailwind's compiler only
+ * emits CSS for candidates that resolve to real utilities and ignores the rest.
+ */
+
+interface OxideVfs {
+  exists(path: string): boolean;
+  stat(path: string): { type: 'file' | 'directory' };
+  readdir(path: string): Array<{ name: string }>;
+  readFileString(path: string): string;
+}
+
+interface SourceEntry {
+  base: string;
+  pattern: string;
+  negated: boolean;
+}
+
+// Directories Tailwind's scanner ignores by default (plus VCS/build output).
+const SKIP_DIRS = new Set([
+  'node_modules', '.git', '.hg', '.svn', 'dist', 'build', '.next', '.nuxt',
+  '.output', '.vite', '.cache', '.turbo', 'coverage', '.svelte-kit', 'out',
+]);
+
+// Extensions worth scanning for class candidates (templates + source + docs).
+const SCAN_EXT = new Set([
+  'html', 'htm', 'js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs', 'mts', 'cts',
+  'vue', 'svelte', 'astro', 'md', 'mdx', 'php', 'erb', 'twig', 'hbs',
+  'handlebars', 'ejs', 'liquid', 'njk', 'json',
+]);
+
+// A candidate is a run of characters bounded by whitespace, quotes, angle
+// brackets, `=`, or JS/JSX braces. Keeps `[]`/`()`/`:`/`/`/`.`/`-` etc. so
+// variants (`hover:`), arbitrary values (`bg-[#fff]`, `grid-cols-[repeat(2,1fr)]`)
+// and modifiers (`text-sm/6`) survive intact.
+const TOKEN_RE = /[^\s"'`<>={}]+/g;
+
+function extractCandidates(content: string, out: Set<string>): void {
+  const matches = content.match(TOKEN_RE);
+  if (!matches) return;
+  for (const m of matches) out.add(m);
+}
+
+function join(dir: string, name: string): string {
+  return dir.endsWith('/') ? dir + name : dir + '/' + name;
+}
+
+function extOf(name: string): string {
+  const i = name.lastIndexOf('.');
+  return i === -1 ? '' : name.slice(i + 1).toLowerCase();
+}
+
+export function createOxideScanner(vfs: OxideVfs) {
+  class Scanner {
+    private sources: SourceEntry[];
+    private _files: string[] | null = null;
+
+    constructor(opts?: { sources?: SourceEntry[] }) {
+      this.sources = (opts?.sources ?? []).filter((s) => !s.negated);
+    }
+
+    private walk(dir: string, files: string[], seen: Set<string>): void {
+      let entries: Array<{ name: string }>;
+      try {
+        entries = vfs.readdir(dir);
+      } catch {
+        return;
+      }
+      for (const e of entries) {
+        const name = e.name;
+        if (!name || name.startsWith('.')) continue; // skip dotfiles/dirs
+        const full = join(dir, name);
+        let type: 'file' | 'directory';
+        try {
+          type = vfs.stat(full).type;
+        } catch {
+          continue;
+        }
+        if (type === 'directory') {
+          if (SKIP_DIRS.has(name)) continue;
+          this.walk(full, files, seen);
+        } else if (SCAN_EXT.has(extOf(name)) && !seen.has(full)) {
+          seen.add(full);
+          files.push(full);
+        }
+      }
+    }
+
+    private collectFiles(): string[] {
+      const files: string[] = [];
+      const seen = new Set<string>();
+      for (const src of this.sources) {
+        if (!src.base || !vfs.exists(src.base)) continue;
+        this.walk(src.base, files, seen);
+      }
+      return files;
+    }
+
+    scan(): string[] {
+      this._files = this.collectFiles();
+      const candidates = new Set<string>();
+      for (const file of this._files) {
+        try {
+          extractCandidates(vfs.readFileString(file), candidates);
+        } catch {
+          /* unreadable/binary — skip */
+        }
+      }
+      return [...candidates];
+    }
+
+    scanFiles(input: Array<{ file?: string; content?: string; extension: string }>): string[] {
+      const candidates = new Set<string>();
+      for (const ch of input) {
+        let content = ch.content ?? '';
+        if (!content && ch.file) {
+          try {
+            content = vfs.readFileString(ch.file);
+          } catch {
+            content = '';
+          }
+        }
+        extractCandidates(content, candidates);
+      }
+      return [...candidates];
+    }
+
+    getCandidatesWithPositions(
+      input: { file?: string; content?: string; extension: string },
+    ): Array<{ candidate: string; position: number }> {
+      let content = input.content ?? '';
+      if (!content && input.file) {
+        try {
+          content = vfs.readFileString(input.file);
+        } catch {
+          content = '';
+        }
+      }
+      const out: Array<{ candidate: string; position: number }> = [];
+      let m: RegExpExecArray | null;
+      TOKEN_RE.lastIndex = 0;
+      while ((m = TOKEN_RE.exec(content))) out.push({ candidate: m[0], position: m.index });
+      return out;
+    }
+
+    get files(): string[] {
+      return this._files ?? (this._files = this.collectFiles());
+    }
+
+    get globs(): Array<{ base: string; pattern: string }> {
+      return this.sources.map((s) => ({ base: s.base, pattern: s.pattern }));
+    }
+
+    get normalizedSources(): Array<{ base: string; pattern: string }> {
+      return this.globs;
+    }
+  }
+
+  return Scanner;
+}

--- a/packages/core/src/node-compat/vm.ts
+++ b/packages/core/src/node-compat/vm.ts
@@ -1,0 +1,85 @@
+/**
+ * Minimal `vm` module shim.
+ *
+ * The browser VM has no real isolated V8 contexts, but tools that pull in `vm`
+ * mostly use it to *evaluate transpiled code* — notably `jiti` (the runtime
+ * TS/ESM loader behind `@tailwindcss/node`, unbuild, many configs), which calls
+ * `vm.runInThisContext(code, opts)` on a wrapped module function and runs the
+ * returned function itself.
+ *
+ * We evaluate in the current realm's global scope via indirect eval. That's not
+ * a security boundary (Lifo's isolation is JS-level regardless), but it makes
+ * `runInThisContext` / `Script` / `compileFunction` behave correctly for these
+ * loaders. Contexts are treated as plain objects.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any, no-eval */
+
+// Indirect eval → evaluates in global scope and returns the completion value
+// (e.g. the wrapped `(function(exports, require, module, …){…})` jiti produces).
+const globalEval: (code: string) => any = eval;
+
+function runInThisContext(code: string, _options?: unknown): unknown {
+  return globalEval(String(code));
+}
+
+class Script {
+  private code: string;
+  constructor(code: string, _options?: unknown) {
+    this.code = String(code);
+  }
+  runInThisContext(_options?: unknown): unknown {
+    return globalEval(this.code);
+  }
+  runInContext(_contextifiedObject?: unknown, _options?: unknown): unknown {
+    return globalEval(this.code);
+  }
+  runInNewContext(_contextObject?: unknown, _options?: unknown): unknown {
+    return globalEval(this.code);
+  }
+}
+
+function createContext(contextObject?: any): any {
+  return contextObject ?? {};
+}
+
+function isContext(_obj: unknown): boolean {
+  return false;
+}
+
+function runInContext(code: string, _contextifiedObject?: unknown, _options?: unknown): unknown {
+  return globalEval(String(code));
+}
+
+function runInNewContext(code: string, _contextObject?: unknown, _options?: unknown): unknown {
+  return globalEval(String(code));
+}
+
+function compileFunction(
+  code: string,
+  params: string[] = [],
+  _options?: unknown,
+): (...args: unknown[]) => unknown {
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  return new Function(...params, String(code)) as (...args: unknown[]) => unknown;
+}
+
+function measureMemory(): Promise<unknown> {
+  return Promise.resolve({ total: { jsMemoryEstimate: 0, jsMemoryRange: [0, 0] } });
+}
+
+export function createVm(): Record<string, unknown> {
+  const mod = {
+    runInThisContext,
+    runInContext,
+    runInNewContext,
+    createContext,
+    isContext,
+    compileFunction,
+    measureMemory,
+    Script,
+    // constants Node exposes; harmless placeholders
+    constants: { DONT_CONTEXTIFY: Symbol('DONT_CONTEXTIFY'), USE_MAIN_CONTEXT_DEFAULT_LOADER: 0 },
+  };
+  return { ...mod, default: mod };
+}

--- a/packages/core/tests/node-compat/tailwind-oxide.test.ts
+++ b/packages/core/tests/node-compat/tailwind-oxide.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { VFS } from '../../src/kernel/vfs/index.js';
+import { createOxideScanner } from '../../src/node-compat/tailwind-oxide.js';
+
+describe('tailwind oxide Scanner shim', () => {
+  it('extracts class candidates and skips node_modules / build dirs', () => {
+    const vfs = new VFS();
+    vfs.mkdir('/app/src', { recursive: true });
+    vfs.writeFile(
+      '/app/src/App.tsx',
+      'export default () => <div className="flex items-center bg-[#fff] hover:bg-red-500 text-sm/6" />',
+    );
+    vfs.mkdir('/app/node_modules/foo', { recursive: true });
+    vfs.writeFile('/app/node_modules/foo/index.js', 'const x = "should-not-appear-nm"');
+    vfs.mkdir('/app/dist', { recursive: true });
+    vfs.writeFile('/app/dist/bundle.js', 'const y = "should-not-appear-dist"');
+
+    const Scanner = createOxideScanner(vfs);
+    const s = new Scanner({ sources: [{ base: '/app', pattern: '**/*', negated: false }] });
+    const cands = s.scan();
+
+    expect(cands).toContain('flex');
+    expect(cands).toContain('items-center');
+    expect(cands).toContain('bg-[#fff]');
+    expect(cands).toContain('hover:bg-red-500');
+    expect(cands).toContain('text-sm/6');
+    expect(cands).not.toContain('should-not-appear-nm');
+    expect(cands).not.toContain('should-not-appear-dist');
+
+    // files/globs getters (used by @tailwindcss/vite for watch)
+    expect(s.files.some((f) => f.endsWith('/App.tsx'))).toBe(true);
+    expect(s.files.some((f) => f.includes('node_modules'))).toBe(false);
+    expect(s.globs).toEqual([{ base: '/app', pattern: '**/*' }]);
+  });
+
+  it('scanFiles extracts candidates from provided content (arbitrary values with parens)', () => {
+    const vfs = new VFS();
+    const Scanner = createOxideScanner(vfs);
+    const s = new Scanner({ sources: [] });
+    const cands = s.scanFiles([
+      { content: '<a class="p-4 grid-cols-[repeat(2,1fr)] -mt-2">', extension: 'html' },
+    ]);
+    expect(cands).toContain('p-4');
+    expect(cands).toContain('grid-cols-[repeat(2,1fr)]');
+    expect(cands).toContain('-mt-2');
+  });
+
+  it('getCandidatesWithPositions returns positions', () => {
+    const vfs = new VFS();
+    const Scanner = createOxideScanner(vfs);
+    const s = new Scanner({ sources: [] });
+    const out = s.getCandidatesWithPositions({ content: 'flex p-2', extension: 'html' });
+    expect(out[0]).toEqual({ candidate: 'flex', position: 0 });
+    expect(out.find((c) => c.candidate === 'p-2')?.position).toBe(5);
+  });
+});

--- a/packages/core/tests/node-compat/vm.test.ts
+++ b/packages/core/tests/node-compat/vm.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { createVm } from '../../src/node-compat/vm.js';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('vm shim', () => {
+  it('runInThisContext evaluates and returns the completion value', () => {
+    const vm = createVm() as any;
+    expect(vm.runInThisContext('1 + 2')).toBe(3);
+  });
+
+  it('runInThisContext returns a wrapped function (jiti pattern)', () => {
+    const vm = createVm() as any;
+    const fn = vm.runInThisContext('(function(a, b){ return a + b; })');
+    expect(typeof fn).toBe('function');
+    expect(fn(2, 3)).toBe(5);
+  });
+
+  it('Script.runInThisContext works', () => {
+    const vm = createVm() as any;
+    const s = new vm.Script('40 + 2');
+    expect(s.runInThisContext()).toBe(42);
+  });
+
+  it('compileFunction builds a callable with params', () => {
+    const vm = createVm() as any;
+    const f = vm.compileFunction('return x * 2', ['x']);
+    expect(f(21)).toBe(42);
+  });
+});


### PR DESCRIPTION
Makes **Tailwind v4 run unmodified in the Lifo VM** — no native binaries, no COOP/COEP. Found by cloning a real Vite+Supabase project and chasing it through the VM.

Three chained core fixes:
1. **`@tailwindcss/oxide` JS Scanner shim** — Tailwind v4's Rust class scanner. Its only wasm build is threaded (needs SharedArrayBuffer → COOP/COEP, which Lifo rejects by design), so the Scanner (file → class-candidate extractor) is reimplemented in JS over the VFS. The rest of Tailwind v4 (`@tailwindcss/node`) is already JS; lightningcss is stubbed.
2. **`vm` module shim** — `@tailwindcss/node` loads via `jiti`, which needs `vm.runInThisContext`. Indirect-eval based (the VM already evals JS).
3. **`readlink` correctness** — it returned the path itself, making `enhanced-resolve` treat every file as a self-symlink and crash. Now Node-correct (ENOENT/EINVAL).

**Verified in the VM:** `@import "tailwindcss"` + oxide-shim scan + `compiler.build()` → 4975 bytes of CSS with `.flex`, `items-center`, `bg-red-500` (hover), `bg-[#fff]` (arbitrary value). 207 node-compat tests pass (incl. new oxide + vm tests).

Follow-up (not in this PR): the `@vitejs/plugin-react-swc` (`@swc/core`) blocker via `@swc/wasm`, then a full Vite dev run of the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)