### PR TITLE
fix(npm): parse pkg@npm:<target> alias specs

### DIFF
--- a/packages/core/src/commands/system/npm.ts
+++ b/packages/core/src/commands/system/npm.ts
@@ -55,13 +55,18 @@ function getRegistry(env: Record<string, string>): string {
 	return env.NPM_REGISTRY || DEFAULT_REGISTRY;
 }
 
-function parsePackageSpec(spec: string): { name: string; version: string | null } {
+export function parsePackageSpec(spec: string): { name: string; version: string | null } {
+	// A package name can't contain '@', so the FIRST '@' after the name is the
+	// version separator — NOT the last. lastIndexOf broke alias specs whose
+	// version itself contains '@', e.g. `pg-mem@npm:@tinbase/pg-mem@^3.2.0`
+	// (name `pg-mem`, version `npm:@tinbase/pg-mem@^3.2.0`).
+
 	// Scoped: @scope/name@version
 	if (spec.startsWith('@')) {
 		const slashIdx = spec.indexOf('/');
 		if (slashIdx === -1) return { name: spec, version: null };
 		const rest = spec.slice(slashIdx + 1);
-		const atIdx = rest.lastIndexOf('@');
+		const atIdx = rest.indexOf('@');
 		if (atIdx > 0) {
 			return {
 				name: spec.slice(0, slashIdx + 1 + atIdx),
@@ -72,7 +77,7 @@ function parsePackageSpec(spec: string): { name: string; version: string | null 
 	}
 
 	// Regular: name@version
-	const atIdx = spec.lastIndexOf('@');
+	const atIdx = spec.indexOf('@');
 	if (atIdx > 0) {
 		return { name: spec.slice(0, atIdx), version: spec.slice(atIdx + 1) };
 	}

--- a/packages/core/tests/commands/npm-spec.test.ts
+++ b/packages/core/tests/commands/npm-spec.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { parsePackageSpec } from '../../src/commands/system/npm.js';
+
+describe('parsePackageSpec', () => {
+  it('parses plain names', () => {
+    expect(parsePackageSpec('lodash')).toEqual({ name: 'lodash', version: null });
+  });
+
+  it('parses name@version', () => {
+    expect(parsePackageSpec('lodash@4.17.21')).toEqual({ name: 'lodash', version: '4.17.21' });
+    expect(parsePackageSpec('inherits@2')).toEqual({ name: 'inherits', version: '2' });
+  });
+
+  it('parses scoped names', () => {
+    expect(parsePackageSpec('@tinbase/pg-mem')).toEqual({ name: '@tinbase/pg-mem', version: null });
+    expect(parsePackageSpec('@tinbase/pg-mem@^3.2.0')).toEqual({ name: '@tinbase/pg-mem', version: '^3.2.0' });
+  });
+
+  it('parses npm: alias specs (version contains @)', () => {
+    // This is the bug: lastIndexOf split at the wrong @.
+    expect(parsePackageSpec('pg-mem@npm:@tinbase/pg-mem@^3.2.0')).toEqual({
+      name: 'pg-mem',
+      version: 'npm:@tinbase/pg-mem@^3.2.0',
+    });
+    expect(parsePackageSpec('my-lodash@npm:lodash@^4')).toEqual({
+      name: 'my-lodash',
+      version: 'npm:lodash@^4',
+    });
+  });
+
+  it('parses a scoped alias spec', () => {
+    expect(parsePackageSpec('@a/b@npm:@c/d@^1')).toEqual({
+      name: '@a/b',
+      version: 'npm:@c/d@^1',
+    });
+  });
+});


### PR DESCRIPTION
`parsePackageSpec` split on the **last** `@`, so `pg-mem@npm:@tinbase/pg-mem@^3.2.0` (a CLI/manifest npm alias) became name `pg-mem@npm:@tinbase/pg-mem` → "Failed to fetch". A package name can't contain `@`, so the **first** `@` after the name is the separator — use `indexOf`.

This blocked installing the `@tinbase/pg-mem` fork under the `pg-mem` name, which tinbase's `--engine pgmem` needs (real `pg-mem` lacks `current_setting`, used by PostgREST's JWT-claims handling). Alias *resolution* (`resolveFetchSpec`) was already wired; only the parse was wrong.

Verified in the VM: `npm install "pg-mem@npm:@tinbase/pg-mem@^3.2.0"` now places `@tinbase/pg-mem@3.2.0` at `node_modules/pg-mem`. +5 parse tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)