### PR TITLE
node-compat: @swc/core shim (wasm-esbuild-backed) for plugin-react-swc

### DIFF
--- a/packages/core/src/commands/system/node.ts
+++ b/packages/core/src/commands/system/node.ts
@@ -62,6 +62,8 @@ function makeNodeGlobal(overrides: Record<string, unknown>): Record<string, unkn
 
 import { makeProxyingFetch } from '../../node-compat/proxy-fetch.js';
 import { createOxideScanner } from '../../node-compat/tailwind-oxide.js';
+import { createSwcCore } from '../../node-compat/swc.js';
+import { createEsbuild } from '../../node-compat/esbuild.js';
 import * as nodeTimers from '../../node-compat/timers.js';
 
 /**
@@ -1039,6 +1041,10 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 		// browser VM. See createOxideScanner.
 		const oxideModule = { Scanner: createOxideScanner(ctx.vfs) };
 
+		// @swc/core (native Rust binding) — backed by the wasm esbuild shim, so
+		// @vitejs/plugin-react-swc runs unmodified. See createSwcCore.
+		const swcModule = createSwcCore({ vfs: ctx.vfs, cwd: ctx.cwd }, createEsbuild);
+
 		// process.exit() handling. While the main script is still executing
 		// synchronously, exit() must throw (to abort it). Once we're purely
 		// event-driven (a long-running server is up and we're just awaiting it),
@@ -1136,6 +1142,8 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 			if (name === 'lightningcss') return lightningcssStub;
 			// @tailwindcss/oxide — JS Scanner shim (see oxideModule / createOxideScanner).
 			if (name === '@tailwindcss/oxide') return oxideModule;
+			// @swc/core — wasm-esbuild-backed shim (see swcModule / createSwcCore).
+			if (name === '@swc/core') return swcModule;
 			// fetch-nodeshim: serve the native fetch stack (see makeFetchNodeshim) —
 			// intercept BEFORE node_modules resolution since the package IS installed.
 			if (name === 'fetch-nodeshim' && fetchNodeshim) return fetchNodeshim;
@@ -1595,6 +1603,8 @@ function createNodeImpl(kernelOrPortRegistry?: Kernel | Map<number, VirtualReque
 			if (name === 'lightningcss') return lightningcssStub;
 			// @tailwindcss/oxide — JS Scanner shim (see oxideModule / createOxideScanner).
 			if (name === '@tailwindcss/oxide') return oxideModule;
+			// @swc/core — wasm-esbuild-backed shim (see swcModule / createSwcCore).
+			if (name === '@swc/core') return swcModule;
 			// fetch-nodeshim: serve the native fetch stack (see makeFetchNodeshim) —
 			// intercept BEFORE node_modules resolution since the package IS installed.
 			if (name === 'fetch-nodeshim' && fetchNodeshim) return fetchNodeshim;

--- a/packages/core/src/node-compat/swc.ts
+++ b/packages/core/src/node-compat/swc.ts
@@ -1,0 +1,74 @@
+/**
+ * `@swc/core` shim backed by Lifo's (wasm) esbuild.
+ *
+ * `@swc/core` is a native Rust binding (`.node`); its loader even calls
+ * `process.report.getReport()` before failing to find the binary. `@swc/wasm`
+ * exists but is ~19 MB — too heavy to ship or fetch per project. Lifo already
+ * has a wasm esbuild that transforms TS/JSX (it's how Vite runs here), so we
+ * back `@swc/core`'s `transform` with it.
+ *
+ * The main consumer is `@vitejs/plugin-react-swc`, which calls the async
+ * `transform(code, options)` and detects React Fast Refresh by testing the
+ * OUTPUT for `$RefreshReg$(`. esbuild doesn't inject those, so the plugin
+ * cleanly falls back to the plain compiled code — the app runs; HMR just does a
+ * full reload instead of fast-refresh. That's the accepted trade-off for
+ * running the plugin unmodified without native SWC.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+interface SwcCtx {
+  vfs: unknown;
+  cwd: string;
+}
+
+function pickLoader(filename: string | undefined, options: any): 'tsx' | 'ts' | 'jsx' | 'js' {
+  const f = String(filename ?? '');
+  if (f.endsWith('.tsx')) return 'tsx';
+  if (f.endsWith('.ts') || f.endsWith('.mts') || f.endsWith('.cts')) return 'ts';
+  if (f.endsWith('.jsx')) return 'jsx';
+  if (f.endsWith('.js') || f.endsWith('.mjs') || f.endsWith('.cjs')) return 'jsx';
+  // Fall back to SWC's parser options.
+  const p = options?.jsc?.parser;
+  if (p?.syntax === 'typescript') return p?.tsx === false ? 'ts' : 'tsx';
+  return 'jsx';
+}
+
+export function createSwcCore(ctx: SwcCtx, makeEsbuild: (c: SwcCtx) => any): Record<string, unknown> {
+  const esb = makeEsbuild(ctx);
+
+  async function transform(code: string, options?: any): Promise<{ code: string; map?: string }> {
+    const react = options?.jsc?.transform?.react;
+    const res = await esb.transform(code, {
+      loader: pickLoader(options?.filename, options),
+      jsx: react ? (react.runtime === 'automatic' ? 'automatic' : 'transform') : 'automatic',
+      jsxDev: !!react?.development,
+      jsxImportSource: react?.importSource || undefined,
+      sourcemap: options?.sourceMaps ? true : false,
+      sourcefile: options?.filename || undefined,
+      target: 'es2020',
+    });
+    return { code: res.code, map: res.map ? res.map : undefined };
+  }
+
+  function transformSync(): never {
+    throw new Error('[lifo] @swc/core.transformSync is unavailable in the browser VM — use the async transform().');
+  }
+
+  const unsupported = (name: string) => () => {
+    throw new Error(`[lifo] @swc/core.${name}() is not supported in the browser VM.`);
+  };
+
+  const mod = {
+    transform,
+    transformSync,
+    parse: async () => unsupported('parse')(),
+    parseSync: unsupported('parseSync'),
+    print: async () => unsupported('print')(),
+    printSync: unsupported('printSync'),
+    // Pass-through minify (esbuild bundling handles real minification elsewhere).
+    minify: async (code: string) => ({ code }),
+    minifySync: (code: string) => ({ code }),
+  };
+  return { ...mod, default: mod };
+}

--- a/packages/core/tests/node-compat/swc.test.ts
+++ b/packages/core/tests/node-compat/swc.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { createSwcCore } from '../../src/node-compat/swc.js';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('@swc/core shim', () => {
+  it('maps SWC transform options to esbuild and returns { code, map }', async () => {
+    let captured: any;
+    const mockEsb = {
+      transform: async (_code: string, opts: any) => {
+        captured = opts;
+        return { code: 'OUT', map: 'MAP' };
+      },
+    };
+    const swc = createSwcCore({ vfs: {}, cwd: '/' }, () => mockEsb) as any;
+    const res = await swc.transform('source', {
+      filename: '/a/App.tsx',
+      sourceMaps: true,
+      jsc: { parser: { syntax: 'typescript', tsx: true }, transform: { react: { runtime: 'automatic', development: true } } },
+    });
+    expect(res).toEqual({ code: 'OUT', map: 'MAP' });
+    expect(captured.loader).toBe('tsx');
+    expect(captured.jsx).toBe('automatic');
+    expect(captured.jsxDev).toBe(true);
+    expect(captured.sourcemap).toBe(true);
+    expect(captured.sourcefile).toBe('/a/App.tsx');
+  });
+
+  it('picks loader by extension when parser options are absent', async () => {
+    const seen: string[] = [];
+    const mockEsb = { transform: async (_c: string, o: any) => { seen.push(o.loader); return { code: '' }; } };
+    const swc = createSwcCore({ vfs: {}, cwd: '/' }, () => mockEsb) as any;
+    await swc.transform('', { filename: 'x.ts' });
+    await swc.transform('', { filename: 'x.jsx' });
+    await swc.transform('', { filename: 'x.js' });
+    expect(seen).toEqual(['ts', 'jsx', 'jsx']);
+  });
+
+  it('transformSync throws (async-only in the VM)', () => {
+    const swc = createSwcCore({ vfs: {}, cwd: '/' }, () => ({})) as any;
+    expect(() => swc.transformSync()).toThrow(/transformSync/);
+  });
+});


### PR DESCRIPTION
Makes `@vitejs/plugin-react-swc` run unmodified in Lifo. `@swc/core` is a native binding (its loader even calls `process.report.getReport()`), and `@swc/wasm` is ~19 MB. Lifo already has a wasm esbuild that transforms TS/JSX, so back `@swc/core.transform` with it.

The plugin detects Fast Refresh by testing the transform output for `$RefreshReg$(` — esbuild doesn't inject that, so the plugin falls back to the plain compiled code. App runs; HMR does full reload instead of fast-refresh.

**Verified in the VM:** `vite dev` boots ("ready in 267 ms") with plugin-react-swc unmodified (previously crashed at config load with the getReport error), and `vite build` transforms the TSX. Note: `vite build` still hits rollup's native parser (build-only; `npm run dev` is unaffected). +3 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)