### PR TITLE
fix(node): ESM masker desync on regex-after-comment (prettier)

### DIFF
--- a/apps/playground/src/components/logo.tsx
+++ b/apps/playground/src/components/logo.tsx
@@ -2,7 +2,7 @@
 export function LifoLogo({ className = 'size-6' }: { className?: string }) {
   return (
     <svg viewBox="0 0 24 24" className={className} aria-hidden="true">
-      <rect width="24" height="24" rx="6" fill="#16161e" stroke="#292e42" />
+      <rect x="0.75" y="0.75" width="22.5" height="22.5" rx="5.25" fill="#16161e" stroke="#292e42" />
       <path
         d="M6.5 8.5 L10 12 L6.5 15.5"
         fill="none"

--- a/packages/core/src/commands/system/node.ts
+++ b/packages/core/src/commands/system/node.ts
@@ -251,15 +251,18 @@ function cjsDecl(name: string): string {
  * triggers the template parser), hence scan-then-validate instead of
  * dropping the weak preceders.
  */
-function isRegexStart(src: string, i: number): 'strong' | 'weak' | false {
-	let k = i - 1;
-	while (k >= 0 && (src[k] === ' ' || src[k] === '\t' || src[k] === '\n' || src[k] === '\r')) k--;
-	const prev = k >= 0 ? src[k] : '\0';
-	if ('\0=([{,;!&|^~?:+-*%<>/'.includes(prev) ||
-		(k >= 1 && /\b(?:return|typeof|void|delete|throw|new|case|of|in|yield|await)\s*$/.test(src.slice(Math.max(0, k - 11), k + 1)))) {
+// `prevChar` is the previous SIGNIFICANT char (see maskStringLiterals' tracking):
+// comments are transparent, and a string/regex value is reported as 'x'. This
+// avoids scanning backward across comments — a regex on its own line after a
+// `// comment` used to see the comment's last char and get misread as division,
+// desyncing the whole masker (prettier's `.replace(\n // …\n /re/)`).
+function isRegexStart(prevChar: string, prevIdx: number, src: string): 'strong' | 'weak' | false {
+	if ('\0=([{,;!&|^~?:+-*%<>/'.includes(prevChar) ||
+		(prevIdx >= 0 && /[A-Za-z_$]/.test(prevChar) &&
+			/\b(?:return|typeof|void|delete|throw|new|case|of|in|yield|await)$/.test(src.slice(Math.max(0, prevIdx - 11), prevIdx + 1)))) {
 		return 'strong';
 	}
-	if (')]}'.includes(prev)) return 'weak';
+	if (')]}'.includes(prevChar)) return 'weak';
 	return false;
 }
 
@@ -268,9 +271,13 @@ function isPlausibleRegex(candidate: string): boolean {
 	const lastSlash = candidate.lastIndexOf('/');
 	if (lastSlash <= 0) return false;
 	const body = candidate.slice(1, lastSlash);
-	if (body.length === 0 || body.length > 500 || body.includes('\n')) return false;
+	// Validate WITH the actual flags — a regex like /[\p{L}]/u is only valid with
+	// `u`, so validating the body flagless wrongly rejected it, left it unmasked,
+	// and its inner quotes desynced the whole masker (prettier is full of these).
+	const flags = candidate.slice(lastSlash + 1);
+	if (body.length === 0 || body.length > 2000 || body.includes('\n')) return false;
 	try {
-		new RegExp(body);
+		new RegExp(body, /^[gimsuyvd]*$/.test(flags) ? flags : '');
 		return true;
 	} catch {
 		return false;
@@ -370,6 +377,10 @@ function maskStringLiterals(src: string): { masked: string; literals: string[] }
 	const literals: string[] = [];
 	let masked = '';
 	let i = 0;
+	// Previous significant char for regex/division disambiguation. Comments are
+	// transparent (don't update it); a string/regex literal is a value → 'x'.
+	let prevChar = '\0';
+	let prevIdx = -1;
 
 	while (i < src.length) {
 		const ch = src[i];
@@ -398,11 +409,12 @@ function maskStringLiterals(src: string): { masked: string; literals: string[] }
 
 		// Regex literals — skip to avoid confusing backticks inside /regex/ with templates
 		if (ch === '/') {
-			const kind = isRegexStart(src, i);
+			const kind = isRegexStart(prevChar, prevIdx, src);
 			if (kind) {
 				const end = scanRegexLiteral(src, i);
 				if (kind === 'strong' || isPlausibleRegex(src.slice(i, end))) {
 					masked += src.slice(i, end);
+					prevChar = 'x'; prevIdx = -1; // a regex literal is a value
 					i = end;
 					continue;
 				}
@@ -421,10 +433,12 @@ function maskStringLiterals(src: string): { masked: string; literals: string[] }
 			// Placeholder uses same quote style so import regexes that capture
 			// ['"][^'"]+['"] still work (they see e.g. "__LIFO_S0__").
 			masked += ch + '__LIFO_S' + idx + '__' + ch;
+			prevChar = 'x'; prevIdx = -1; // a string/template literal is a value
 			continue;
 		}
 
 		masked += ch;
+		if (ch !== ' ' && ch !== '\t' && ch !== '\n' && ch !== '\r') { prevChar = ch; prevIdx = i; }
 		i++;
 	}
 

--- a/packages/core/tests/commands/esm-transform.test.ts
+++ b/packages/core/tests/commands/esm-transform.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { transformEsmToCjs } from '../../src/commands/system/node.js';
+
+// Ensure the transformed output has no ESM `import`/`export` statement syntax
+// left (which would throw "Cannot use import statement outside a module" when
+// run in the CJS wrapper).
+function noEsmSyntax(out: string): boolean {
+  return !out.split('\n').some(
+    (l) => /^\s*import\s+[\w${*{]/.test(l) && /from\s*['"]/.test(l),
+  ) && !/(^|\n)\s*export\s+(default|const|let|var|function|class|\{)/.test(out);
+}
+
+describe('transformEsmToCjs', () => {
+  it('transforms a plain default + named imports', () => {
+    const out = transformEsmToCjs(`import fs from "fs/promises";\nimport { a, b as c } from "m";\nexport const x = 1;`);
+    expect(out).toContain('require("fs/promises")');
+    expect(out).toContain('require("m")');
+    expect(noEsmSyntax(out)).toBe(true);
+  });
+
+  it('does not desync on a regex that follows a // comment (prettier repro)', () => {
+    // The regex is on its own line after a comment whose last char is a digit.
+    // Previously isRegexStart saw the comment text, misread the regex as
+    // division, left it unmasked, and its inner quotes swallowed later code —
+    // so the trailing import survived untransformed.
+    const src = [
+      'const f = (message) => message.replace(',
+      '  // TODO[engine:node@>=20]: quoted after Node.js 20',
+      "  /(?<=^Unexpected token )(['\"])/,",
+      '  "$1",',
+      ');',
+      'import fs3 from "fs/promises";',
+      'export { f };',
+    ].join('\n');
+    const out = transformEsmToCjs(src);
+    expect(out).toContain('require("fs/promises")');
+    expect(noEsmSyntax(out)).toBe(true);
+  });
+
+  it('validates regex flags — /[\\p{L}]/u is masked, not treated as code', () => {
+    const src = [
+      'const re = /[\\p{L}"\']/u;',
+      'import x from "y";',
+    ].join('\n');
+    const out = transformEsmToCjs(src);
+    expect(out).toContain('require("y")');
+    expect(noEsmSyntax(out)).toBe(true);
+  });
+
+  it('treats division after a value as division, not a regex', () => {
+    // `a) / b / c` must not be masked as a regex (which would swallow later code).
+    const src = [
+      'function g(a, b, c){ return (a) / b / c }',
+      'import z from "w";',
+      'export default g;',
+    ].join('\n');
+    const out = transformEsmToCjs(src);
+    expect(out).toContain('require("w")');
+    expect(noEsmSyntax(out)).toBe(true);
+  });
+});


### PR DESCRIPTION
`npm run dev` on a real project crashed loading `prettier/index.mjs`: "Cannot use import statement outside a module". 20 top-level imports survived the ESM→CJS transform.

**Root cause:** the masker's `isRegexStart` skipped backward over whitespace but not **comments**. prettier has `.replace(\n // TODO…Node.js 20\n /(?<=^Unexpected token )(['"])/, …)` — a regex on its own line after a `//` comment. `isRegexStart` saw the comment's last char (`0`), misread the regex as division, left it unmasked, and its inner `'`/`"` desynced the whole masker, swallowing later code including imports.

**Fix:** track the previous *significant* char as the masker runs (comments transparent; string/regex values reported as `'x'`) so `isRegexStart` never scans across comments. Also validate regex bodies with their real flags (`/[\p{L}]/u`) and raise the body-length cap.

Verified: prettier transforms with 0 surviving imports and parses as CJS. +4 regression tests; 284 node/node-compat tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)