### PR TITLE
chore: release @lifo-sh/core@0.6.1

### DIFF
--- a/apps/api-server/CHANGELOG.md
+++ b/apps/api-server/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @lifo-sh/api-server
+
+## 0.1.1
+
+### Patch Changes
+
+- lifo-sh@0.6.1

--- a/apps/api-server/package.json
+++ b/apps/api-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/api-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @lifo-sh/desktop
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.1
+  - @lifo-sh/ui@0.6.1

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/desktop",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # lifo-sh
 
+## 0.6.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.1
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-sh",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Run Lifo (a Linux-like OS) in your terminal -- npx lifo-sh",
   "license": "MIT",
   "repository": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @lifo-sh/core
 
+## 0.6.1
+
+### Patch Changes
+
+- Fix ESM masker desync on a regex after a comment
+  - @lifo-sh/ui@0.6.1
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Linux-like OS engine for JavaScript -- kernel, shell, VFS, and 60+ commands",
   "license": "MIT",
   "repository": {

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -1,5 +1,12 @@
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
+import pkg from './package.json' with { type: 'json' };
+
+const external = [
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.peerDependencies ?? {}),
+  ...Object.keys(pkg.optionalDependencies ?? {}),
+];
 
 export default defineConfig({
   plugins: [
@@ -12,9 +19,7 @@ export default defineConfig({
       fileName: 'index',
     },
     rollupOptions: {
-      external: [
-        '@lifo-sh/ui',
-      ],
+      external,
     },
   },
   test: {

--- a/packages/lifo-pkg-bc/CHANGELOG.md
+++ b/packages/lifo-pkg-bc/CHANGELOG.md
@@ -1,0 +1,8 @@
+# lifo-pkg-bc
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.1

--- a/packages/lifo-pkg-bc/package.json
+++ b/packages/lifo-pkg-bc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-bc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "bc calculator",
   "license": "MIT",
   "author": "Sanket Sahu",
@@ -8,13 +8,45 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "exports": { ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } },
-  "files": ["dist"],
-  "publishConfig": { "access": "public" },
-  "lifo": { "commands": { "bc": "./dist/index.js" } },
-  "keywords": ["lifo-pkg", "bc"],
-  "scripts": { "build": "vite build", "test": "vitest run", "test:watch": "vitest" },
-  "peerDependencies": { "@lifo-sh/core": "workspace:*" },
-  "peerDependenciesMeta": { "@lifo-sh/core": { "optional": true } },
-  "devDependencies": { "@lifo-sh/core": "workspace:*", "typescript": "^5.7.0", "vite": "^6.0.0", "vite-plugin-dts": "^4.5.0", "vitest": "^3.0.0" }
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "lifo": {
+    "commands": {
+      "bc": "./dist/index.js"
+    }
+  },
+  "keywords": [
+    "lifo-pkg",
+    "bc"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@lifo-sh/core": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@lifo-sh/core": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@lifo-sh/core": "workspace:*",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vite-plugin-dts": "^4.5.0",
+    "vitest": "^3.0.0"
+  }
 }

--- a/packages/lifo-pkg-cal/CHANGELOG.md
+++ b/packages/lifo-pkg-cal/CHANGELOG.md
@@ -1,0 +1,8 @@
+# lifo-pkg-cal
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.1

--- a/packages/lifo-pkg-cal/package.json
+++ b/packages/lifo-pkg-cal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-cal",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "cal calendar",
   "license": "MIT",
   "author": "Sanket Sahu",
@@ -8,13 +8,45 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "exports": { ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } },
-  "files": ["dist"],
-  "publishConfig": { "access": "public" },
-  "lifo": { "commands": { "cal": "./dist/index.js" } },
-  "keywords": ["lifo-pkg", "cal"],
-  "scripts": { "build": "vite build", "test": "vitest run", "test:watch": "vitest" },
-  "peerDependencies": { "@lifo-sh/core": "workspace:*" },
-  "peerDependenciesMeta": { "@lifo-sh/core": { "optional": true } },
-  "devDependencies": { "@lifo-sh/core": "workspace:*", "typescript": "^5.7.0", "vite": "^6.0.0", "vite-plugin-dts": "^4.5.0", "vitest": "^3.0.0" }
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "lifo": {
+    "commands": {
+      "cal": "./dist/index.js"
+    }
+  },
+  "keywords": [
+    "lifo-pkg",
+    "cal"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@lifo-sh/core": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@lifo-sh/core": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@lifo-sh/core": "workspace:*",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vite-plugin-dts": "^4.5.0",
+    "vitest": "^3.0.0"
+  }
 }

--- a/packages/lifo-pkg-fastfetch/CHANGELOG.md
+++ b/packages/lifo-pkg-fastfetch/CHANGELOG.md
@@ -1,0 +1,8 @@
+# lifo-pkg-fastfetch
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.1

--- a/packages/lifo-pkg-fastfetch/package.json
+++ b/packages/lifo-pkg-fastfetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-fastfetch",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "fastfetch / neofetch system-info command for Lifo",
   "license": "MIT",
   "author": "Sanket Sahu",

--- a/packages/lifo-pkg-ffmpeg/CHANGELOG.md
+++ b/packages/lifo-pkg-ffmpeg/CHANGELOG.md
@@ -1,8 +1,14 @@
 # lifo-pkg-ffmpeg
 
+## 0.6.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.1
+
 ## 0.6.0
 
 ### Minor Changes
 
 - Version alignment with `@lifo-sh/core` 0.6.0.
-

--- a/packages/lifo-pkg-ffmpeg/package.json
+++ b/packages/lifo-pkg-ffmpeg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-ffmpeg",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "FFmpeg command for Lifo, powered by ffmpeg.wasm",
   "license": "MIT",
   "author": "Sanket Sahu",

--- a/packages/lifo-pkg-git/CHANGELOG.md
+++ b/packages/lifo-pkg-git/CHANGELOG.md
@@ -1,8 +1,14 @@
 # lifo-pkg-git
 
+## 0.6.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.1
+
 ## 0.6.0
 
 ### Minor Changes
 
 - Version alignment with `@lifo-sh/core` 0.6.0.
-

--- a/packages/lifo-pkg-git/package.json
+++ b/packages/lifo-pkg-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-git",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Git command for Lifo, powered by isomorphic-git",
   "license": "MIT",
   "author": "Sanket Sahu",

--- a/packages/lifo-pkg-less/CHANGELOG.md
+++ b/packages/lifo-pkg-less/CHANGELOG.md
@@ -1,0 +1,8 @@
+# lifo-pkg-less
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.1

--- a/packages/lifo-pkg-less/package.json
+++ b/packages/lifo-pkg-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-less",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "less pager",
   "license": "MIT",
   "author": "Sanket Sahu",
@@ -8,13 +8,45 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "exports": { ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } },
-  "files": ["dist"],
-  "publishConfig": { "access": "public" },
-  "lifo": { "commands": { "less": "./dist/index.js" } },
-  "keywords": ["lifo-pkg", "less"],
-  "scripts": { "build": "vite build", "test": "vitest run", "test:watch": "vitest" },
-  "peerDependencies": { "@lifo-sh/core": "workspace:*" },
-  "peerDependenciesMeta": { "@lifo-sh/core": { "optional": true } },
-  "devDependencies": { "@lifo-sh/core": "workspace:*", "typescript": "^5.7.0", "vite": "^6.0.0", "vite-plugin-dts": "^4.5.0", "vitest": "^3.0.0" }
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "lifo": {
+    "commands": {
+      "less": "./dist/index.js"
+    }
+  },
+  "keywords": [
+    "lifo-pkg",
+    "less"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@lifo-sh/core": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@lifo-sh/core": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@lifo-sh/core": "workspace:*",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vite-plugin-dts": "^4.5.0",
+    "vitest": "^3.0.0"
+  }
 }

--- a/packages/lifo-pkg-man/CHANGELOG.md
+++ b/packages/lifo-pkg-man/CHANGELOG.md
@@ -1,0 +1,8 @@
+# lifo-pkg-man
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.1

--- a/packages/lifo-pkg-man/package.json
+++ b/packages/lifo-pkg-man/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-man",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "man manual pages",
   "license": "MIT",
   "author": "Sanket Sahu",
@@ -8,13 +8,45 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "exports": { ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } },
-  "files": ["dist"],
-  "publishConfig": { "access": "public" },
-  "lifo": { "commands": { "man": "./dist/index.js" } },
-  "keywords": ["lifo-pkg", "man"],
-  "scripts": { "build": "vite build", "test": "vitest run", "test:watch": "vitest" },
-  "peerDependencies": { "@lifo-sh/core": "workspace:*" },
-  "peerDependenciesMeta": { "@lifo-sh/core": { "optional": true } },
-  "devDependencies": { "@lifo-sh/core": "workspace:*", "typescript": "^5.7.0", "vite": "^6.0.0", "vite-plugin-dts": "^4.5.0", "vitest": "^3.0.0" }
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "lifo": {
+    "commands": {
+      "man": "./dist/index.js"
+    }
+  },
+  "keywords": [
+    "lifo-pkg",
+    "man"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@lifo-sh/core": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@lifo-sh/core": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@lifo-sh/core": "workspace:*",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vite-plugin-dts": "^4.5.0",
+    "vitest": "^3.0.0"
+  }
 }

--- a/packages/lifo-pkg-nano/CHANGELOG.md
+++ b/packages/lifo-pkg-nano/CHANGELOG.md
@@ -1,0 +1,8 @@
+# lifo-pkg-nano
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.1

--- a/packages/lifo-pkg-nano/package.json
+++ b/packages/lifo-pkg-nano/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-nano",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "nano text editor",
   "license": "MIT",
   "author": "Sanket Sahu",
@@ -8,13 +8,45 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "exports": { ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } },
-  "files": ["dist"],
-  "publishConfig": { "access": "public" },
-  "lifo": { "commands": { "nano": "./dist/index.js" } },
-  "keywords": ["lifo-pkg", "nano"],
-  "scripts": { "build": "vite build", "test": "vitest run", "test:watch": "vitest" },
-  "peerDependencies": { "@lifo-sh/core": "workspace:*" },
-  "peerDependenciesMeta": { "@lifo-sh/core": { "optional": true } },
-  "devDependencies": { "@lifo-sh/core": "workspace:*", "typescript": "^5.7.0", "vite": "^6.0.0", "vite-plugin-dts": "^4.5.0", "vitest": "^3.0.0" }
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "lifo": {
+    "commands": {
+      "nano": "./dist/index.js"
+    }
+  },
+  "keywords": [
+    "lifo-pkg",
+    "nano"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@lifo-sh/core": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@lifo-sh/core": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@lifo-sh/core": "workspace:*",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vite-plugin-dts": "^4.5.0",
+    "vitest": "^3.0.0"
+  }
 }

--- a/packages/lifo-pkg-vi/CHANGELOG.md
+++ b/packages/lifo-pkg-vi/CHANGELOG.md
@@ -1,0 +1,8 @@
+# lifo-pkg-vi
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.1

--- a/packages/lifo-pkg-vi/package.json
+++ b/packages/lifo-pkg-vi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-vi",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "vi/vim modal editor",
   "license": "MIT",
   "author": "Sanket Sahu",
@@ -8,13 +8,46 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "exports": { ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } },
-  "files": ["dist"],
-  "publishConfig": { "access": "public" },
-  "lifo": { "commands": { "vi": "./dist/index.js", "vim": "./dist/index.js" } },
-  "keywords": ["lifo-pkg", "vi"],
-  "scripts": { "build": "vite build", "test": "vitest run", "test:watch": "vitest" },
-  "peerDependencies": { "@lifo-sh/core": "workspace:*" },
-  "peerDependenciesMeta": { "@lifo-sh/core": { "optional": true } },
-  "devDependencies": { "@lifo-sh/core": "workspace:*", "typescript": "^5.7.0", "vite": "^6.0.0", "vite-plugin-dts": "^4.5.0", "vitest": "^3.0.0" }
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "lifo": {
+    "commands": {
+      "vi": "./dist/index.js",
+      "vim": "./dist/index.js"
+    }
+  },
+  "keywords": [
+    "lifo-pkg",
+    "vi"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@lifo-sh/core": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@lifo-sh/core": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@lifo-sh/core": "workspace:*",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vite-plugin-dts": "^4.5.0",
+    "vitest": "^3.0.0"
+  }
 }

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @lifo-sh/ui
 
+## 0.6.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.1
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/ui",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Embeddable UI components for Lifo — terminal, preview browser, and file explorer",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Publish `@lifo-sh/core@0.6.1` (patch: ESM masker desync fix)
- Bump all linked packages via changesets
- Externalize all runtime deps in core `vite.config.ts` to fix build failures

## Test plan
- [x] `@lifo-sh/core@0.6.1` published to npm
- [ ] Verify downstream consumers can install and use the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)