### PR TITLE
chore: release @lifo-sh/core@0.6.2

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/core",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "Linux-like OS engine for JavaScript -- kernel, shell, VFS, and 60+ commands",
   "license": "MIT",
   "repository": {

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -1,5 +1,12 @@
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
+import pkg from './package.json' with { type: 'json' };
+
+const external = [
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.peerDependencies ?? {}),
+  ...Object.keys(pkg.optionalDependencies ?? {}),
+];
 
 export default defineConfig({
   plugins: [
@@ -12,9 +19,7 @@ export default defineConfig({
       fileName: 'index',
     },
     rollupOptions: {
-      external: [
-        '@lifo-sh/ui',
-      ],
+      external,
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- Bump `@lifo-sh/core` version to `0.6.2` (already published to npm)
- Restore auto-externalization of dependencies in `vite.config.ts` — was accidentally hardcoded to only `@lifo-sh/ui`, breaking builds when `acorn`, `ws`, or `esbuild` weren't externalized

## Test plan
- [x] `pnpm --filter @lifo-sh/core build` passes
- [x] Published to npm as `@lifo-sh/core@0.6.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)