### PR TITLE
chore: release @lifo-sh/core@0.6.3, @lifo-sh/ui@0.6.1, lifo-sh@0.6.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-sh",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Run Lifo (a Linux-like OS) in your terminal -- npx lifo-sh",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/core",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Linux-like OS engine for JavaScript -- kernel, shell, VFS, and 60+ commands",
   "license": "MIT",
   "repository": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/ui",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Embeddable UI components for Lifo — terminal, preview browser, and file explorer",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump `@lifo-sh/core` from 0.6.2 → 0.6.3
- Bump `@lifo-sh/ui` from 0.6.0 → 0.6.1
- Bump `lifo-sh` from 0.6.0 → 0.6.1

## Test plan
- [ ] Build all packages (`pnpm build`)
- [ ] Publish to npm (`pnpm release`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)