### PR TITLE
chore: release @lifo-sh/core@0.6.4, @lifo-sh/ui@0.6.4

### DIFF
--- a/apps/api-server/CHANGELOG.md
+++ b/apps/api-server/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @lifo-sh/api-server
+
+## 0.1.1
+
+### Patch Changes
+
+- lifo-sh@0.6.4

--- a/apps/api-server/package.json
+++ b/apps/api-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/api-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @lifo-sh/desktop
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.4
+  - @lifo-sh/ui@0.6.4

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/desktop",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # lifo-sh
 
+## 0.6.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.4
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-sh",
-  "version": "0.6.1",
+  "version": "0.6.4",
   "description": "Run Lifo (a Linux-like OS) in your terminal -- npx lifo-sh",
   "license": "MIT",
   "repository": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @lifo-sh/core
 
+## 0.6.4
+
+### Patch Changes
+
+- Bug fixes and improvements
+- Updated dependencies
+  - @lifo-sh/ui@0.6.4
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/core",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Linux-like OS engine for JavaScript -- kernel, shell, VFS, and 60+ commands",
   "license": "MIT",
   "repository": {

--- a/packages/lifo-pkg-bc/CHANGELOG.md
+++ b/packages/lifo-pkg-bc/CHANGELOG.md
@@ -1,0 +1,8 @@
+# lifo-pkg-bc
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.4

--- a/packages/lifo-pkg-bc/package.json
+++ b/packages/lifo-pkg-bc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-bc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "bc calculator",
   "license": "MIT",
   "author": "Sanket Sahu",
@@ -8,13 +8,45 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "exports": { ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } },
-  "files": ["dist"],
-  "publishConfig": { "access": "public" },
-  "lifo": { "commands": { "bc": "./dist/index.js" } },
-  "keywords": ["lifo-pkg", "bc"],
-  "scripts": { "build": "vite build", "test": "vitest run", "test:watch": "vitest" },
-  "peerDependencies": { "@lifo-sh/core": "workspace:*" },
-  "peerDependenciesMeta": { "@lifo-sh/core": { "optional": true } },
-  "devDependencies": { "@lifo-sh/core": "workspace:*", "typescript": "^5.7.0", "vite": "^6.0.0", "vite-plugin-dts": "^4.5.0", "vitest": "^3.0.0" }
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "lifo": {
+    "commands": {
+      "bc": "./dist/index.js"
+    }
+  },
+  "keywords": [
+    "lifo-pkg",
+    "bc"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@lifo-sh/core": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@lifo-sh/core": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@lifo-sh/core": "workspace:*",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vite-plugin-dts": "^4.5.0",
+    "vitest": "^3.0.0"
+  }
 }

--- a/packages/lifo-pkg-cal/CHANGELOG.md
+++ b/packages/lifo-pkg-cal/CHANGELOG.md
@@ -1,0 +1,8 @@
+# lifo-pkg-cal
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.4

--- a/packages/lifo-pkg-cal/package.json
+++ b/packages/lifo-pkg-cal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-cal",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "cal calendar",
   "license": "MIT",
   "author": "Sanket Sahu",
@@ -8,13 +8,45 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "exports": { ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } },
-  "files": ["dist"],
-  "publishConfig": { "access": "public" },
-  "lifo": { "commands": { "cal": "./dist/index.js" } },
-  "keywords": ["lifo-pkg", "cal"],
-  "scripts": { "build": "vite build", "test": "vitest run", "test:watch": "vitest" },
-  "peerDependencies": { "@lifo-sh/core": "workspace:*" },
-  "peerDependenciesMeta": { "@lifo-sh/core": { "optional": true } },
-  "devDependencies": { "@lifo-sh/core": "workspace:*", "typescript": "^5.7.0", "vite": "^6.0.0", "vite-plugin-dts": "^4.5.0", "vitest": "^3.0.0" }
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "lifo": {
+    "commands": {
+      "cal": "./dist/index.js"
+    }
+  },
+  "keywords": [
+    "lifo-pkg",
+    "cal"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@lifo-sh/core": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@lifo-sh/core": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@lifo-sh/core": "workspace:*",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vite-plugin-dts": "^4.5.0",
+    "vitest": "^3.0.0"
+  }
 }

--- a/packages/lifo-pkg-fastfetch/CHANGELOG.md
+++ b/packages/lifo-pkg-fastfetch/CHANGELOG.md
@@ -1,0 +1,8 @@
+# lifo-pkg-fastfetch
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.4

--- a/packages/lifo-pkg-fastfetch/package.json
+++ b/packages/lifo-pkg-fastfetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-fastfetch",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "fastfetch / neofetch system-info command for Lifo",
   "license": "MIT",
   "author": "Sanket Sahu",

--- a/packages/lifo-pkg-ffmpeg/CHANGELOG.md
+++ b/packages/lifo-pkg-ffmpeg/CHANGELOG.md
@@ -1,8 +1,14 @@
 # lifo-pkg-ffmpeg
 
+## 0.6.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.4
+
 ## 0.6.0
 
 ### Minor Changes
 
 - Version alignment with `@lifo-sh/core` 0.6.0.
-

--- a/packages/lifo-pkg-ffmpeg/package.json
+++ b/packages/lifo-pkg-ffmpeg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-ffmpeg",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "FFmpeg command for Lifo, powered by ffmpeg.wasm",
   "license": "MIT",
   "author": "Sanket Sahu",

--- a/packages/lifo-pkg-git/CHANGELOG.md
+++ b/packages/lifo-pkg-git/CHANGELOG.md
@@ -1,8 +1,14 @@
 # lifo-pkg-git
 
+## 0.6.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.4
+
 ## 0.6.0
 
 ### Minor Changes
 
 - Version alignment with `@lifo-sh/core` 0.6.0.
-

--- a/packages/lifo-pkg-git/package.json
+++ b/packages/lifo-pkg-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-git",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Git command for Lifo, powered by isomorphic-git",
   "license": "MIT",
   "author": "Sanket Sahu",

--- a/packages/lifo-pkg-less/CHANGELOG.md
+++ b/packages/lifo-pkg-less/CHANGELOG.md
@@ -1,0 +1,8 @@
+# lifo-pkg-less
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.4

--- a/packages/lifo-pkg-less/package.json
+++ b/packages/lifo-pkg-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-less",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "less pager",
   "license": "MIT",
   "author": "Sanket Sahu",
@@ -8,13 +8,45 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "exports": { ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } },
-  "files": ["dist"],
-  "publishConfig": { "access": "public" },
-  "lifo": { "commands": { "less": "./dist/index.js" } },
-  "keywords": ["lifo-pkg", "less"],
-  "scripts": { "build": "vite build", "test": "vitest run", "test:watch": "vitest" },
-  "peerDependencies": { "@lifo-sh/core": "workspace:*" },
-  "peerDependenciesMeta": { "@lifo-sh/core": { "optional": true } },
-  "devDependencies": { "@lifo-sh/core": "workspace:*", "typescript": "^5.7.0", "vite": "^6.0.0", "vite-plugin-dts": "^4.5.0", "vitest": "^3.0.0" }
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "lifo": {
+    "commands": {
+      "less": "./dist/index.js"
+    }
+  },
+  "keywords": [
+    "lifo-pkg",
+    "less"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@lifo-sh/core": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@lifo-sh/core": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@lifo-sh/core": "workspace:*",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vite-plugin-dts": "^4.5.0",
+    "vitest": "^3.0.0"
+  }
 }

--- a/packages/lifo-pkg-man/CHANGELOG.md
+++ b/packages/lifo-pkg-man/CHANGELOG.md
@@ -1,0 +1,8 @@
+# lifo-pkg-man
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.4

--- a/packages/lifo-pkg-man/package.json
+++ b/packages/lifo-pkg-man/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-man",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "man manual pages",
   "license": "MIT",
   "author": "Sanket Sahu",
@@ -8,13 +8,45 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "exports": { ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } },
-  "files": ["dist"],
-  "publishConfig": { "access": "public" },
-  "lifo": { "commands": { "man": "./dist/index.js" } },
-  "keywords": ["lifo-pkg", "man"],
-  "scripts": { "build": "vite build", "test": "vitest run", "test:watch": "vitest" },
-  "peerDependencies": { "@lifo-sh/core": "workspace:*" },
-  "peerDependenciesMeta": { "@lifo-sh/core": { "optional": true } },
-  "devDependencies": { "@lifo-sh/core": "workspace:*", "typescript": "^5.7.0", "vite": "^6.0.0", "vite-plugin-dts": "^4.5.0", "vitest": "^3.0.0" }
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "lifo": {
+    "commands": {
+      "man": "./dist/index.js"
+    }
+  },
+  "keywords": [
+    "lifo-pkg",
+    "man"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@lifo-sh/core": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@lifo-sh/core": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@lifo-sh/core": "workspace:*",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vite-plugin-dts": "^4.5.0",
+    "vitest": "^3.0.0"
+  }
 }

--- a/packages/lifo-pkg-nano/CHANGELOG.md
+++ b/packages/lifo-pkg-nano/CHANGELOG.md
@@ -1,0 +1,8 @@
+# lifo-pkg-nano
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.4

--- a/packages/lifo-pkg-nano/package.json
+++ b/packages/lifo-pkg-nano/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-nano",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "nano text editor",
   "license": "MIT",
   "author": "Sanket Sahu",
@@ -8,13 +8,45 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "exports": { ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } },
-  "files": ["dist"],
-  "publishConfig": { "access": "public" },
-  "lifo": { "commands": { "nano": "./dist/index.js" } },
-  "keywords": ["lifo-pkg", "nano"],
-  "scripts": { "build": "vite build", "test": "vitest run", "test:watch": "vitest" },
-  "peerDependencies": { "@lifo-sh/core": "workspace:*" },
-  "peerDependenciesMeta": { "@lifo-sh/core": { "optional": true } },
-  "devDependencies": { "@lifo-sh/core": "workspace:*", "typescript": "^5.7.0", "vite": "^6.0.0", "vite-plugin-dts": "^4.5.0", "vitest": "^3.0.0" }
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "lifo": {
+    "commands": {
+      "nano": "./dist/index.js"
+    }
+  },
+  "keywords": [
+    "lifo-pkg",
+    "nano"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@lifo-sh/core": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@lifo-sh/core": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@lifo-sh/core": "workspace:*",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vite-plugin-dts": "^4.5.0",
+    "vitest": "^3.0.0"
+  }
 }

--- a/packages/lifo-pkg-vi/CHANGELOG.md
+++ b/packages/lifo-pkg-vi/CHANGELOG.md
@@ -1,0 +1,8 @@
+# lifo-pkg-vi
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.4

--- a/packages/lifo-pkg-vi/package.json
+++ b/packages/lifo-pkg-vi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-vi",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "vi/vim modal editor",
   "license": "MIT",
   "author": "Sanket Sahu",
@@ -8,13 +8,46 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "exports": { ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } },
-  "files": ["dist"],
-  "publishConfig": { "access": "public" },
-  "lifo": { "commands": { "vi": "./dist/index.js", "vim": "./dist/index.js" } },
-  "keywords": ["lifo-pkg", "vi"],
-  "scripts": { "build": "vite build", "test": "vitest run", "test:watch": "vitest" },
-  "peerDependencies": { "@lifo-sh/core": "workspace:*" },
-  "peerDependenciesMeta": { "@lifo-sh/core": { "optional": true } },
-  "devDependencies": { "@lifo-sh/core": "workspace:*", "typescript": "^5.7.0", "vite": "^6.0.0", "vite-plugin-dts": "^4.5.0", "vitest": "^3.0.0" }
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "lifo": {
+    "commands": {
+      "vi": "./dist/index.js",
+      "vim": "./dist/index.js"
+    }
+  },
+  "keywords": [
+    "lifo-pkg",
+    "vi"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@lifo-sh/core": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@lifo-sh/core": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@lifo-sh/core": "workspace:*",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vite-plugin-dts": "^4.5.0",
+    "vitest": "^3.0.0"
+  }
 }

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @lifo-sh/ui
 
+## 0.6.4
+
+### Patch Changes
+
+- Bug fixes and improvements
+- Updated dependencies
+  - @lifo-sh/core@0.6.4
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/ui",
-  "version": "0.6.1",
+  "version": "0.6.4",
   "description": "Embeddable UI components for Lifo — terminal, preview browser, and file explorer",
   "license": "MIT",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,8 +403,8 @@ importers:
   packages/ui:
     dependencies:
       '@lifo-sh/core':
-        specifier: workspace:*
-        version: link:../core
+        specifier: '>=0.6.0'
+        version: 0.6.2
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -1215,6 +1215,14 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lifo-sh/core@0.6.2':
+    resolution: {integrity: sha512-6RTYSdvuElfrsGNBvGbTXhhqtwW7TeVVlahWY0ER04yEvO6hlG/g+L+BaLVKveD0djtdx93xfl2XnFQ48ncl8Q==}
+    peerDependencies:
+      '@lifo-sh/ui': 0.6.0
+    peerDependenciesMeta:
+      '@lifo-sh/ui':
+        optional: true
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -5293,6 +5301,17 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lifo-sh/core@0.6.2':
+    dependencies:
+      acorn: 8.17.0
+      browser-metro: 1.0.31
+      ws: 8.19.0
+    optionalDependencies:
+      esbuild: 0.28.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@manypkg/find-root@1.1.0':
     dependencies:


### PR DESCRIPTION
## Summary
- Bumped `@lifo-sh/core` from `0.6.3` → `0.6.4`
- Bumped `@lifo-sh/ui` from `0.6.1` → `0.6.4`
- Bumped `lifo-sh` from `0.6.1` → `0.6.4`
- Bug fixes and improvements

## Published
- ✅ `@lifo-sh/core@0.6.4`
- ✅ `@lifo-sh/ui@0.6.4`
- ❌ `lifo-sh@0.6.4` (403 permission error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)