### PR TITLE
fix: prevent webpack from resolving node:module in bundled output

### DIFF
--- a/apps/api-server/CHANGELOG.md
+++ b/apps/api-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lifo-sh/api-server
 
+## 0.1.2
+
+### Patch Changes
+
+- lifo-sh@0.6.5
+
 ## 0.1.1
 
 ### Patch Changes

--- a/apps/api-server/package.json
+++ b/apps/api-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/api-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @lifo-sh/desktop
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.5
+
 ## 0.0.1
 
 ### Patch Changes

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/desktop",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # lifo-sh
 
+## 0.6.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.5
+
 ## 0.6.4
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-sh",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Run Lifo (a Linux-like OS) in your terminal -- npx lifo-sh",
   "license": "MIT",
   "repository": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lifo-sh/core
 
+## 0.6.5
+
+### Patch Changes
+
+- Fix webpack build error caused by static `node:module` import in bundled output
+
 ## 0.6.4
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/core",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Linux-like OS engine for JavaScript -- kernel, shell, VFS, and 60+ commands",
   "license": "MIT",
   "repository": {

--- a/packages/core/src/pkg/lifo-runtime.ts
+++ b/packages/core/src/pkg/lifo-runtime.ts
@@ -177,9 +177,13 @@ async function ensureHttpsLoader(): Promise<void> {
 
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const modId = 'node:' + 'module'; // prevent static analysis
+    const nodeModuleSpec = ['node', 'module'].join(':');
     const nodeModule: { register?: (specifier: string) => void } =
-      await import(/* @vite-ignore */ /* webpackIgnore: true */ modId);
+      await import(
+        /* @vite-ignore */
+        /* webpackIgnore: true */
+        nodeModuleSpec
+      );
     if (typeof nodeModule.register !== 'function') {
       // Node.js < 20.6 -- module.register() not available
       return;

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -6,6 +6,7 @@ const external = [
   ...Object.keys(pkg.dependencies ?? {}),
   ...Object.keys(pkg.peerDependencies ?? {}),
   ...Object.keys(pkg.optionalDependencies ?? {}),
+  /^node:/,
 ];
 
 export default defineConfig({

--- a/packages/lifo-pkg-bc/CHANGELOG.md
+++ b/packages/lifo-pkg-bc/CHANGELOG.md
@@ -1,5 +1,12 @@
 # lifo-pkg-bc
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.5
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/lifo-pkg-bc/package.json
+++ b/packages/lifo-pkg-bc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-bc",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "bc calculator",
   "license": "MIT",
   "author": "Sanket Sahu",

--- a/packages/lifo-pkg-cal/CHANGELOG.md
+++ b/packages/lifo-pkg-cal/CHANGELOG.md
@@ -1,5 +1,12 @@
 # lifo-pkg-cal
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.5
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/lifo-pkg-cal/package.json
+++ b/packages/lifo-pkg-cal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-cal",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "cal calendar",
   "license": "MIT",
   "author": "Sanket Sahu",

--- a/packages/lifo-pkg-fastfetch/CHANGELOG.md
+++ b/packages/lifo-pkg-fastfetch/CHANGELOG.md
@@ -1,5 +1,12 @@
 # lifo-pkg-fastfetch
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.5
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/lifo-pkg-fastfetch/package.json
+++ b/packages/lifo-pkg-fastfetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-fastfetch",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "fastfetch / neofetch system-info command for Lifo",
   "license": "MIT",
   "author": "Sanket Sahu",

--- a/packages/lifo-pkg-ffmpeg/CHANGELOG.md
+++ b/packages/lifo-pkg-ffmpeg/CHANGELOG.md
@@ -1,5 +1,12 @@
 # lifo-pkg-ffmpeg
 
+## 0.6.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.5
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/lifo-pkg-ffmpeg/package.json
+++ b/packages/lifo-pkg-ffmpeg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-ffmpeg",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "FFmpeg command for Lifo, powered by ffmpeg.wasm",
   "license": "MIT",
   "author": "Sanket Sahu",

--- a/packages/lifo-pkg-git/CHANGELOG.md
+++ b/packages/lifo-pkg-git/CHANGELOG.md
@@ -1,5 +1,12 @@
 # lifo-pkg-git
 
+## 0.6.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.5
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/lifo-pkg-git/package.json
+++ b/packages/lifo-pkg-git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-git",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Git command for Lifo, powered by isomorphic-git",
   "license": "MIT",
   "author": "Sanket Sahu",

--- a/packages/lifo-pkg-less/CHANGELOG.md
+++ b/packages/lifo-pkg-less/CHANGELOG.md
@@ -1,5 +1,12 @@
 # lifo-pkg-less
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.5
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/lifo-pkg-less/package.json
+++ b/packages/lifo-pkg-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-less",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "less pager",
   "license": "MIT",
   "author": "Sanket Sahu",

--- a/packages/lifo-pkg-man/CHANGELOG.md
+++ b/packages/lifo-pkg-man/CHANGELOG.md
@@ -1,5 +1,12 @@
 # lifo-pkg-man
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.5
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/lifo-pkg-man/package.json
+++ b/packages/lifo-pkg-man/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-man",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "man manual pages",
   "license": "MIT",
   "author": "Sanket Sahu",

--- a/packages/lifo-pkg-nano/CHANGELOG.md
+++ b/packages/lifo-pkg-nano/CHANGELOG.md
@@ -1,5 +1,12 @@
 # lifo-pkg-nano
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.5
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/lifo-pkg-nano/package.json
+++ b/packages/lifo-pkg-nano/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-nano",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "nano text editor",
   "license": "MIT",
   "author": "Sanket Sahu",

--- a/packages/lifo-pkg-vi/CHANGELOG.md
+++ b/packages/lifo-pkg-vi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # lifo-pkg-vi
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.6.5
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/lifo-pkg-vi/package.json
+++ b/packages/lifo-pkg-vi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-pkg-vi",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "vi/vim modal editor",
   "license": "MIT",
   "author": "Sanket Sahu",


### PR DESCRIPTION
Vite constant-folds string concatenation ('node:' + 'module') into a literal "node:module" import and strips webpackIgnore comments during minification. Use Array.join() instead which Vite cannot constant-fold, keeping the import dynamic so webpack skips resolution.

Also externalize node: builtins in vite config.