### PR TITLE
fix(grep): support long options; --include / --exclude / --exclude-dir

### DIFF
--- a/.changeset/grep-long-options.md
+++ b/.changeset/grep-long-options.md
@@ -1,0 +1,23 @@
+---
+"@lifo-sh/core": patch
+---
+
+grep: support long options, and stop treating them as filenames
+
+`--include`, `--exclude` and `--exclude-dir` are now implemented, along with long
+aliases for the existing short flags (`--ignore-case`, `--line-number`,
+`--recursive`, `--invert-match`, `--files-with-matches`, `--count`,
+`--word-regexp`, `--extended-regexp`) and `-R`.
+
+Previously the parser only recognised single-dash flags, so `grep -rn
+--include="*.ts" foo src` treated `--include=*.ts` as a file operand: it printed
+"no such file or directory" to stderr, searched every file anyway, and still
+exited 0. An unrecognised long option now exits 2 with a message rather than
+quietly searching the wrong set.
+
+Also fixes `--` handling. It ended option parsing before the pattern was read, so
+`grep -- pattern file` failed with "missing pattern" and pushed the pattern into
+the file list.
+
+`--exclude-dir` prunes during the directory walk rather than filtering afterwards,
+so excluding `node_modules` avoids reading it.

--- a/packages/core/src/commands/text/grep.ts
+++ b/packages/core/src/commands/text/grep.ts
@@ -3,6 +3,35 @@ import { resolve } from '../../utils/path.js';
 import { VFSError } from '../../kernel/vfs/index.js';
 import { getMimeType, isBinaryMime } from '../../utils/mime.js';
 
+/**
+ * Shell-style glob to RegExp, for --include / --exclude / --exclude-dir.
+ *
+ * Only the subset those options actually use: `*`, `?`, and character classes. A pattern without a
+ * slash matches the BASENAME, which is what `--include="*.ts"` means.
+ */
+function globToRegExp(glob: string): RegExp {
+  let out = '';
+  for (let i = 0; i < glob.length; i++) {
+    const ch = glob[i];
+    if (ch === '*') out += '[^/]*';
+    else if (ch === '?') out += '[^/]';
+    else if (ch === '[') {
+      const end = glob.indexOf(']', i + 1);
+      if (end === -1) out += '\\[';
+      else {
+        out += glob.slice(i, end + 1);
+        i = end;
+      }
+    } else out += ch.replace(/[.+^${}()|\\]/g, '\\$&');
+  }
+  return new RegExp(`^${out}$`);
+}
+
+function basename(path: string): string {
+  const idx = path.lastIndexOf('/');
+  return idx === -1 ? path : path.slice(idx + 1);
+}
+
 const command: Command = async (ctx) => {
   const args = ctx.args;
   let ignoreCase = false;
@@ -14,11 +43,70 @@ const command: Command = async (ctx) => {
   let wordMatch = false;
   let pattern = '';
   const files: string[] = [];
+  const includeGlobs: RegExp[] = [];
+  const excludeGlobs: RegExp[] = [];
+  const excludeDirGlobs: RegExp[] = [];
 
   let i = 0;
   while (i < args.length) {
     const arg = args[i];
-    if (arg === '--') { i++; break; }
+    if (arg === '--') {
+      // End of options. The pattern may still be ahead of us: `grep -- -pattern file` is the whole
+      // point of `--`. Breaking straight out left `pattern` empty and every remaining argument —
+      // including the pattern itself — was pushed into `files`, so the command failed with
+      // "missing pattern".
+      i++;
+      if (!pattern && i < args.length) {
+        pattern = args[i++];
+      }
+      break;
+    }
+
+    // Long options. Previously these fell through to the file loop, so `--include=*.ts` was treated
+    // as a filename: grep printed "no such file or directory" to stderr and still exited 0 because
+    // other files matched. Silently searching the wrong set is worse than refusing.
+    if (arg.startsWith('--')) {
+      const eq = arg.indexOf('=');
+      const name = eq === -1 ? arg.slice(2) : arg.slice(2, eq);
+      const inlineValue = eq === -1 ? undefined : arg.slice(eq + 1);
+      const takeValue = (): string | undefined => {
+        if (inlineValue !== undefined) return inlineValue;
+        // GNU also accepts `--include GLOB`.
+        return args[++i];
+      };
+
+      switch (name) {
+        case 'include': {
+          const value = takeValue();
+          if (value) includeGlobs.push(globToRegExp(value));
+          break;
+        }
+        case 'exclude': {
+          const value = takeValue();
+          if (value) excludeGlobs.push(globToRegExp(value));
+          break;
+        }
+        case 'exclude-dir': {
+          const value = takeValue();
+          if (value) excludeDirGlobs.push(globToRegExp(value.replace(/\/$/, '')));
+          break;
+        }
+        case 'ignore-case': ignoreCase = true; break;
+        case 'invert-match': invert = true; break;
+        case 'line-number': lineNumbers = true; break;
+        case 'count': countOnly = true; break;
+        case 'files-with-matches': filesWithMatches = true; break;
+        case 'recursive': recursive = true; break;
+        case 'word-regexp': wordMatch = true; break;
+        case 'extended-regexp': break; // JS regex is already ERE
+        default:
+          ctx.stderr.write(`grep: unrecognized option '${arg}'\n`);
+          return 2;
+      }
+      i++;
+      continue;
+    }
+
     if (arg.startsWith('-') && arg.length > 1 && arg[1] !== '-') {
       for (let j = 1; j < arg.length; j++) {
         switch (arg[j]) {
@@ -28,6 +116,7 @@ const command: Command = async (ctx) => {
           case 'c': countOnly = true; break;
           case 'l': filesWithMatches = true; break;
           case 'r': recursive = true; break;
+          case 'R': recursive = true; break;
           case 'E': break; // JS regex is already ERE
           case 'w': wordMatch = true; break;
         }
@@ -65,6 +154,14 @@ const command: Command = async (ctx) => {
 
   let matched = false;
   const multiFile = files.length > 1 || recursive;
+
+  /** --include / --exclude, matched against the basename as GNU grep does. */
+  function fileIsSearchable(path: string): boolean {
+    const name = basename(path);
+    if (excludeGlobs.some((re) => re.test(name))) return false;
+    if (includeGlobs.length && !includeGlobs.some((re) => re.test(name))) return false;
+    return true;
+  }
 
   async function grepLines(lines: string[], fileName: string | null): Promise<void> {
     let count = 0;
@@ -104,6 +201,9 @@ const command: Command = async (ctx) => {
         if (entry.type === 'file') {
           result.push(fullPath);
         } else if (entry.type === 'directory') {
+          // Pruned during the walk, not filtered afterwards: --exclude-dir exists to avoid
+          // descending into node_modules, and filtering later would still read every file in it.
+          if (excludeDirGlobs.some((re) => re.test(entry.name))) continue;
           result.push(...walkDir(fullPath));
         }
       }
@@ -132,6 +232,9 @@ const command: Command = async (ctx) => {
             const dirFiles = walkDir(path);
             for (const f of dirFiles) {
               try {
+                if (!fileIsSearchable(f)) {
+                  continue;
+                }
                 if (isBinaryMime(getMimeType(f))) {
                   continue;
                 }
@@ -145,6 +248,9 @@ const command: Command = async (ctx) => {
           } else {
             ctx.stderr.write(`grep: ${file}: Is a directory\n`);
           }
+          continue;
+        }
+        if (!fileIsSearchable(path)) {
           continue;
         }
         if (isBinaryMime(getMimeType(path))) {

--- a/packages/core/tests/commands/grep-options.test.ts
+++ b/packages/core/tests/commands/grep-options.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { VFS } from '../../src/kernel/vfs/index.js';
+import type { CommandContext, CommandOutputStream } from '../../src/commands/types.js';
+import grep from '../../src/commands/text/grep.js';
+
+function createContext(
+  vfs: VFS,
+  args: string[],
+  cwd = '/project'
+): CommandContext & { stdout: CommandOutputStream & { text: string }; stderr: CommandOutputStream & { text: string } } {
+  const stdout = { text: '', write(t: string) { this.text += t; } };
+  const stderr = { text: '', write(t: string) { this.text += t; } };
+  return {
+    args,
+    env: { HOME: '/home/user', USER: 'user' },
+    cwd,
+    vfs,
+    stdout,
+    stderr,
+    signal: new AbortController().signal,
+  } as any;
+}
+
+async function run(vfs: VFS, args: string[]) {
+  const ctx = createContext(vfs, args);
+  const code = await grep(ctx);
+  return { code, stdout: ctx.stdout.text, stderr: ctx.stderr.text };
+}
+
+describe('grep long options', () => {
+  let vfs: VFS;
+
+  beforeEach(() => {
+    vfs = new VFS();
+    vfs.mkdir('/project', { recursive: true });
+    vfs.mkdir('/project/src', { recursive: true });
+    vfs.mkdir('/project/node_modules/dep', { recursive: true });
+    vfs.writeFile('/project/src/a.ts', 'const needle = 1;\n');
+    vfs.writeFile('/project/src/b.tsx', 'const needle = 2;\n');
+    vfs.writeFile('/project/src/c.md', 'needle in prose\n');
+    vfs.writeFile('/project/node_modules/dep/index.js', 'needle in a dependency\n');
+  });
+
+  describe('--include', () => {
+    it('restricts the search to matching basenames', async () => {
+      const { code, stdout } = await run(vfs, ['-rn', '--include=*.ts', 'needle', 'src']);
+      expect(code).toBe(0);
+      expect(stdout).toContain('a.ts');
+      expect(stdout).not.toContain('b.tsx');
+      expect(stdout).not.toContain('c.md');
+    });
+
+    it('accepts a separate argument as well as --include=GLOB', async () => {
+      const { stdout } = await run(vfs, ['-rl', '--include', '*.tsx', 'needle', 'src']);
+      expect(stdout.trim()).toBe('/project/src/b.tsx');
+    });
+
+    it('unions multiple --include globs', async () => {
+      const { stdout } = await run(vfs, ['-rl', '--include=*.ts', '--include=*.tsx', 'needle', 'src']);
+      expect(stdout).toContain('a.ts');
+      expect(stdout).toContain('b.tsx');
+      expect(stdout).not.toContain('c.md');
+    });
+
+    // The bug this file exists for: the option was parsed as a file operand, so grep reported
+    // "no such file or directory" on stderr, searched everything anyway, and still exited 0.
+    it('is not treated as a file operand', async () => {
+      const { stderr } = await run(vfs, ['-rn', '--include=*.ts', 'needle', 'src']);
+      expect(stderr).toBe('');
+    });
+  });
+
+  describe('--exclude and --exclude-dir', () => {
+    it('--exclude drops matching basenames', async () => {
+      const { stdout } = await run(vfs, ['-rl', '--exclude=*.md', 'needle', 'src']);
+      expect(stdout).not.toContain('c.md');
+      expect(stdout).toContain('a.ts');
+    });
+
+    it('--exclude-dir prunes the directory', async () => {
+      const { stdout } = await run(vfs, ['-rl', '--exclude-dir=node_modules', 'needle', '.']);
+      expect(stdout).not.toContain('node_modules');
+      expect(stdout).toContain('src/a.ts');
+    });
+
+    it('--exclude-dir tolerates a trailing slash', async () => {
+      const { stdout } = await run(vfs, ['-rl', '--exclude-dir=node_modules/', 'needle', '.']);
+      expect(stdout).not.toContain('node_modules');
+    });
+
+    it('--exclude wins over --include', async () => {
+      const { stdout } = await run(vfs, ['-rl', '--include=*.ts', '--exclude=a.ts', 'needle', 'src']);
+      expect(stdout.trim()).toBe('');
+    });
+  });
+
+  describe('long aliases', () => {
+    it('--ignore-case behaves like -i', async () => {
+      vfs.writeFile('/project/src/upper.ts', 'NEEDLE\n');
+      const { stdout } = await run(vfs, ['-rl', '--ignore-case', 'needle', 'src']);
+      expect(stdout).toContain('upper.ts');
+    });
+
+    it('--line-number behaves like -n', async () => {
+      const { stdout } = await run(vfs, ['--line-number', 'needle', 'src/a.ts']);
+      expect(stdout.trim()).toBe('1:const needle = 1;');
+    });
+
+    it('--recursive behaves like -r', async () => {
+      const { code } = await run(vfs, ['--recursive', '--files-with-matches', 'needle', 'src']);
+      expect(code).toBe(0);
+    });
+
+    it('-R is accepted as -r', async () => {
+      const { stdout } = await run(vfs, ['-Rl', 'needle', 'src']);
+      expect(stdout).toContain('a.ts');
+    });
+  });
+
+  describe('unknown options', () => {
+    // Failing loudly beats searching the wrong file set and reporting success.
+    it('exits 2 with a message', async () => {
+      const { code, stderr } = await run(vfs, ['-rn', '--no-such-option', 'needle', 'src']);
+      expect(code).toBe(2);
+      expect(stderr).toContain("unrecognized option '--no-such-option'");
+    });
+  });
+
+  describe('unchanged behaviour', () => {
+    it('still exits 1 when nothing matches', async () => {
+      const { code, stdout } = await run(vfs, ['-rn', 'absent-pattern', 'src']);
+      expect(code).toBe(1);
+      expect(stdout).toBe('');
+    });
+
+    it('still treats -- as end of options', async () => {
+      vfs.writeFile('/project/src/dash.ts', '--include\n');
+      const { stdout } = await run(vfs, ['--', '--include', 'src/dash.ts']);
+      expect(stdout.trim()).toBe('--include');
+    });
+  });
+});


### PR DESCRIPTION
`grep` only recognised single-dash flags, so any long option fell through to the file-operand loop and was treated as a filename.

```
$ grep -rn --include="*.ts" needle src
grep: --include=*.ts: no such file or directory     ← on stderr
src/a.ts:1:const needle = 1;
src/b.tsx:1:const needle = 2;                       ← searched anyway
src/c.md:1:needle in prose
$ echo $?
0                                                   ← reported success
```

A wrong result reported as success is the worst of the three possible outcomes — worse than not supporting the flag at all, because nothing downstream can tell.

## What this adds

- **`--include` / `--exclude`** — match the basename, as GNU grep does. Both forms accepted: `--include=*.ts` and `--include *.ts`. Multiple `--include`s union; `--exclude` wins over `--include`.
- **`--exclude-dir`** — prunes during the directory walk rather than filtering afterwards, so excluding `node_modules` avoids *reading* it. A trailing slash is tolerated (`--exclude-dir=node_modules/`).
- **Long aliases** for the existing short flags: `--ignore-case`, `--line-number`, `--recursive`, `--invert-match`, `--files-with-matches`, `--count`, `--word-regexp`, `--extended-regexp`. Plus `-R`.
- **Unrecognised long options exit 2** with `grep: unrecognized option '--foo'`, instead of being searched as a path.

Globs are converted with a small `*` / `?` / `[…]` translator — the subset those options actually use — with everything else escaped.

## Also fixes `--`

Found while writing the tests: `--` ended option parsing *before* the pattern was read, so the pattern was pushed into the file list.

```
$ grep -- needle src/a.ts
grep: missing pattern      ← exit 2
```

That's the one case `--` exists for. It now consumes the pattern before breaking.

## Tests

15 new tests in `packages/core/tests/commands/grep-options.test.ts`, following the existing command-test style (real `VFS`, synthetic `CommandContext`). They cover include/exclude/exclude-dir, both argument forms, precedence, long aliases, unknown-option exit code, and two regression guards — that `--include` no longer writes to stderr, and that "no matches" still exits 1.

Suite is otherwise unchanged: **29 pre-existing failures across `tests/commands` and `tests/shell` before and after** this change (`main` is red in those files independently — `system-extra`, `ProcessRegistry`, `shell`, and an OOM in the full run at the default heap size).

## Where this came from

Giving an AI coding agent shell access against a Lifo VFS. It searched with `--include`, got a plausible-looking wrong answer, then retried the same search with different flags twice before giving up — the failure was invisible because the exit code said success.

A changeset is included (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
