### PR TITLE
fix(core): ESM transform crashed on a regex inside a ${…} template expression; release 0.7.1

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -111,6 +111,7 @@ Turn the playground's building blocks into reusable components so anyone can emb
 - [ ] Migrate the playground to consume the packaged components (dogfood).
 - [x] Example: a **Node/Express server with the preview browser** bound to its port — a full backend + live preview in one box, alongside the existing Vite/Expo examples. **← current focus #1**
 - [x] **Supabase (tinbase) fidelity:** both the Supabase (tinbase) and Expo Router + Supabase examples ship a real `supabase/` folder (`config.toml`, `migrations/*.sql`, `seed.sql`) and start the backend with the `npx tinbase --engine pgmem` CLI (like `supabase start`) — no hand-written `server.mjs`, no hard-coded migration. Each has a `README.txt`.
+  - Fixed in 0.7.1: `npx tinbase --engine pgmem` died with `Cannot read properties of undefined (reading 'slice')`. The ESM→CJS masker's `scanBracedExpr` called `isRegexStart` with two arguments against a three-parameter signature, so **any `/` inside a `${…}` template expression threw** — which `pg-mem`, `tinbase/dist/db/pgmem-engine.js` and `schema-diff.js` all contain (`` `${l.replace(/'/g, "''")}` ``), and nothing else in the examples did. Note the thrown error names the *parent* module being executed, not the module whose transform failed; sweeping `transformEsmToCjs` over every file in `node_modules` is what located it. Covered by `tests/commands/esm-transform.test.ts`; verified end-to-end by `bench/test-tinbase-cli.mjs`.
 
 ### 8. Package manager & WASM runtimes — *planned*
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,43 @@
 # lifo-sh
 
+## 0.7.1
+
+### Patch Changes
+
+- node: fix ESM transform crashing on a regex literal inside a `${…}` template expression
+
+  `npx tinbase --engine pgmem` — the backend behind both Supabase examples — died on startup with:
+
+  ```
+  TypeError: [/…/node_modules/tinbase/dist/index.js] Cannot read properties of undefined (reading 'slice')
+  ```
+
+  The ESM→CJS string masker was at fault, not tinbase (which runs fine on the host on both 0.8.1 and
+  0.10.0). `scanBracedExpr` called the three-parameter `isRegexStart(prevChar, prevIdx, src)` with two
+  arguments:
+
+  ```js
+  const kind = isRegexStart(src, i); // src lands in prevChar, i in prevIdx, src is undefined
+  ```
+
+  `prevChar` then held the entire source, so the `/[A-Za-z_$]/` keyword check passed on any file
+  containing a letter and fell through to `src.slice(…)` on `undefined`. Every `/` inside a `${…}`
+  template expression — division or regex — threw.
+
+  Only the pgmem path happened to contain that shape, which is why just that engine broke:
+  `pg-mem/index.js`, `tinbase/dist/db/pgmem-engine.js` and `tinbase/dist/db/schema-diff.js` all build
+  SQL with `` `${l.replace(/'/g, "''")}` ``. A sweep of `transformEsmToCjs` over all 175 files in the
+  example's `node_modules` fails on exactly those three before the fix and none after.
+
+  `scanBracedExpr` now tracks `prevChar`/`prevIdx` the same way `maskStringLiterals` does — comments
+  transparent, a string or regex literal reported as a value — and passes all three arguments.
+
+  **Debugging note for next time:** the error names the _parent_ module being executed, not the module
+  whose transform threw. `tinbase/dist/index.js` was never the problem.
+
+- Updated dependencies
+  - @lifo-sh/core@0.7.1
+
 ## 0.7.0
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-sh",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Run Lifo (a Linux-like OS) in your terminal -- npx lifo-sh",
   "license": "MIT",
   "repository": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,43 @@
 # @lifo-sh/core
 
+## 0.7.1
+
+### Patch Changes
+
+- node: fix ESM transform crashing on a regex literal inside a `${…}` template expression
+
+  `npx tinbase --engine pgmem` — the backend behind both Supabase examples — died on startup with:
+
+  ```
+  TypeError: [/…/node_modules/tinbase/dist/index.js] Cannot read properties of undefined (reading 'slice')
+  ```
+
+  The ESM→CJS string masker was at fault, not tinbase (which runs fine on the host on both 0.8.1 and
+  0.10.0). `scanBracedExpr` called the three-parameter `isRegexStart(prevChar, prevIdx, src)` with two
+  arguments:
+
+  ```js
+  const kind = isRegexStart(src, i); // src lands in prevChar, i in prevIdx, src is undefined
+  ```
+
+  `prevChar` then held the entire source, so the `/[A-Za-z_$]/` keyword check passed on any file
+  containing a letter and fell through to `src.slice(…)` on `undefined`. Every `/` inside a `${…}`
+  template expression — division or regex — threw.
+
+  Only the pgmem path happened to contain that shape, which is why just that engine broke:
+  `pg-mem/index.js`, `tinbase/dist/db/pgmem-engine.js` and `tinbase/dist/db/schema-diff.js` all build
+  SQL with `` `${l.replace(/'/g, "''")}` ``. A sweep of `transformEsmToCjs` over all 175 files in the
+  example's `node_modules` fails on exactly those three before the fix and none after.
+
+  `scanBracedExpr` now tracks `prevChar`/`prevIdx` the same way `maskStringLiterals` does — comments
+  transparent, a string or regex literal reported as a value — and passes all three arguments.
+
+  **Debugging note for next time:** the error names the _parent_ module being executed, not the module
+  whose transform threw. `tinbase/dist/index.js` was never the problem.
+
+- Updated dependencies
+  - @lifo-sh/ui@0.7.1
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Linux-like OS engine for JavaScript -- kernel, shell, VFS, and 60+ commands",
   "license": "MIT",
   "repository": {

--- a/packages/core/src/commands/system/node.ts
+++ b/packages/core/src/commands/system/node.ts
@@ -340,6 +340,11 @@ function scanTemplateLiteral(src: string, i: number): number {
  */
 function scanBracedExpr(src: string, i: number): number {
 	let depth = 1;
+	// Previous significant char, tracked exactly as maskStringLiterals does: the
+	// '${' that opened this expression is an operator-ish context, comments are
+	// transparent, and a string/regex literal is a value → 'x'.
+	let prevChar = '{';
+	let prevIdx = i - 1;
 	while (i < src.length && depth > 0) {
 		const c = src[i];
 		if (c === '/' && i + 1 < src.length && src[i + 1] === '/') {
@@ -353,16 +358,29 @@ function scanBracedExpr(src: string, i: number): number {
 			continue;
 		}
 		if (c === '/') {
-			const kind = isRegexStart(src, i);
+			const kind = isRegexStart(prevChar, prevIdx, src);
 			if (kind) {
 				const end = scanRegexLiteral(src, i);
-				if (kind === 'strong' || isPlausibleRegex(src.slice(i, end))) { i = end; continue; }
+				if (kind === 'strong' || isPlausibleRegex(src.slice(i, end))) {
+					prevChar = 'x'; prevIdx = -1;
+					i = end;
+					continue;
+				}
 			}
 		}
-		if (c === "'" || c === '"') { i = scanQuoteLiteral(src, i); continue; }
-		if (c === '`') { i = scanTemplateLiteral(src, i); continue; }
+		if (c === "'" || c === '"') {
+			i = scanQuoteLiteral(src, i);
+			prevChar = 'x'; prevIdx = -1;
+			continue;
+		}
+		if (c === '`') {
+			i = scanTemplateLiteral(src, i);
+			prevChar = 'x'; prevIdx = -1;
+			continue;
+		}
 		if (c === '{') depth++;
 		else if (c === '}') depth--;
+		if (c !== ' ' && c !== '\t' && c !== '\n' && c !== '\r') { prevChar = c; prevIdx = i; }
 		i++;
 	}
 	return i;

--- a/packages/core/tests/commands/esm-transform.test.ts
+++ b/packages/core/tests/commands/esm-transform.test.ts
@@ -58,4 +58,31 @@ describe('transformEsmToCjs', () => {
     expect(out).toContain('require("w")');
     expect(noEsmSyntax(out)).toBe(true);
   });
+
+  // A regex literal inside a ${...} expression used to throw
+  // "Cannot read properties of undefined (reading 'slice')" — scanBracedExpr
+  // called isRegexStart() with the wrong arguments. This is the exact shape in
+  // tinbase's pgmem engine and pg-mem, so `npx tinbase --engine pgmem` died.
+  it('handles a regex literal inside a ${...} template expression', () => {
+    const src = [
+      'export function q(labels) {',
+      "  return `enum (${labels.map((l) => `'${l.replace(/'/g, \"''\")}'`).join(', ')})`;",
+      '}',
+      'import x from "y";',
+    ].join('\n');
+    const out = transformEsmToCjs(src);
+    expect(out).toContain('require("y")');
+    expect(noEsmSyntax(out)).toBe(true);
+  });
+
+  it('handles division inside a ${...} template expression', () => {
+    const src = [
+      'const s = `${a / b} and ${c / d}`;',
+      'import x from "y";',
+      'export { s };',
+    ].join('\n');
+    const out = transformEsmToCjs(src);
+    expect(out).toContain('require("y")');
+    expect(noEsmSyntax(out)).toBe(true);
+  });
 });

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,43 @@
 # @lifo-sh/ui
 
+## 0.7.1
+
+### Patch Changes
+
+- node: fix ESM transform crashing on a regex literal inside a `${…}` template expression
+
+  `npx tinbase --engine pgmem` — the backend behind both Supabase examples — died on startup with:
+
+  ```
+  TypeError: [/…/node_modules/tinbase/dist/index.js] Cannot read properties of undefined (reading 'slice')
+  ```
+
+  The ESM→CJS string masker was at fault, not tinbase (which runs fine on the host on both 0.8.1 and
+  0.10.0). `scanBracedExpr` called the three-parameter `isRegexStart(prevChar, prevIdx, src)` with two
+  arguments:
+
+  ```js
+  const kind = isRegexStart(src, i); // src lands in prevChar, i in prevIdx, src is undefined
+  ```
+
+  `prevChar` then held the entire source, so the `/[A-Za-z_$]/` keyword check passed on any file
+  containing a letter and fell through to `src.slice(…)` on `undefined`. Every `/` inside a `${…}`
+  template expression — division or regex — threw.
+
+  Only the pgmem path happened to contain that shape, which is why just that engine broke:
+  `pg-mem/index.js`, `tinbase/dist/db/pgmem-engine.js` and `tinbase/dist/db/schema-diff.js` all build
+  SQL with `` `${l.replace(/'/g, "''")}` ``. A sweep of `transformEsmToCjs` over all 175 files in the
+  example's `node_modules` fails on exactly those three before the fix and none after.
+
+  `scanBracedExpr` now tracks `prevChar`/`prevIdx` the same way `maskStringLiterals` does — comments
+  transparent, a string or regex literal reported as a value — and passes all three arguments.
+
+  **Debugging note for next time:** the error names the _parent_ module being executed, not the module
+  whose transform threw. `tinbase/dist/index.js` was never the problem.
+
+- Updated dependencies
+  - @lifo-sh/core@0.7.1
+
 ## 0.7.0
 
 ### Patch Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/ui",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Embeddable UI components for Lifo — terminal, preview browser, and file explorer",
   "license": "MIT",
   "repository": {
@@ -46,7 +46,7 @@
     "@xterm/addon-webgl": "^0.18.0"
   },
   "peerDependencies": {
-    "@lifo-sh/core": ">=0.6.0"
+    "@lifo-sh/core": "workspace:^"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
         version: 22.19.11
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(@microsoft/api-extractor@7.57.3(@types/node@22.19.11))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(@microsoft/api-extractor@7.57.3(@types/node@22.19.11))(jiti@2.6.1)(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -136,10 +136,10 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+        version: 4.7.0(supports-color@8.1.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       shadcn:
         specifier: ^3.8.5
-        version: 3.8.5(@types/node@22.19.11)(typescript@5.9.3)
+        version: 3.8.5(@types/node@22.19.11)(supports-color@8.1.1)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -176,7 +176,7 @@ importers:
         version: 8.18.1
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(@microsoft/api-extractor@7.57.3(@types/node@22.19.11))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(@microsoft/api-extractor@7.57.3(@types/node@22.19.11))(jiti@2.6.1)(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -210,10 +210,10 @@ importers:
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(supports-color@8.1.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(supports-color@8.1.1)(tsx@4.21.0)
     optionalDependencies:
       esbuild:
         specifier: ^0.28.1
@@ -226,7 +226,7 @@ importers:
         version: 22.19.11
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(@microsoft/api-extractor@7.57.3(@types/node@22.19.11))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(@microsoft/api-extractor@7.57.3(@types/node@22.19.11))(jiti@2.6.1)(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -244,10 +244,10 @@ importers:
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(supports-color@8.1.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(supports-color@8.1.1)(tsx@4.21.0)
 
   packages/lifo-pkg-cal:
     devDependencies:
@@ -262,10 +262,10 @@ importers:
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(supports-color@8.1.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(supports-color@8.1.1)(tsx@4.21.0)
 
   packages/lifo-pkg-fastfetch:
     devDependencies:
@@ -280,10 +280,10 @@ importers:
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(supports-color@8.1.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(supports-color@8.1.1)(tsx@4.21.0)
 
   packages/lifo-pkg-ffmpeg:
     devDependencies:
@@ -304,7 +304,7 @@ importers:
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(supports-color@8.1.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
 
   packages/lifo-pkg-git:
     dependencies:
@@ -323,10 +323,10 @@ importers:
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(supports-color@8.1.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(supports-color@8.1.1)(tsx@4.21.0)
 
   packages/lifo-pkg-less:
     devDependencies:
@@ -341,10 +341,10 @@ importers:
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(supports-color@8.1.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(supports-color@8.1.1)(tsx@4.21.0)
 
   packages/lifo-pkg-man:
     devDependencies:
@@ -359,10 +359,10 @@ importers:
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(supports-color@8.1.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(supports-color@8.1.1)(tsx@4.21.0)
 
   packages/lifo-pkg-nano:
     devDependencies:
@@ -377,10 +377,10 @@ importers:
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(supports-color@8.1.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(supports-color@8.1.1)(tsx@4.21.0)
 
   packages/lifo-pkg-vi:
     devDependencies:
@@ -395,16 +395,16 @@ importers:
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(supports-color@8.1.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(supports-color@8.1.1)(tsx@4.21.0)
 
   packages/ui:
     dependencies:
       '@lifo-sh/core':
-        specifier: '>=0.6.0'
-        version: 0.6.2
+        specifier: workspace:^
+        version: link:../core
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -423,7 +423,7 @@ importers:
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(supports-color@8.1.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
 
 packages:
 
@@ -1215,14 +1215,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@lifo-sh/core@0.6.2':
-    resolution: {integrity: sha512-6RTYSdvuElfrsGNBvGbTXhhqtwW7TeVVlahWY0ER04yEvO6hlG/g+L+BaLVKveD0djtdx93xfl2XnFQ48ncl8Q==}
-    peerDependencies:
-      '@lifo-sh/ui': 0.6.0
-    peerDependenciesMeta:
-      '@lifo-sh/ui':
-        optional: true
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -4618,20 +4610,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7':
+  '@babel/core@7.29.7(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -4658,41 +4650,41 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@8.1.1)
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-member-expression-to-functions@7.29.7':
+  '@babel/helper-member-expression-to-functions@7.29.7(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.29.7':
+  '@babel/helper-module-imports@7.29.7(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -4702,18 +4694,18 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.29.7': {}
 
-  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@8.1.1)
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -4741,53 +4733,53 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@8.1.1)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-typescript@7.29.7(@babel/core@7.29.7)':
+  '@babel/preset-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -4799,7 +4791,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -4807,7 +4799,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5302,17 +5294,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lifo-sh/core@0.6.2':
-    dependencies:
-      acorn: 8.17.0
-      browser-metro: 1.0.31
-      ws: 8.19.0
-    optionalDependencies:
-      esbuild: 0.28.1
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -5365,7 +5346,7 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.28)
       ajv: 8.20.0
@@ -5375,8 +5356,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
+      express: 5.2.1(supports-color@8.1.1)
+      express-rate-limit: 8.5.2(express@5.2.1(supports-color@8.1.1))
       hono: 4.12.28
       jose: 6.2.3
       json-schema-typed: 8.0.2
@@ -6434,11 +6415,11 @@ snapshots:
     dependencies:
       '@types/node': 22.19.11
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))':
+  '@vitejs/plugin-react@4.7.0(supports-color@8.1.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
@@ -6648,11 +6629,11 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  body-parser@2.3.0:
+  body-parser@2.3.0(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -6848,9 +6829,11 @@ snapshots:
     dependencies:
       mimic-fn: 3.1.0
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
   decompress-response@6.0.0:
     dependencies:
@@ -7090,25 +7073,25 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.5.2(express@5.2.1):
+  express-rate-limit@8.5.2(express@5.2.1(supports-color@8.1.1)):
     dependencies:
-      express: 5.2.1
+      express: 5.2.1(supports-color@8.1.1)
       ip-address: 10.2.0
 
-  express@5.2.1:
+  express@5.2.1(supports-color@8.1.1):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 2.3.0(supports-color@8.1.1)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@8.1.1)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -7119,9 +7102,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.3
       range-parser: 1.3.0
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
+      router: 2.2.0(supports-color@8.1.1)
+      send: 1.2.1(supports-color@8.1.1)
+      serve-static: 2.2.1(supports-color@8.1.1)
       statuses: 2.0.2
       type-is: 2.1.0
       vary: 1.1.2
@@ -7179,9 +7162,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -7338,10 +7321,10 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8127,9 +8110,9 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
-  router@2.2.0:
+  router@2.2.0(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -8155,9 +8138,9 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
-  send@1.2.1:
+  send@1.2.1(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -8171,12 +8154,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.1:
+  serve-static@2.2.1(supports-color@8.1.1):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8199,15 +8182,15 @@ snapshots:
       safe-buffer: 5.2.1
       to-buffer: 1.2.2
 
-  shadcn@3.8.5(@types/node@22.19.11)(typescript@5.9.3):
+  shadcn@3.8.5(@types/node@22.19.11)(supports-color@8.1.1)(typescript@5.9.3):
     dependencies:
       '@antfu/ni': 25.0.0
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/parser': 7.29.0
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
-      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@dotenvx/dotenvx': 1.75.1
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(supports-color@8.1.1)(zod@3.25.76)
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.4
       commander: 14.0.3
@@ -8219,7 +8202,7 @@ snapshots:
       fast-glob: 3.3.3
       fs-extra: 11.3.3
       fuzzysort: 3.1.0
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       kleur: 4.1.5
       msw: 2.14.6(@types/node@22.19.11)(typescript@5.9.3)
       node-fetch: 3.3.2
@@ -8456,13 +8439,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(@microsoft/api-extractor@7.57.3(@types/node@22.19.11))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3):
+  tsup@8.5.1(@microsoft/api-extractor@7.57.3(@types/node@22.19.11))(jiti@2.6.1)(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       esbuild: 0.27.3
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -8561,10 +8544,10 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0):
+  vite-node@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(supports-color@8.1.1)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
@@ -8582,14 +8565,14 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@4.5.4(@types/node@22.19.11)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)):
+  vite-plugin-dts@4.5.4(@types/node@22.19.11)(rollup@4.59.0)(supports-color@8.1.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)):
     dependencies:
       '@microsoft/api-extractor': 7.57.3(@types/node@22.19.11)
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
       '@volar/typescript': 2.4.28
       '@vue/language-core': 2.2.0(typescript@5.9.3)
       compare-versions: 6.1.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21
@@ -8616,7 +8599,7 @@ snapshots:
       lightningcss: 1.31.1
       tsx: 4.21.0
 
-  vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.21.0):
+  vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(supports-color@8.1.1)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -8627,7 +8610,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.3.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
@@ -8639,7 +8622,7 @@ snapshots:
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
-      vite-node: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(supports-color@8.1.1)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.11


### PR DESCRIPTION
## The bug

`npx tinbase --engine pgmem` — the backend behind both Supabase examples (`tinbase` and `expo-supabase`) — died on startup:

```
TypeError: [/…/node_modules/tinbase/dist/index.js] Cannot read properties of undefined (reading 'slice')
```

**tinbase was not at fault.** It runs fine on the host on both 0.8.1 (what the templates pin) and 0.10.0 — verified with a new host bench (real `supabase/` folder + Vite frontend + headless probe: select/insert/update/delete all pass, CORS preflight correct, the templates' static anon JWT accepted).

The ESM→CJS string masker in `packages/core/src/commands/system/node.ts` was. `scanBracedExpr` called the three-parameter helper with two arguments:

```js
const kind = isRegexStart(src, i);   // signature: (prevChar, prevIdx, src)
```

`src` landed in `prevChar` and `i` in `prevIdx`, leaving `src` undefined. `prevChar` then held the whole source, so the `/[A-Za-z_$]/` keyword check passed for any file containing a letter and fell through to `src.slice(…)` on `undefined`. **Any `/` inside a `${…}` template expression — division or regex — threw.**

Only the pgmem path happened to contain that shape, which is why just that engine broke. Sweeping `transformEsmToCjs` over all 175 files in the example's `node_modules` fails on exactly three files before the fix and none after:

- `pg-mem/index.js`
- `tinbase/dist/db/pgmem-engine.js`
- `tinbase/dist/db/schema-diff.js` ← trigger: `` `${l.replace(/'/g, "''")}` ``

> **Debugging note:** the thrown error names the *parent* module being executed, not the module whose transform failed. `tinbase/dist/index.js` was never the problem — that misdirection is what made this look like a tinbase bug.

## The fix

`scanBracedExpr` now tracks `prevChar`/`prevIdx` exactly as `maskStringLiterals` does — comments transparent, a string or regex literal reported as a value — and passes all three arguments.

## Release

core, ui and `lifo-sh` → **0.7.1**. They are `linked` in `.changeset/config.json` and must satisfy each other. Packed manifests confirm they cross-satisfy:

| package | version | cross-reference |
| --- | --- | --- |
| `lifo-sh` | 0.7.1 | `@lifo-sh/core: 0.7.1` |
| `@lifo-sh/core` | 0.7.1 | peer `@lifo-sh/ui: 0.7.1` (optional) |
| `@lifo-sh/ui` | 0.7.1 | peer `@lifo-sh/core: ^0.7.1` |

### One extra change worth reviewing

`@lifo-sh/ui`'s peer on core moves from a plain range to `workspace:^`. Two reasons:

1. **It broke the build.** Changesets rewrites internal ranges on every release, so `>=0.6.0` became `>=0.7.1` — a plain registry range for a version that doesn't exist yet. `pnpm install` failed with `ERR_PNPM_NO_MATCHING_VERSION`. This would recur on every future release.
2. **It was resolving from the registry.** The lockfile diff shows a stale published `@lifo-sh/core@0.6.2` entry disappearing — ui had been resolving its core peer from npm rather than the workspace package, so it was built against a stale core.

`workspace:^` links locally and publishes as `^0.7.1`.

## Verification

- `bench/test-tinbase-cli.mjs` — passes end-to-end in the VM: port 54321 bound, `GET /rest/v1/todos` → 200 with both seeded rows, `POST` → 201, Studio at `/_/` → 200
- 2 regression tests added to `esm-transform.test.ts` (regex and division inside `${…}`); 80 transform/node tests pass
- `pnpm build` clean across all 18 workspace projects; `pnpm install --frozen-lockfile` consistent

## Notes for the reviewer

- **Pre-existing failures, not from this PR** (verified identical on a clean `main`): `tests/commands/system-extra.test.ts` (7 failed), `tests/shell/shell.test.ts` (21 failed), and `tests/kernel/content-store.test.ts` OOMs — the last is why a full `pnpm test` dies. Worth a separate issue.
- **Lockfile churn:** beyond our two intended changes, pnpm re-resolved babel's `supports-color` peer suffixes. Incidental to the install, not to this fix.
- `@lifo-sh/core`'s own peer on ui is still `workspace:*`, which publishes as an exact `0.7.1`. Strict for an optional peer — happy to change it to `workspace:^` too if you'd prefer, but I left existing behaviour alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)