### PR TITLE
fix(preview): unblank the SW preview, and stop the SW-free one using a worker

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,48 @@
 # lifo-sh
 
+## 0.8.1
+
+### Patch Changes
+
+- Fix both preview engines against a server that sets security headers, and stop the SW-free preview depending on a service worker
+
+  Two bugs that only surfaced once tinbase 0.10.1 shipped a hardened studio and the
+  SW-free preview was driven for real.
+
+  **A server's anti-framing headers blanked the service-worker preview.**
+  `tinbase@0.10.1` began serving its studio with `x-frame-options: DENY` and a CSP
+  containing `frame-ancestors 'none'`. The service worker forwards real response
+  headers, so the browser refused to render the preview — while the SW-free engine
+  worked, because re-serving the document as a blob drops those headers. That
+  asymmetry is what made it look like the service worker had broken.
+
+  This is not specific to tinbase: `helmet()` sets `X-Frame-Options: DENY` by
+  default, so any in-VM Express app using it would blank a preview the same way.
+  `stripPreviewBlockingHeaders()` now removes `x-frame-options`,
+  `content-security-policy` and `content-security-policy-report-only` **on the
+  preview path only** — tunnels, `curl` and `sandbox.fetch` still see exactly what
+  the server sent. There is nothing for those headers to protect on a preview: the
+  "server" is a JavaScript object in the very tab doing the framing. CSP goes too,
+  not just its `frame-ancestors`, because preview transports inject an inline script
+  into VM-served documents and a `script-src 'self'` policy blocks it.
+
+  **The SW-free preview was quietly using the service worker.** React Native needs
+  absolute URLs, so an app resolves its configured `/_sw/54321` against
+  `location.origin` — which inside a `blob:` document is the EMBEDDER's origin. The
+  app therefore requests `http://localhost:5173/_sw/54321/rest/v1/todos`. The
+  embedder-port exclusion (which keeps the embedding page's own assets and CORS
+  proxy on the real network) ran before the `/_sw/<port>/` prefix check, so that URL
+  fell through to the network, where a registered service worker answered it. It
+  appeared to work while masking a total failure on any browser without a
+  dependable worker — the case the SW-free engine exists for.
+
+  An explicit `/_sw/<port>/` prefix is now honoured before the embedder-port
+  exclusion, and still after the foreign-origin rejection, so a hostile origin can't
+  route itself into the VM by putting `/_sw/` in its path.
+
+- Updated dependencies
+  - @lifo-sh/core@0.8.1
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-sh",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Run Lifo (a Linux-like OS) in your terminal -- npx lifo-sh",
   "license": "MIT",
   "repository": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,48 @@
 # @lifo-sh/core
 
+## 0.8.1
+
+### Patch Changes
+
+- Fix both preview engines against a server that sets security headers, and stop the SW-free preview depending on a service worker
+
+  Two bugs that only surfaced once tinbase 0.10.1 shipped a hardened studio and the
+  SW-free preview was driven for real.
+
+  **A server's anti-framing headers blanked the service-worker preview.**
+  `tinbase@0.10.1` began serving its studio with `x-frame-options: DENY` and a CSP
+  containing `frame-ancestors 'none'`. The service worker forwards real response
+  headers, so the browser refused to render the preview — while the SW-free engine
+  worked, because re-serving the document as a blob drops those headers. That
+  asymmetry is what made it look like the service worker had broken.
+
+  This is not specific to tinbase: `helmet()` sets `X-Frame-Options: DENY` by
+  default, so any in-VM Express app using it would blank a preview the same way.
+  `stripPreviewBlockingHeaders()` now removes `x-frame-options`,
+  `content-security-policy` and `content-security-policy-report-only` **on the
+  preview path only** — tunnels, `curl` and `sandbox.fetch` still see exactly what
+  the server sent. There is nothing for those headers to protect on a preview: the
+  "server" is a JavaScript object in the very tab doing the framing. CSP goes too,
+  not just its `frame-ancestors`, because preview transports inject an inline script
+  into VM-served documents and a `script-src 'self'` policy blocks it.
+
+  **The SW-free preview was quietly using the service worker.** React Native needs
+  absolute URLs, so an app resolves its configured `/_sw/54321` against
+  `location.origin` — which inside a `blob:` document is the EMBEDDER's origin. The
+  app therefore requests `http://localhost:5173/_sw/54321/rest/v1/todos`. The
+  embedder-port exclusion (which keeps the embedding page's own assets and CORS
+  proxy on the real network) ran before the `/_sw/<port>/` prefix check, so that URL
+  fell through to the network, where a registered service worker answered it. It
+  appeared to work while masking a total failure on any browser without a
+  dependable worker — the case the SW-free engine exists for.
+
+  An explicit `/_sw/<port>/` prefix is now honoured before the embedder-port
+  exclusion, and still after the foreign-origin rejection, so a hostile origin can't
+  route itself into the VM by putting `/_sw/` in its path.
+
+- Updated dependencies
+  - @lifo-sh/ui@0.8.1
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Linux-like OS engine for JavaScript -- kernel, shell, VFS, and 60+ commands",
   "license": "MIT",
   "repository": {

--- a/packages/core/src/kernel/network/ServiceWorkerBridge.ts
+++ b/packages/core/src/kernel/network/ServiceWorkerBridge.ts
@@ -14,7 +14,7 @@ import { getUpgradeHandlers } from '../../node-compat/http.js';
 import { EventEmitter } from '../../node-compat/events.js';
 import { Buffer } from '../../node-compat/buffer.js';
 import { encodeFrame, FrameDecoder, OPCODE, splitHandshake } from './ws-frame.js';
-import { dispatchRequest } from './dispatch.js';
+import { dispatchRequest, stripPreviewBlockingHeaders } from './dispatch.js';
 
 interface SwRequestMessage {
 	type: 'request';
@@ -264,7 +264,15 @@ export class ServiceWorkerBridge {
 		const buf = bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength
 			? bytes.buffer
 			: bytes.slice().buffer;
-		this.port?.postMessage({ type: 'response', requestId, statusCode, headers, bodyBuffer: buf }, [buf]);
+		this.port?.postMessage({
+			type: 'response',
+			requestId,
+			statusCode,
+			// An in-VM server's anti-framing headers would blank the preview it is
+			// being previewed in. See stripPreviewBlockingHeaders.
+			headers: stripPreviewBlockingHeaders(headers),
+			bodyBuffer: buf,
+		}, [buf]);
 	}
 
 	private async handleRequest(message: SwRequestMessage): Promise<void> {

--- a/packages/core/src/kernel/network/dispatch.ts
+++ b/packages/core/src/kernel/network/dispatch.ts
@@ -41,6 +41,45 @@ export const DEFAULT_DISPATCH_TIMEOUT_MS = 120_000;
  */
 export const LIFO_HEADER = 'x-lifo';
 
+/**
+ * Response headers that make sense for a server on the public internet but not
+ * for one running inside the page, and that actively break a preview.
+ *
+ * A preview renders an in-VM server's document in a same-origin iframe. If the
+ * server sends `X-Frame-Options: DENY` or a CSP with `frame-ancestors 'none'`,
+ * the browser refuses to render it and the preview is blank — even though there
+ * is no cross-origin embedding happening and nothing to protect: the "server" is
+ * a JavaScript object in the very tab doing the framing.
+ *
+ * This is not one library's quirk. `helmet()` sets `X-Frame-Options: DENY` by
+ * default, so any Express app using it hits this, as does tinbase's studio.
+ *
+ * CSP goes too, not just its `frame-ancestors`: preview transports inject a small
+ * inline script into VM-served documents (to strip the URL prefix so client
+ * routers see a clean path), and a `script-src 'self'` policy blocks it. A
+ * dev preview of your own code is not the place to enforce a production CSP.
+ *
+ * Stripped only on the PREVIEW path. Tunnels, `curl` and `sandbox.fetch` see
+ * exactly what the server sent.
+ */
+export const PREVIEW_STRIPPED_HEADERS = [
+	'x-frame-options',
+	'content-security-policy',
+	'content-security-policy-report-only',
+];
+
+/**
+ * Copy `headers` without the headers that break framing a preview.
+ * Case-insensitive: header names arrive however the server wrote them.
+ */
+export function stripPreviewBlockingHeaders(headers: Record<string, string>): Record<string, string> {
+	const out: Record<string, string> = {};
+	for (const [key, value] of Object.entries(headers)) {
+		if (!PREVIEW_STRIPPED_HEADERS.includes(key.toLowerCase())) out[key] = value;
+	}
+	return out;
+}
+
 export interface DispatchInit {
 	method?: string;
 	/** Path + query as the server sees it, e.g. `/rest/v1/todos?select=*`. */

--- a/packages/core/tests/kernel/dispatch.test.ts
+++ b/packages/core/tests/kernel/dispatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { dispatchRequest, waitForPort, LIFO_HEADER } from '../../src/kernel/network/dispatch.js';
+import { dispatchRequest, waitForPort, LIFO_HEADER, stripPreviewBlockingHeaders } from '../../src/kernel/network/dispatch.js';
 import { PortBridge } from '../../src/kernel/network/PortBridge.js';
 import type { VirtualRequestHandler, VirtualResponse } from '../../src/kernel/index.js';
 
@@ -91,6 +91,42 @@ describe('dispatchRequest', () => {
       body: new TextEncoder().encode('{"a":1}'),
     });
     expect(seen).toBe('{"a":1}');
+  });
+});
+
+describe('stripPreviewBlockingHeaders', () => {
+  // Regression: tinbase 0.10.1 started sending `x-frame-options: DENY` and a CSP
+  // with `frame-ancestors 'none'` on its studio, which blanked the service-worker
+  // preview. helmet() sets the same X-Frame-Options by default, so any Express
+  // app using it would break a preview the same way.
+  it('drops the headers that stop a document being framed', () => {
+    const out = stripPreviewBlockingHeaders({
+      'content-type': 'text/html',
+      'x-frame-options': 'DENY',
+      'content-security-policy': "default-src 'self'; frame-ancestors 'none'",
+      'content-security-policy-report-only': "frame-ancestors 'none'",
+      etag: 'W/"abc"',
+    });
+    expect(out).toEqual({ 'content-type': 'text/html', etag: 'W/"abc"' });
+  });
+
+  it('matches header names case-insensitively', () => {
+    const out = stripPreviewBlockingHeaders({
+      'X-Frame-Options': 'SAMEORIGIN',
+      'Content-Security-Policy': "frame-ancestors 'none'",
+      'Content-Type': 'text/html',
+    });
+    expect(out).toEqual({ 'Content-Type': 'text/html' });
+  });
+
+  it('leaves everything else untouched, including other security headers', () => {
+    const headers = {
+      'content-type': 'application/json',
+      'x-content-type-options': 'nosniff',
+      'strict-transport-security': 'max-age=31536000',
+      'cache-control': 'no-cache',
+    };
+    expect(stripPreviewBlockingHeaders(headers)).toEqual(headers);
   });
 });
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,48 @@
 # @lifo-sh/ui
 
+## 0.8.1
+
+### Patch Changes
+
+- Fix both preview engines against a server that sets security headers, and stop the SW-free preview depending on a service worker
+
+  Two bugs that only surfaced once tinbase 0.10.1 shipped a hardened studio and the
+  SW-free preview was driven for real.
+
+  **A server's anti-framing headers blanked the service-worker preview.**
+  `tinbase@0.10.1` began serving its studio with `x-frame-options: DENY` and a CSP
+  containing `frame-ancestors 'none'`. The service worker forwards real response
+  headers, so the browser refused to render the preview — while the SW-free engine
+  worked, because re-serving the document as a blob drops those headers. That
+  asymmetry is what made it look like the service worker had broken.
+
+  This is not specific to tinbase: `helmet()` sets `X-Frame-Options: DENY` by
+  default, so any in-VM Express app using it would blank a preview the same way.
+  `stripPreviewBlockingHeaders()` now removes `x-frame-options`,
+  `content-security-policy` and `content-security-policy-report-only` **on the
+  preview path only** — tunnels, `curl` and `sandbox.fetch` still see exactly what
+  the server sent. There is nothing for those headers to protect on a preview: the
+  "server" is a JavaScript object in the very tab doing the framing. CSP goes too,
+  not just its `frame-ancestors`, because preview transports inject an inline script
+  into VM-served documents and a `script-src 'self'` policy blocks it.
+
+  **The SW-free preview was quietly using the service worker.** React Native needs
+  absolute URLs, so an app resolves its configured `/_sw/54321` against
+  `location.origin` — which inside a `blob:` document is the EMBEDDER's origin. The
+  app therefore requests `http://localhost:5173/_sw/54321/rest/v1/todos`. The
+  embedder-port exclusion (which keeps the embedding page's own assets and CORS
+  proxy on the real network) ran before the `/_sw/<port>/` prefix check, so that URL
+  fell through to the network, where a registered service worker answered it. It
+  appeared to work while masking a total failure on any browser without a
+  dependable worker — the case the SW-free engine exists for.
+
+  An explicit `/_sw/<port>/` prefix is now honoured before the embedder-port
+  exclusion, and still after the foreign-origin rejection, so a hostile origin can't
+  route itself into the VM by putting `/_sw/` in its path.
+
+- Updated dependencies
+  - @lifo-sh/core@0.8.1
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lifo-sh/ui",
-  "version": "0.8.0",
-  "description": "Embeddable UI components for Lifo \u2014 terminal, preview browser, and file explorer",
+  "version": "0.8.1",
+  "description": "Embeddable UI components for Lifo — terminal, preview browser, and file explorer",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/ui/src/vm-routing.ts
+++ b/packages/ui/src/vm-routing.ts
@@ -79,11 +79,27 @@ export function resolveVmTarget(
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
 
   const loopback = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
-  if (loopback && hostPort && parsed.port === hostPort) return null;
+
+  // A genuinely foreign origin is never in-VM, whatever its path says.
   if (!loopback && parsed.host !== locationHost) return null;
 
+  // An explicit /_sw/<port>/ prefix is an unambiguous routing instruction, so it
+  // is honoured BEFORE the embedder-port exclusion below.
+  //
+  // This ordering is the whole ballgame for a blob: preview. React Native needs
+  // absolute URLs, so an app resolves its configured `/_sw/54321` against
+  // `location.origin` — which inside a blob document is the EMBEDDER's origin.
+  // The app therefore requests `http://localhost:5173/_sw/54321/rest/v1/todos`.
+  // Excluding the embedder's port first made that fall through to the real
+  // network, where a registered service worker would answer it: the SW-free
+  // preview silently depended on a service worker, which is exactly what it
+  // exists to avoid (iOS Chrome has no dependable one).
   const nested = parsed.pathname.match(swPrefix);
   if (nested) return { port: Number(nested[1]), path: (nested[2] || '/') + parsed.search };
+
+  // The embedding page's own origin is not an in-VM port. Its assets and its
+  // CORS proxy must reach the real network.
+  if (loopback && hostPort && parsed.port === hostPort) return null;
 
   return {
     port: loopback && parsed.port ? Number(parsed.port) : previewPort,

--- a/packages/ui/tests/vm-routing.test.ts
+++ b/packages/ui/tests/vm-routing.test.ts
@@ -80,6 +80,33 @@ describe('resolveVmTarget', () => {
     });
   });
 
+  // Regression: this is the URL an Expo app actually requests. React Native
+  // needs absolute URLs, so the app resolves its configured `/_sw/54321` against
+  // location.origin — which inside a blob document is the EMBEDDER's origin. The
+  // embedder-port exclusion used to run first, so this fell through to the real
+  // network and a registered service worker answered it: the SW-free preview
+  // was quietly depending on a service worker.
+  it('tunnels an embedder-origin URL that carries a /_sw/<port>/ prefix', () => {
+    expect(resolve('http://localhost:5173/_sw/54321/rest/v1/todos?select=*', '5173')).toEqual({
+      port: 54321,
+      path: '/rest/v1/todos?select=*',
+    });
+    // …while the same origin WITHOUT the prefix still goes to the real network.
+    expect(resolve('http://localhost:5173/_cors?url=https://x.dev', '5173')).toBeNull();
+    expect(resolve('http://localhost:5173/assets/x.png', '5173')).toBeNull();
+  });
+
+  it('honours the boxId form on the embedder origin too', () => {
+    expect(resolve('http://localhost:5173/_sw/box_ab12/54321/auth/v1/token', '5173')).toEqual({
+      port: 54321,
+      path: '/auth/v1/token',
+    });
+  });
+
+  it('never tunnels a foreign origin, even with a /_sw/ path', () => {
+    expect(resolve('https://evil.example.com/_sw/54321/rest/v1/todos', '5173')).toBeNull();
+  });
+
   it('tunnels a same-origin non-loopback URL to the preview port', () => {
     expect(resolve('https://preview.example.dev/assets/x.png', '', 'preview.example.dev')).toEqual({
       port: 8081,


### PR DESCRIPTION
Release **0.8.1**. Two bugs that only surfaced once `tinbase@0.10.1` shipped a hardened studio and the SW-free engine was driven for real. Both confirmed fixed by hand, for the Expo app **and** the tinbase studio, under **both** engines.

## 1. A server's anti-framing headers blanked the service-worker preview

`tinbase@0.10.1` began serving its studio with:

```
x-frame-options: DENY
content-security-policy: … frame-ancestors 'none'
```

The service worker forwards real response headers, so the browser refused to render the iframe. The SW-free engine kept working, because re-serving the document as a blob drops those headers — **that asymmetry is what made it look like the service worker itself had broken.** It hadn't; I confirmed it was still registered, controlling, and correctly returning `x-lifo: no-server` for unbound ports.

| | `/_/` response headers |
| --- | --- |
| `tinbase@0.8.1` | *(none)* |
| `tinbase@0.10.1` | `x-frame-options: DENY` + CSP `frame-ancestors 'none'` |

**This is not tinbase-specific.** `helmet()` sets `X-Frame-Options: DENY` by default, so any in-VM Express app using it blanks a preview the same way — which is why the fix belongs here and not in tinbase.

`stripPreviewBlockingHeaders()` drops `x-frame-options`, `content-security-policy` and `content-security-policy-report-only` **on the preview path only**. Tunnels, `curl` and `sandbox.fetch` — which can genuinely expose a server to other people — still see exactly what the server sent.

Nothing is given up: the "server" is a JavaScript object in the very tab doing the framing, so there is no cross-origin embedding to defend against. CSP goes too, not only its `frame-ancestors`, because preview transports inject an inline path shim that a `script-src 'self'` policy would block.

## 2. The SW-free preview was quietly depending on a service worker

React Native needs absolute URLs, so an app resolves its configured `/_sw/54321` against `location.origin` — which inside a `blob:` document is the **embedder's** origin. The app therefore requests:

```
http://localhost:5173/_sw/54321/rest/v1/todos
```

The embedder-port exclusion — added earlier so the embedding page's own assets and its `/_cors` proxy reach the real network — ran **before** the `/_sw/<port>/` prefix check. So that URL resolved to `null`, fell through to the network, and a registered service worker answered it.

It looked like it worked. It was masking a total failure on any browser without a dependable worker, which is the entire reason this engine exists.

Before → after, from the built resolver:

| URL | before | after |
| --- | --- | --- |
| `http://localhost:5173/_sw/54321/rest/v1/todos` | `null` → network → SW | **port 54321** |
| `http://localhost:5173/_sw/54321/realtime/v1/websocket` | `null` | **port 54321** |
| `http://localhost:5173/_cors?url=…` | `null` | `null` |
| `http://localhost:5173/assets/x.png` | `null` | `null` |
| `https://evil.example.com/_sw/54321/x` | `null` | `null` |

An explicit `/_sw/<port>/` prefix now wins over the embedder-port exclusion, and still **loses** to the foreign-origin rejection — so a hostile origin can't route itself into the VM by putting `/_sw/` in its path.

## Verification

- 15 core dispatch tests (3 new for the header strip, incl. case-insensitivity and "other security headers are left alone")
- 25 ui tests (4 new, incl. the literal URL an Expo app requests, the `boxId` form on the embedder origin, and the hostile-origin case)
- `pnpm build` exits 0
- Manual: Expo app + tinbase studio, both engines. The meaningful SW-free check is DevTools → Application → Service Workers → **"Bypass for network"**, then reload — the app keeps working, which is the iOS condition.

## Note on the version

`0.8.1` came out of `changeset version` directly this time. That refines what the 0.8.0 release commit says: the core↔ui peer relationship escalates **`minor`/`major`** bumps to major, but leaves `patch` alone — so no hand-pinning was needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)