### PR TITLE
fix(preview): route by the embedder's ORIGIN, not location.host (0.8.2)

### DIFF
--- a/bench/test-host-net.mjs
+++ b/bench/test-host-net.mjs
@@ -127,10 +127,10 @@ const bridge = new ServiceWorkerBridge(sb.kernel.portRegistry);
 bridge.attach(adapter);
 
 const PREVIEW_PORT = 8081; // where Metro would be — deliberately NOT tinbase
-const HOST_PORT = '5173'; // the embedding page, excluded from in-VM routing
+const HOST_ORIGIN = 'http://localhost:5173'; // the embedding page, excluded from in-VM routing
 
 // The exact function the shim inlines into the iframe, imported directly.
-const resolveTarget = (url) => resolveVmTarget(url, PREVIEW_PORT, HOST_PORT, '');
+const resolveTarget = (url) => resolveVmTarget(url, PREVIEW_PORT, HOST_ORIGIN);
 
 let seq = 0;
 async function shimFetch(url, { method = 'GET', headers = {}, body } = {}) {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,50 @@
 # lifo-sh
 
+## 0.8.2
+
+### Patch Changes
+
+- Fix SW-free preview routing on a deployed origin (it only worked on localhost)
+
+  The SW-free preview decided whether a URL belonged to the embedding page by
+  comparing against `location.host` — read inside the preview document. **Inside a
+  `blob:` document `location.host` is the empty string** (only `location.origin`
+  survives), so every non-loopback embedder was treated as a foreign origin and its
+  URLs were never tunnelled.
+
+  That made the previous release's fix work only where the embedder happened to be
+  loopback. In production:
+
+  | deployment                      | app requests                         | before                                                                                                   |
+  | ------------------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+  | `https://lifo.sh`               | `https://lifo.sh/_sw/54321/…`        | not tunnelled → network → a registered service worker answered it, so it looked fine but was not SW-free |
+  | a host that unregisters `sw.js` | `https://<site>/_sw/<boxId>/54321/…` | not tunnelled → nothing answers → the app's API calls fail outright                                      |
+
+  The embedder's origin is now captured in the PARENT document, where
+  `location.host` is real, and passed into the shim. A URL on that origin is
+  same-origin: a `/_sw/<port>/` prefix on it is ours to route, and without a prefix
+  it is the embedder's own asset and goes to the real network. Loopback is still
+  accepted for local dev, and a genuinely foreign origin is still rejected even if
+  its path contains `/_sw/`.
+
+  **Signature change to two exports introduced in 0.8.0:**
+
+  ```diff
+  - resolveVmTarget(url, previewPort, hostPort, locationHost)
+  + resolveVmTarget(url, previewPort, hostOrigin)
+
+  - buildPreviewShim({ port, hostPort: location.port })
+  + buildPreviewShim({ port, hostOrigin: location.origin })
+  ```
+
+  Comparing by port could never distinguish a deployed embedder (no port) from an
+  in-VM one, so the port form was unfixable rather than merely awkward.
+  `mountNoSwPreview` and `PreviewBrowser` are unaffected — they pass this
+  themselves.
+
+- Updated dependencies
+  - @lifo-sh/core@0.8.2
+
 ## 0.8.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-sh",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Run Lifo (a Linux-like OS) in your terminal -- npx lifo-sh",
   "license": "MIT",
   "repository": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,50 @@
 # @lifo-sh/core
 
+## 0.8.2
+
+### Patch Changes
+
+- Fix SW-free preview routing on a deployed origin (it only worked on localhost)
+
+  The SW-free preview decided whether a URL belonged to the embedding page by
+  comparing against `location.host` — read inside the preview document. **Inside a
+  `blob:` document `location.host` is the empty string** (only `location.origin`
+  survives), so every non-loopback embedder was treated as a foreign origin and its
+  URLs were never tunnelled.
+
+  That made the previous release's fix work only where the embedder happened to be
+  loopback. In production:
+
+  | deployment                      | app requests                         | before                                                                                                   |
+  | ------------------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+  | `https://lifo.sh`               | `https://lifo.sh/_sw/54321/…`        | not tunnelled → network → a registered service worker answered it, so it looked fine but was not SW-free |
+  | a host that unregisters `sw.js` | `https://<site>/_sw/<boxId>/54321/…` | not tunnelled → nothing answers → the app's API calls fail outright                                      |
+
+  The embedder's origin is now captured in the PARENT document, where
+  `location.host` is real, and passed into the shim. A URL on that origin is
+  same-origin: a `/_sw/<port>/` prefix on it is ours to route, and without a prefix
+  it is the embedder's own asset and goes to the real network. Loopback is still
+  accepted for local dev, and a genuinely foreign origin is still rejected even if
+  its path contains `/_sw/`.
+
+  **Signature change to two exports introduced in 0.8.0:**
+
+  ```diff
+  - resolveVmTarget(url, previewPort, hostPort, locationHost)
+  + resolveVmTarget(url, previewPort, hostOrigin)
+
+  - buildPreviewShim({ port, hostPort: location.port })
+  + buildPreviewShim({ port, hostOrigin: location.origin })
+  ```
+
+  Comparing by port could never distinguish a deployed embedder (no port) from an
+  in-VM one, so the port form was unfixable rather than merely awkward.
+  `mountNoSwPreview` and `PreviewBrowser` are unaffected — they pass this
+  themselves.
+
+- Updated dependencies
+  - @lifo-sh/ui@0.8.2
+
 ## 0.8.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Linux-like OS engine for JavaScript -- kernel, shell, VFS, and 60+ commands",
   "license": "MIT",
   "repository": {

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,50 @@
 # @lifo-sh/ui
 
+## 0.8.2
+
+### Patch Changes
+
+- Fix SW-free preview routing on a deployed origin (it only worked on localhost)
+
+  The SW-free preview decided whether a URL belonged to the embedding page by
+  comparing against `location.host` — read inside the preview document. **Inside a
+  `blob:` document `location.host` is the empty string** (only `location.origin`
+  survives), so every non-loopback embedder was treated as a foreign origin and its
+  URLs were never tunnelled.
+
+  That made the previous release's fix work only where the embedder happened to be
+  loopback. In production:
+
+  | deployment                      | app requests                         | before                                                                                                   |
+  | ------------------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+  | `https://lifo.sh`               | `https://lifo.sh/_sw/54321/…`        | not tunnelled → network → a registered service worker answered it, so it looked fine but was not SW-free |
+  | a host that unregisters `sw.js` | `https://<site>/_sw/<boxId>/54321/…` | not tunnelled → nothing answers → the app's API calls fail outright                                      |
+
+  The embedder's origin is now captured in the PARENT document, where
+  `location.host` is real, and passed into the shim. A URL on that origin is
+  same-origin: a `/_sw/<port>/` prefix on it is ours to route, and without a prefix
+  it is the embedder's own asset and goes to the real network. Loopback is still
+  accepted for local dev, and a genuinely foreign origin is still rejected even if
+  its path contains `/_sw/`.
+
+  **Signature change to two exports introduced in 0.8.0:**
+
+  ```diff
+  - resolveVmTarget(url, previewPort, hostPort, locationHost)
+  + resolveVmTarget(url, previewPort, hostOrigin)
+
+  - buildPreviewShim({ port, hostPort: location.port })
+  + buildPreviewShim({ port, hostOrigin: location.origin })
+  ```
+
+  Comparing by port could never distinguish a deployed embedder (no port) from an
+  in-VM one, so the port form was unfixable rather than merely awkward.
+  `mountNoSwPreview` and `PreviewBrowser` are unaffected — they pass this
+  themselves.
+
+- Updated dependencies
+  - @lifo-sh/core@0.8.2
+
 ## 0.8.1
 
 ### Patch Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/ui",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Embeddable UI components for Lifo — terminal, preview browser, and file explorer",
   "license": "MIT",
   "repository": {

--- a/packages/ui/src/preview-nosw.ts
+++ b/packages/ui/src/preview-nosw.ts
@@ -44,8 +44,8 @@ async function vmFetch(kernel: Kernel, port: number, url: string, timeoutMs = 12
  * import `buildPreviewShim` directly to take a subset (e.g. HTTP only) in
  * another embedder.
  */
-export function shimScript(port: number, hostPort = ''): string {
-  return buildPreviewShim({ port, hostPort });
+export function shimScript(port: number, hostOrigin = ''): string {
+  return buildPreviewShim({ port, hostOrigin });
 }
 
 /**
@@ -167,9 +167,11 @@ export async function mountNoSwPreview(
   }
 
   // Inject router shim + transport shim before the bundle.
-  // The embedding page's port is excluded from in-VM routing (see resolveTarget).
-  const hostPort = typeof location !== 'undefined' ? location.port : '';
-  html = html.replace(/<head(\s[^>]*)?>/i, (h) => `${h}\n<script>${routerShim(bundleBlob, realBundlePath)}</script>\n<script>${shimScript(port, hostPort)}</script>`);
+  // Captured HERE, in the parent document: inside the blob preview
+  // `location.host` is the empty string, so the embedder's origin has to be
+  // baked in (see resolveVmTarget).
+  const hostOrigin = typeof location !== 'undefined' ? location.origin : '';
+  html = html.replace(/<head(\s[^>]*)?>/i, (h) => `${h}\n<script>${routerShim(bundleBlob, realBundlePath)}</script>\n<script>${shimScript(port, hostOrigin)}</script>`);
 
   // Serve the HTML as a blob.
   const hashPath = path && path !== '/' ? '#' + path.replace(/^\//, '') : '';

--- a/packages/ui/src/preview-shims.ts
+++ b/packages/ui/src/preview-shims.ts
@@ -14,7 +14,7 @@
  *
  * ```ts
  * // everything (what mountNoSwPreview uses)
- * buildPreviewShim({ port: 8081, hostPort: location.port })
+ * buildPreviewShim({ port: 8081, hostOrigin: location.origin })
  *
  * // just HTTP — no ws, no asset interception
  * buildPreviewShim({ port: 3000, include: ['fetch', 'xhr'] })
@@ -44,10 +44,13 @@ export interface PreviewShimOptions {
   /** In-VM port backing the preview document; the default for relative URLs. */
   port: number;
   /**
-   * Port of the EMBEDDING page, excluded from in-VM routing. In local dev the
-   * embedder is on loopback too, and its port is not an in-VM port.
+   * Origin of the EMBEDDING page — pass `location.origin` from the parent
+   * document. Needed both to recognise the embedder's own assets (they must
+   * reach the real network) and to accept a `/_sw/<port>/` prefix on its origin
+   * as ours to route. It cannot be read inside the preview: a `blob:` document
+   * reports `location.host` as the empty string.
    */
-  hostPort?: string | number;
+  hostOrigin?: string;
   /** Which patches to install. Defaults to all of them. */
   include?: ShimName[];
   /** How a request leaves the document. Defaults to `postMessage` to the parent. */
@@ -59,9 +62,9 @@ export interface PreviewShimOptions {
  * and `resolveTarget` (inlined from the real `resolveVmTarget` so the sandboxed
  * copy and the unit-tested copy cannot drift).
  */
-function runtime(port: number, hostPort: string): string {
+function runtime(port: number, hostOrigin: string): string {
   return `
-  var PORT=${port}, HOST_PORT=${JSON.stringify(hostPort)};
+  var PORT=${port}, HOST_ORIGIN=${JSON.stringify(hostOrigin)};
   var parentWin=window.parent, seq=0, pending=new Map(), wsConns=new Map();
   function b64enc(u8){var s='';for(var i=0;i<u8.length;i++)s+=String.fromCharCode(u8[i]);return btoa(s);}
   function b64dec(b){var s=atob(b),u=new Uint8Array(s.length);for(var i=0;i<s.length;i++)u[i]=s.charCodeAt(i);return u;}
@@ -75,7 +78,7 @@ function runtime(port: number, hostPort: string): string {
   });
   // Inlined verbatim from vm-routing.ts — same function, here and in its tests.
   var resolveVmTarget=${resolveVmTarget.toString()};
-  function resolveTarget(u){ return resolveVmTarget(u,PORT,HOST_PORT,location.host||''); }
+  function resolveTarget(u){ return resolveVmTarget(u,PORT,HOST_ORIGIN); }
   // "Does this go to the VM?" — for patches that re-enter through window.fetch,
   // which resolves the port itself.
   function tunnelable(u){ return resolveTarget(u)!==null; }
@@ -253,7 +256,7 @@ const FRAGMENTS: Record<ShimName, () => string> = {
  * so including them without `fetch` would leave them hitting the real network.
  */
 export function buildPreviewShim(options: PreviewShimOptions): string {
-  const { port, hostPort = '', include = ALL_SHIMS, transport = 'postMessage' } = options;
+  const { port, hostOrigin = '', include = ALL_SHIMS, transport = 'postMessage' } = options;
   if (transport !== 'postMessage') throw new Error(`preview shim: unsupported transport "${transport}"`);
 
   const wanted = ALL_SHIMS.filter((name) => include.includes(name));
@@ -263,5 +266,5 @@ export function buildPreviewShim(options: PreviewShimOptions): string {
   }
 
   const body = wanted.map((name) => FRAGMENTS[name]()).join('\n');
-  return `(function(){${runtime(port, String(hostPort || ''))}\n${body}\n})();`;
+  return `(function(){${runtime(port, String(hostOrigin || ''))}\n${body}\n})();`;
 }

--- a/packages/ui/src/vm-routing.ts
+++ b/packages/ui/src/vm-routing.ts
@@ -28,21 +28,30 @@ export interface VmTarget {
  * that same port. Callers pass the preview port as the default for anything
  * relative.
  *
- * @param url          The URL as the app wrote it (may be relative).
- * @param previewPort  Port backing the preview document itself.
- * @param hostPort     Port of the EMBEDDING page, or '' if unknown. Excluded
- *                     from in-VM routing: during local dev the embedder is on
- *                     loopback too (e.g. a playground on localhost:5173), and
- *                     its port is not an in-VM port — routing it into the
- *                     registry hits nothing.
- * @param locationHost `location.host` of the preview document; '' in a blob
- *                     document, which is why it cannot be relied on alone.
+ * @param url         The URL as the app wrote it (may be relative).
+ * @param previewPort Port backing the preview document itself.
+ * @param hostOrigin  Origin of the EMBEDDING page, e.g. `https://lifo.sh` or
+ *                    `http://localhost:5173`, captured in the parent document
+ *                    and passed in.
+ *
+ *                    It must be passed in rather than read here: inside a
+ *                    `blob:` document `location.host` is the empty string (only
+ *                    `location.origin` survives), so a check against
+ *                    `location.host` silently rejects every non-loopback
+ *                    embedder. That made an app's absolute
+ *                    `https://<site>/_sw/<port>/…` URL skip the tunnel in
+ *                    production while working locally, where the embedder
+ *                    happens to be loopback.
+ *
+ *                    Two things depend on knowing it: a URL on the embedder's
+ *                    own origin is same-origin (so a `/_sw/` prefix on it is
+ *                    ours to route), and without a prefix it is the embedder's
+ *                    own asset and must reach the real network.
  */
 export function resolveVmTarget(
   url: unknown,
   previewPort: number,
-  hostPort: string,
-  locationHost: string,
+  hostOrigin: string,
 ): VmTarget | null {
   if (!url) return null;
   const raw = String(url);
@@ -80,8 +89,18 @@ export function resolveVmTarget(
 
   const loopback = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
 
+  // Is this the page doing the embedding? Compared by host, so the scheme and any
+  // default port don't matter.
+  let hostHost = '';
+  try {
+    hostHost = hostOrigin ? new URL(hostOrigin).host : '';
+  } catch {
+    hostHost = '';
+  }
+  const isEmbedder = hostHost !== '' && parsed.host === hostHost;
+
   // A genuinely foreign origin is never in-VM, whatever its path says.
-  if (!loopback && parsed.host !== locationHost) return null;
+  if (!loopback && !isEmbedder) return null;
 
   // An explicit /_sw/<port>/ prefix is an unambiguous routing instruction, so it
   // is honoured BEFORE the embedder-port exclusion below.
@@ -99,7 +118,7 @@ export function resolveVmTarget(
 
   // The embedding page's own origin is not an in-VM port. Its assets and its
   // CORS proxy must reach the real network.
-  if (loopback && hostPort && parsed.port === hostPort) return null;
+  if (isEmbedder) return null;
 
   return {
     port: loopback && parsed.port ? Number(parsed.port) : previewPort,

--- a/packages/ui/tests/preview-shims.test.ts
+++ b/packages/ui/tests/preview-shims.test.ts
@@ -19,7 +19,7 @@ function parses(src: string): boolean {
 
 describe('buildPreviewShim', () => {
   it('produces valid JavaScript with every patch', () => {
-    const src = buildPreviewShim({ port: 8081, hostPort: '5173' });
+    const src = buildPreviewShim({ port: 8081, hostOrigin: 'http://localhost:5173' });
     expect(parses(src)).toBe(true);
     expect(src).toContain('window.fetch=');
     expect(src).toContain('window.XMLHttpRequest=');
@@ -62,10 +62,12 @@ describe('buildPreviewShim', () => {
     expect(src).toContain(resolveVmTarget.toString());
   });
 
-  it('bakes in the port and the excluded host port', () => {
-    const src = buildPreviewShim({ port: 8081, hostPort: 5173 });
+  it('bakes in the preview port and the embedder origin', () => {
+    // The embedder origin must be baked in by the parent: a blob: document
+    // reports location.host as the empty string, so it cannot be read inside.
+    const src = buildPreviewShim({ port: 8081, hostOrigin: 'https://lifo.sh' });
     expect(src).toContain('var PORT=8081');
-    expect(src).toContain('HOST_PORT="5173"');
+    expect(src).toContain('HOST_ORIGIN="https://lifo.sh"');
   });
 
   // The asset patches call window.fetch, so shipping them without the fetch
@@ -85,6 +87,6 @@ describe('buildPreviewShim', () => {
   });
 
   it('shimScript stays a thin wrapper (back-compat)', () => {
-    expect(shimScript(8081, '5173')).toBe(buildPreviewShim({ port: 8081, hostPort: '5173' }));
+    expect(shimScript(8081, 'http://localhost:5173')).toBe(buildPreviewShim({ port: 8081, hostOrigin: 'http://localhost:5173' }));
   });
 });

--- a/packages/ui/tests/vm-routing.test.ts
+++ b/packages/ui/tests/vm-routing.test.ts
@@ -9,8 +9,10 @@ import { resolveVmTarget } from '../src/vm-routing.js';
  * so testing it here tests what actually runs in the sandboxed document.
  */
 const PREVIEW = 8081;
-const resolve = (url: unknown, hostPort = '', locationHost = '') =>
-  resolveVmTarget(url, PREVIEW, hostPort, locationHost);
+/** `hostOrigin` is the EMBEDDING page's origin, captured in the parent document. */
+const resolve = (url: unknown, hostOrigin = '') => resolveVmTarget(url, PREVIEW, hostOrigin);
+const DEV = 'http://localhost:5173';
+const PROD = 'https://lifo.sh';
 
 describe('resolveVmTarget', () => {
   it('sends a root-absolute path to the preview port', () => {
@@ -71,10 +73,10 @@ describe('resolveVmTarget', () => {
   // naive "loopback ⇒ in-VM" rule sent requests for the playground's own origin
   // (and its /_cors proxy) to a non-existent in-VM port 5173.
   it('does not tunnel the embedding page’s own origin', () => {
-    expect(resolve('http://localhost:5173/assets/x.png', '5173')).toBeNull();
-    expect(resolve('http://localhost:5173/_cors?url=https://x.dev/y', '5173')).toBeNull();
+    expect(resolve('http://localhost:5173/assets/x.png', DEV)).toBeNull();
+    expect(resolve('http://localhost:5173/_cors?url=https://x.dev/y', DEV)).toBeNull();
     // …while a genuine sibling service on another loopback port still routes.
-    expect(resolve('http://localhost:54321/rest/v1/todos', '5173')).toEqual({
+    expect(resolve('http://localhost:54321/rest/v1/todos', DEV)).toEqual({
       port: 54321,
       path: '/rest/v1/todos',
     });
@@ -87,30 +89,57 @@ describe('resolveVmTarget', () => {
   // network and a registered service worker answered it: the SW-free preview
   // was quietly depending on a service worker.
   it('tunnels an embedder-origin URL that carries a /_sw/<port>/ prefix', () => {
-    expect(resolve('http://localhost:5173/_sw/54321/rest/v1/todos?select=*', '5173')).toEqual({
+    expect(resolve('http://localhost:5173/_sw/54321/rest/v1/todos?select=*', DEV)).toEqual({
       port: 54321,
       path: '/rest/v1/todos?select=*',
     });
     // …while the same origin WITHOUT the prefix still goes to the real network.
-    expect(resolve('http://localhost:5173/_cors?url=https://x.dev', '5173')).toBeNull();
-    expect(resolve('http://localhost:5173/assets/x.png', '5173')).toBeNull();
+    expect(resolve('http://localhost:5173/_cors?url=https://x.dev', DEV)).toBeNull();
+    expect(resolve('http://localhost:5173/assets/x.png', DEV)).toBeNull();
   });
 
   it('honours the boxId form on the embedder origin too', () => {
-    expect(resolve('http://localhost:5173/_sw/box_ab12/54321/auth/v1/token', '5173')).toEqual({
+    expect(resolve('http://localhost:5173/_sw/box_ab12/54321/auth/v1/token', DEV)).toEqual({
       port: 54321,
       path: '/auth/v1/token',
     });
   });
 
   it('never tunnels a foreign origin, even with a /_sw/ path', () => {
-    expect(resolve('https://evil.example.com/_sw/54321/rest/v1/todos', '5173')).toBeNull();
+    expect(resolve('https://evil.example.com/_sw/54321/rest/v1/todos', DEV)).toBeNull();
   });
 
-  it('tunnels a same-origin non-loopback URL to the preview port', () => {
-    expect(resolve('https://preview.example.dev/assets/x.png', '', 'preview.example.dev')).toEqual({
-      port: 8081,
-      path: '/assets/x.png',
+  // Regression: the embedder check used to compare against `location.host`, which
+  // is the empty string inside a blob: document. Every non-loopback embedder was
+  // therefore treated as foreign, so a deployed site's own
+  // https://<site>/_sw/<port>/… URL skipped the tunnel — while localhost worked,
+  // because the embedder happened to be loopback. Broken in production only.
+  it('tunnels a DEPLOYED embedder origin carrying a /_sw/<port>/ prefix', () => {
+    expect(resolve('https://lifo.sh/_sw/54321/rest/v1/todos', PROD)).toEqual({
+      port: 54321,
+      path: '/rest/v1/todos',
+    });
+    expect(resolve('https://lifo.sh/_sw/box_ab12/54321/rest/v1/todos', PROD)).toEqual({
+      port: 54321,
+      path: '/rest/v1/todos',
+    });
+  });
+
+  it('sends a deployed embedder’s own assets to the real network', () => {
+    expect(resolve('https://lifo.sh/assets/x.png', PROD)).toBeNull();
+    expect(resolve('https://lifo.sh/_cors?url=https://x.dev', PROD)).toBeNull();
+  });
+
+  it('still rejects a foreign origin when deployed', () => {
+    expect(resolve('https://evil.example.com/_sw/54321/x', PROD)).toBeNull();
+    expect(resolve('https://cdn.example.com/lib.js', PROD)).toBeNull();
+  });
+
+  it('routes a sibling loopback port even when the embedder is deployed', () => {
+    // The VM's ports are always loopback, whatever origin the page is served from.
+    expect(resolve('http://localhost:54321/rest/v1/todos', PROD)).toEqual({
+      port: 54321,
+      path: '/rest/v1/todos',
     });
   });
 });


### PR DESCRIPTION
**0.8.1's routing fix only worked on localhost.** Found while wiring this into rapidnative-website, whose editor embeds the preview from a deployed origin.

## The bug

The SW-free preview decided whether a URL belonged to the embedding page by comparing against `location.host` — read **inside** the preview document. In a `blob:` document `location.host` is the empty string; only `location.origin` survives. Verified in a real browser:

```
inside a blob: iframe on http://localhost:5173
-> { host: "", origin: "http://localhost:5173", protocol: "blob:" }
```

So every non-loopback embedder was treated as a **foreign origin** and never tunnelled. Locally the embedder is `localhost:5173`, which is loopback, so it passed — the bug is production-only:

| deployment | app requests | before |
| --- | --- | --- |
| `https://lifo.sh` | `https://lifo.sh/_sw/54321/…` | not tunnelled → network → the registered service worker answered it, so it **looked fine while not being SW-free at all** |
| a host that unregisters `sw.js` | `https://<site>/_sw/<boxId>/54321/…` | not tunnelled, and nothing answers it → the app's API calls simply fail |

That second row is rapidnative-website: it deliberately unregisters `sw.js`, so its Expo app's database calls never reach the in-VM tinbase.

## The fix

The embedder's origin is captured in the **parent** document, where `location.host` is real, and baked into the shim. A URL on that origin is same-origin — a `/_sw/<port>/` prefix on it is ours to route; without a prefix it's the embedder's own asset and goes to the real network. Loopback is still accepted for local dev, and a foreign origin is still rejected even when its path contains `/_sw/`.

Verified against the **built dist** for three deployment shapes:

| embedder | URL | result |
| --- | --- | --- |
| `http://localhost:5173` | `…/_sw/54321/rest/v1/todos` | port 54321 |
| `https://lifo.sh` | `…/_sw/54321/rest/v1/todos` | port 54321 |
| `https://lifo.sh` | `…/_sw/box_ab12/54321/rest/v1/todos` | port 54321 |
| `https://lifo.sh` | `…/assets/x.png` | real network |
| `https://lifo.sh` | `https://evil.example.com/_sw/54321/x` | real network |
| `https://rapidnative.com` | `…/_sw/box_9f/54321/rest/v1/todos` | port 54321 |
| any | `http://localhost:54321/rest/v1/todos` | port 54321 |

## Signature change

Two exports introduced in 0.8.0 (one day old, no external consumers yet):

```diff
- resolveVmTarget(url, previewPort, hostPort, locationHost)
+ resolveVmTarget(url, previewPort, hostOrigin)

- buildPreviewShim({ port, hostPort: location.port })
+ buildPreviewShim({ port, hostOrigin: location.origin })
```

Comparing by *port* could never distinguish a deployed embedder (which has no port) from an in-VM one, so the port form was unfixable rather than merely awkward. `mountNoSwPreview` and `PreviewBrowser` are unaffected — they pass this themselves, so anyone using those (including rapidnative) needs no code change.

Shipping as a **patch** deliberately: these exports are days old with no external users, and a `minor` would be escalated to `1.0.0` by the core↔ui peer relationship. Flagging it rather than burying it.

## Verification

- **28 ui tests** (4 new: deployed embedder with a prefix, its own assets, a foreign origin while deployed, and a sibling loopback port while deployed)
- 27 core tests, `pnpm build` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)