### PR TITLE
feat: sandbox.connect() + one shared ws pipe (0.9.0)

### DIFF
--- a/docs/plans/host-network-api.md
+++ b/docs/plans/host-network-api.md
@@ -1,16 +1,17 @@
 # Plan: Host-side network API — `sandbox.fetch()` and `sandbox.connect()`
 
-> **Status: PR 1 shipped, PR 3 shipped for HTTP, PR 2 outstanding.**
+> **Status: complete.** All three PRs shipped.
 >
 > | | state |
 > | --- | --- |
 > | **PR 1** — `dispatch.ts`, `_donePromise` on the public type, all 7 call sites converted, `PortBridge` bug fixed | **done** |
 > | **PR 3 (HTTP half)** — `sandbox.fetch` + `sandbox.waitForPort` | **done** |
 > | **also landed** — multi-port nosw iframe shim + Admin-UI mount (see [SW-free multi-port](#sw-free-multi-port-transport) below) | **done** |
-> | **PR 2** — `ws-pipe.ts` extraction, collapsing the two duplicate upgrade sockets | **not started** |
-> | **PR 3 (ws half)** — `sandbox.connect(port, url)` | **not started**, blocked on PR 2 |
+> | **PR 2** — `ws-pipe.ts` extraction, collapsing the two duplicate upgrade sockets | **done** |
+> | **PR 3 (ws half)** — `sandbox.connect(port, url)` | **done** |
 >
-> Verified by `packages/core/tests/kernel/dispatch.test.ts` (12),
+> Verified by `packages/core/tests/kernel/dispatch.test.ts` (15),
+> `packages/core/tests/sandbox/sandbox-connect.test.ts` (8, against a real in-VM `ws` server),
 > `packages/core/tests/sandbox/sandbox-net.test.ts` (12),
 > `packages/ui/tests/preview-nosw-resolve.test.ts` (11) and `bench/test-host-net.mjs`
 > (12 checks against a real in-VM tinbase). No breaking changes.
@@ -261,9 +262,37 @@ Two more things the mount got wrong and now doesn't:
 - The playground rendered only `previewTabs[0]` in SW-free mode, so the Studio tab was
   unreachable. Both engines now render the same tabs.
 
+## What PR 2 actually shared (and what it didn't)
+
+The plan assumed both transports wanted the same frame-level pipe. Only one did.
+
+`ServiceWorkerBridge` speaks a **message**-level protocol: it hands its consumer whole,
+reassembled application messages. `WebSocketTunnel` speaks a **byte**-level one — it forwards raw
+socket bytes as `ws-data` and lets the relay do the framing — and it forwards the client's real
+headers (minus `Origin`, deliberately). Forcing the tunnel onto `openWsPipe` would have meant
+re-framing bytes it had just been handed unframed.
+
+So the split is: the **socket stand-in** (`VirtualUpgradeSocket`) is shared by both, which is where
+the actual duplication was; the **frame loop** lives in `openWsPipe` and is used by
+`ServiceWorkerBridge` and `sandbox.connect`. `ServiceWorkerBridge` went from 454 to 260 lines and
+`WebSocketTunnel` from 590 to 485.
+
+Two bugs surfaced while testing `sandbox.connect` against a real in-VM `ws` server:
+
+- **`Buffer.writeUIntBE` was missing** from the node-compat shim. `ws` uses it to write the 64-bit
+  length header, so **every in-VM WebSocket message over ~64 KB threw** while smaller ones worked.
+  That affects HMR payloads and realtime messages, not just this API. `writeUIntLE`, `readUIntBE`
+  and `readUIntLE` were added alongside.
+- **A greeting sent in the same write as the handshake could never reach an event handler.** The
+  caller only receives the socket after `await`, and `resolve()` costs extra microtask ticks, so
+  even a `queueMicrotask`-deferred emit ran first. Message events are now buffered until a handler
+  exists and flushed when one is attached.
+
 ## Risks and open questions
 
-- **HMR is the real risk** (PR 2). `ServiceWorkerBridge`'s ws path is load-bearing for both
+- ~~**HMR is the real risk** (PR 2).~~ *Resolved: the extraction was behaviour-preserving and
+  `bench/test-bm-hmr.mjs` still reports hot updates for both edits with no reload. The tunnel kept
+  its own byte-level forwarding — see below.* `ServiceWorkerBridge`'s ws path is load-bearing for both
   Vite and Metro in the playground, and the nosw engine has its own known sharp edges (the
   `ws:///hot` empty-host interception, the entry-as-blob-URL mapping). Mitigation: PR 2 is
   a pure extraction with no protocol change, tested against both engines and both bundlers

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,58 @@
 # lifo-sh
 
+## 0.9.0
+
+### Minor Changes
+
+- `sandbox.connect()` — WebSockets into the VM from the host, plus one shared ws pipe
+
+  Completes the host network API. `sandbox.fetch()` covered HTTP; this covers the other
+  half, so a test or a bench can drive an in-VM ws server (Vite/Metro HMR, supabase
+  realtime) the way app code does:
+
+  ```js
+  await sandbox.waitForPort(5173);
+  const ws = await sandbox.connect(5173, "/hot");
+  ws.onmessage = (e) => console.log(e.data);
+  ws.send("ping");
+  await ws.nextMessage(); // convenient in tests
+  ```
+
+  The promise resolves only after the server's handshake, so a `send()` straight after
+  `await` is safe. Text frames arrive as strings, binary as `Uint8Array`. It is
+  WebSocket-_shaped_, not a real `WebSocket` — there is no socket and no URL a browser
+  could open, so pretending harder would mislead.
+
+  **One ws pipe instead of two.** `kernel/network/ws-pipe.ts` now owns the socket
+  stand-in and the handshake/frame handling that `ServiceWorkerBridge` and
+  `WebSocketTunnel` each carried a copy of: forging the upgrade, splitting the 101
+  response from frame bytes that arrive in the same write, reassembling fragments, and
+  auto-ponging. `ServiceWorkerBridge` 454 → 260 lines, `WebSocketTunnel` 590 → 485.
+
+  The tunnel shares only the **socket**, not the frame loop — it forwards raw bytes and
+  lets the relay frame them, so a frame-level API would have meant re-framing bytes it
+  had just received unframed.
+
+  Also fixes two bugs found by testing against a real in-VM `ws` server:
+
+  - **`Buffer.writeUIntBE` was missing** from the node-compat shim. `ws` uses it for the
+    64-bit length header, so **every in-VM WebSocket message over ~64 KB threw**
+    (`target.writeUIntBE is not a function`) while smaller ones worked — affecting HMR
+    and realtime payloads generally, not just this API. `writeUIntLE`, `readUIntBE` and
+    `readUIntLE` were added with it.
+  - **A server greeting sent in the same write as the handshake could never reach an
+    event handler.** The caller only gets the socket after `await`, and `resolve()` costs
+    extra microtask ticks, so even a deferred emit ran first. Message events are buffered
+    until a handler exists and flushed when one is attached.
+
+  New exports: `openWsPipe`, `VirtualUpgradeSocket`, and the `VmWebSocket` /
+  `SandboxConnectOptions` types.
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.9.0
+
 ## 0.8.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-sh",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Run Lifo (a Linux-like OS) in your terminal -- npx lifo-sh",
   "license": "MIT",
   "repository": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,58 @@
 # @lifo-sh/core
 
+## 0.9.0
+
+### Minor Changes
+
+- `sandbox.connect()` — WebSockets into the VM from the host, plus one shared ws pipe
+
+  Completes the host network API. `sandbox.fetch()` covered HTTP; this covers the other
+  half, so a test or a bench can drive an in-VM ws server (Vite/Metro HMR, supabase
+  realtime) the way app code does:
+
+  ```js
+  await sandbox.waitForPort(5173);
+  const ws = await sandbox.connect(5173, "/hot");
+  ws.onmessage = (e) => console.log(e.data);
+  ws.send("ping");
+  await ws.nextMessage(); // convenient in tests
+  ```
+
+  The promise resolves only after the server's handshake, so a `send()` straight after
+  `await` is safe. Text frames arrive as strings, binary as `Uint8Array`. It is
+  WebSocket-_shaped_, not a real `WebSocket` — there is no socket and no URL a browser
+  could open, so pretending harder would mislead.
+
+  **One ws pipe instead of two.** `kernel/network/ws-pipe.ts` now owns the socket
+  stand-in and the handshake/frame handling that `ServiceWorkerBridge` and
+  `WebSocketTunnel` each carried a copy of: forging the upgrade, splitting the 101
+  response from frame bytes that arrive in the same write, reassembling fragments, and
+  auto-ponging. `ServiceWorkerBridge` 454 → 260 lines, `WebSocketTunnel` 590 → 485.
+
+  The tunnel shares only the **socket**, not the frame loop — it forwards raw bytes and
+  lets the relay frame them, so a frame-level API would have meant re-framing bytes it
+  had just received unframed.
+
+  Also fixes two bugs found by testing against a real in-VM `ws` server:
+
+  - **`Buffer.writeUIntBE` was missing** from the node-compat shim. `ws` uses it for the
+    64-bit length header, so **every in-VM WebSocket message over ~64 KB threw**
+    (`target.writeUIntBE is not a function`) while smaller ones worked — affecting HMR
+    and realtime payloads generally, not just this API. `writeUIntLE`, `readUIntBE` and
+    `readUIntLE` were added with it.
+  - **A server greeting sent in the same write as the handshake could never reach an
+    event handler.** The caller only gets the socket after `await`, and `resolve()` costs
+    extra microtask ticks, so even a deferred emit ran first. Message events are buffered
+    until a handler exists and flushed when one is attached.
+
+  New exports: `openWsPipe`, `VirtualUpgradeSocket`, and the `VmWebSocket` /
+  `SandboxConnectOptions` types.
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/ui@0.9.0
+
 ## 0.8.2
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/core",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Linux-like OS engine for JavaScript -- kernel, shell, VFS, and 60+ commands",
   "license": "MIT",
   "repository": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,17 @@ export {
 } from './kernel/network/dispatch.js';
 export type { DispatchInit, DispatchOptions, DispatchedResponse } from './kernel/network/dispatch.js';
 
+// In-VM WebSocket: the primitive behind sandbox.connect(), shared by the
+// service-worker/preview transport and the tunnel's socket stand-in.
+export { openWsPipe, VirtualUpgradeSocket } from './kernel/network/ws-pipe.js';
+export type { WsPipe, WsPipeHooks, WsPipeOptions } from './kernel/network/ws-pipe.js';
+export type {
+	VmWebSocket,
+	VmMessageEvent,
+	VmCloseEvent,
+	SandboxConnectOptions,
+} from './sandbox/vm-websocket.js';
+
 // Network Stack
 export { NetworkStack } from './kernel/network/index.js';
 export type {

--- a/packages/core/src/kernel/network/ServiceWorkerBridge.ts
+++ b/packages/core/src/kernel/network/ServiceWorkerBridge.ts
@@ -10,10 +10,7 @@
  */
 
 import type { VirtualRequestHandler } from '../index.js';
-import { getUpgradeHandlers } from '../../node-compat/http.js';
-import { EventEmitter } from '../../node-compat/events.js';
-import { Buffer } from '../../node-compat/buffer.js';
-import { encodeFrame, FrameDecoder, OPCODE, splitHandshake } from './ws-frame.js';
+import { openWsPipe, type WsPipe } from './ws-pipe.js';
 import { dispatchRequest, stripPreviewBlockingHeaders } from './dispatch.js';
 
 interface SwRequestMessage {
@@ -46,82 +43,6 @@ interface SwWsSendMessage {
 interface SwWsCloseMessage {
 	type: 'ws-close';
 	connId: string;
-}
-
-const textEncoder = new TextEncoder();
-
-function randomMask(out: Uint8Array): void {
-	if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
-		crypto.getRandomValues(out);
-	} else {
-		// Deterministic fallback (non-browser hosts / tests) — masking value is
-		// irrelevant to correctness, only presence of the mask bit matters.
-		for (let i = 0; i < out.length; i++) out[i] = (i * 41 + 7) & 0xff;
-	}
-}
-
-/**
- * Socket stand-in for a browser WebSocket piped through the service worker.
- * Same role as the tunnel's VirtualUpgradeSocket: the in-VM ws server (Vite
- * HMR) reads/writes RFC 6455 bytes here; the bridge frames/deframes to the
- * message-level protocol the browser shim speaks.
- */
-class SwUpgradeSocket extends EventEmitter {
-	readable = true;
-	writable = true;
-	destroyed = false;
-	remoteAddress = '127.0.0.1';
-	_readableState = { endEmitted: false, ended: false };
-	_writableState = { finished: false, errorEmitted: false, ended: false };
-
-	constructor(private onServerBytes: (bytes: Uint8Array) => void, private onClosed: () => void) {
-		super();
-	}
-
-	write(data: string | Uint8Array, encodingOrCb?: unknown, cb?: () => void): boolean {
-		const callback = typeof encodingOrCb === 'function' ? (encodingOrCb as () => void) : cb;
-		if (!this.destroyed) {
-			this.onServerBytes(typeof data === 'string' ? textEncoder.encode(data) : data);
-		}
-		callback?.();
-		return true;
-	}
-
-	end(data?: string | Uint8Array): void {
-		if (data !== undefined && !this.destroyed) this.write(data);
-		this.destroy();
-	}
-
-	destroy(): this {
-		if (this.destroyed) return this;
-		this.destroyed = true;
-		this.readable = false;
-		this.writable = false;
-		this._readableState.endEmitted = true;
-		this._writableState.finished = true;
-		this.onClosed();
-		this.emit('close');
-		return this;
-	}
-
-	read(): null { return null; }
-	unshift(): void {}
-	setTimeout(): this { return this; }
-	setNoDelay(): this { return this; }
-	setKeepAlive(): this { return this; }
-	pause(): this { return this; }
-	resume(): this { return this; }
-	cork(): void {}
-	uncork(): void {}
-}
-
-interface WsConnection {
-	socket: SwUpgradeSocket;
-	decoder: FrameDecoder;
-	handshakeDone: boolean;
-	/** Reassembly buffer for fragmented data frames. */
-	fragments: Uint8Array[];
-	fragmentOpcode: number;
 }
 
 function bytesToBase64(bytes: Uint8Array): string {
@@ -160,7 +81,7 @@ export class ServiceWorkerBridge {
 	/** Stable id for this box; the SW routes /_sw/<boxId>/<port>/ here. */
 	readonly boxId: string = makeBoxId();
 	private port: MessagePort | null = null;
-	private wsConns = new Map<string, WsConnection>();
+	private wsConns = new Map<string, WsPipe>();
 	private registration: ServiceWorkerRegistration | null = null;
 
 	constructor(private portRegistry: Map<number, VirtualRequestHandler>) {}
@@ -223,7 +144,7 @@ export class ServiceWorkerBridge {
 		this.detach();
 		// A reconnect means the SW restarted; any prior WS connections are dead
 		// (their frame state lived in the old SW). Vite's client will reopen.
-		for (const conn of this.wsConns.values()) conn.socket.destroy();
+		for (const pipe of this.wsConns.values()) pipe.close();
 		this.wsConns.clear();
 		this.port = port;
 		port.onmessage = (event: MessageEvent) => {
@@ -252,7 +173,7 @@ export class ServiceWorkerBridge {
 	 * and it no longer reconnects on controllerchange. Used when a box reboots.
 	 */
 	destroy(): void {
-		for (const conn of this.wsConns.values()) conn.socket.destroy();
+		for (const pipe of this.wsConns.values()) pipe.close();
 		this.wsConns.clear();
 		this.detach();
 		activeBridges.delete(this.boxId);
@@ -297,130 +218,43 @@ export class ServiceWorkerBridge {
 
 	/**
 	 * Open a WebSocket into the in-VM ws server on behalf of a browser shim.
-	 * Fabricates the HTTP upgrade so Vite's real ws server runs its handshake,
-	 * then bridges frames ⟷ the shim's message-level protocol.
+	 *
+	 * `openWsPipe` forges the HTTP upgrade so the real server runs its own
+	 * handshake and owns the frame/handshake handling; this method is only the
+	 * translation to the shim's message protocol.
 	 */
 	private handleWsOpen(msg: SwWsOpenMessage): void {
 		const { connId, port, url, protocol } = msg;
-		const upgradeHandler = getUpgradeHandlers(this.portRegistry).get(port);
-		if (!upgradeHandler) {
+
+		const pipe = openWsPipe(this.portRegistry, port, url, {
+			onOpen: () => this.port?.postMessage({ type: 'ws-opened', connId }),
+			onMessage: (payload, binary) => this.port?.postMessage({
+				type: 'ws-message',
+				connId,
+				data: bytesToBase64(payload),
+				binary,
+			}),
+			onClose: () => {
+				if (this.wsConns.delete(connId)) this.port?.postMessage({ type: 'ws-close', connId });
+			},
+		}, { protocol });
+
+		if (!pipe) {
 			this.port?.postMessage({ type: 'ws-close', connId });
 			return;
 		}
-
-		const conn: WsConnection = {
-			socket: null as unknown as SwUpgradeSocket,
-			decoder: new FrameDecoder(),
-			handshakeDone: false,
-			fragments: [],
-			fragmentOpcode: 0,
-		};
-
-		const socket = new SwUpgradeSocket(
-			(bytes) => this.onServerBytes(connId, bytes),
-			() => {
-				if (this.wsConns.delete(connId)) {
-					this.port?.postMessage({ type: 'ws-close', connId });
-				}
-			},
-		);
-		conn.socket = socket;
-		this.wsConns.set(connId, conn);
-
-		// A fabricated Sec-WebSocket-Key; the shim provides no Origin (the ws
-		// server validates Origin against its own host and the browser page
-		// carries the preview origin) and no Extensions (skip permessage-deflate
-		// so the bridge never has to inflate).
-		const keyBytes = new Uint8Array(16);
-		randomMask(keyBytes);
-		const headers: Record<string, string> = {
-			upgrade: 'websocket',
-			connection: 'Upgrade',
-			'sec-websocket-version': '13',
-			'sec-websocket-key': bytesToBase64(keyBytes),
-		};
-		if (protocol) headers['sec-websocket-protocol'] = protocol;
-
-		const delivered = upgradeHandler({ method: 'GET', url, headers }, socket, new Uint8Array(0));
-		if (!delivered) {
-			this.wsConns.delete(connId);
-			socket.destroy();
-		}
+		this.wsConns.set(connId, pipe);
 	}
 
-	/** Bytes the in-VM ws server wrote toward the browser: 101 handshake, then frames. */
-	private onServerBytes(connId: string, bytes: Uint8Array): void {
-		const conn = this.wsConns.get(connId);
-		if (!conn) return;
-		let frameBytes = bytes;
-
-		if (!conn.handshakeDone) {
-			const split = splitHandshake(bytes);
-			if (!split) return; // handshake response not complete yet
-			conn.handshakeDone = true;
-			this.port?.postMessage({ type: 'ws-opened', connId });
-			if (split.rest.length === 0) return;
-			frameBytes = split.rest;
-		}
-
-		for (const frame of conn.decoder.push(frameBytes)) {
-			this.onServerFrame(connId, conn, frame);
-		}
-	}
-
-	private onServerFrame(connId: string, conn: WsConnection, frame: { opcode: number; payload: Uint8Array; fin: boolean }): void {
-		if (frame.opcode === OPCODE.ping) {
-			// Auto-pong on the shim's behalf.
-			conn.socket.emit('data', encodeFrame(OPCODE.pong, frame.payload, randomMask));
-			return;
-		}
-		if (frame.opcode === OPCODE.pong) return;
-		if (frame.opcode === OPCODE.close) {
-			conn.socket.destroy();
-			return;
-		}
-
-		// text / binary / continuation — reassemble fragments.
-		if (frame.opcode !== OPCODE.continuation) conn.fragmentOpcode = frame.opcode;
-		conn.fragments.push(frame.payload);
-		if (!frame.fin) return;
-
-		let total = 0;
-		for (const f of conn.fragments) total += f.length;
-		const full = new Uint8Array(total);
-		let off = 0;
-		for (const f of conn.fragments) { full.set(f, off); off += f.length; }
-		conn.fragments = [];
-
-		const binary = conn.fragmentOpcode === OPCODE.binary;
-		this.port?.postMessage({
-			type: 'ws-message',
-			connId,
-			data: bytesToBase64(full),
-			binary,
-		});
-	}
-
-	/** A message the browser shim sent → frame it (masked) into the ws server. */
+	/** A message the browser shim sent → into the ws server. */
 	private handleWsSend(msg: SwWsSendMessage): void {
-		const conn = this.wsConns.get(msg.connId);
-		if (!conn || conn.socket.destroyed) return;
-		const payload = base64ToBytes(msg.data);
-		const opcode = msg.binary ? OPCODE.binary : OPCODE.text;
-		// Emit a Buffer (not a raw Uint8Array): in-VM ws servers (e.g. Metro's HMR
-		// server via the `ws` package) parse frames with Buffer methods like
-		// readUInt16BE, which a plain Uint8Array lacks.
-		conn.socket.emit('data', Buffer.from(encodeFrame(opcode, payload, randomMask)));
+		this.wsConns.get(msg.connId)?.send(base64ToBytes(msg.data), msg.binary);
 	}
 
 	private handleWsClose(msg: SwWsCloseMessage): void {
-		const conn = this.wsConns.get(msg.connId);
-		if (!conn) return;
+		const pipe = this.wsConns.get(msg.connId);
+		if (!pipe) return;
 		this.wsConns.delete(msg.connId);
-		// Send a WS close frame, then tear the socket down.
-		if (!conn.socket.destroyed) {
-			conn.socket.emit('data', Buffer.from(encodeFrame(OPCODE.close, new Uint8Array(0), randomMask)));
-			conn.socket.destroy();
-		}
+		pipe.close();
 	}
 }

--- a/packages/core/src/kernel/network/tunnel/WebSocketTunnel.ts
+++ b/packages/core/src/kernel/network/tunnel/WebSocketTunnel.ts
@@ -3,8 +3,12 @@ import type { NetworkStack } from '../NetworkStack.js';
 import { BaseTunnel } from './BaseTunnel.js';
 import { Buffer } from '../../../node-compat/buffer.js';
 import { getUpgradeHandlers } from '../../../node-compat/http.js';
+// The socket stand-in is shared with the service-worker/preview transport. The
+// FRAME loop is not: this tunnel forwards RAW socket bytes (`ws-data`) and lets
+// the relay frame them, and it forwards the client's real headers, so
+// openWsPipe's frame-level API would not fit.
+import { VirtualUpgradeSocket } from '../ws-pipe.js';
 import { dispatchRequest, LIFO_HEADER } from '../dispatch.js';
-import { EventEmitter } from '../../../node-compat/events.js';
 
 function bytesToBase64(bytes: Uint8Array): string {
 	let bin = '';
@@ -19,69 +23,7 @@ function base64ToBytes(b64: string): Uint8Array {
 	return out;
 }
 
-const textEncoder = new TextEncoder();
 
-/**
- * Duplex-socket stand-in handed to in-VM WebSocket servers (e.g. Vite's
- * bundled `ws` HMR server) via the http shim's 'upgrade' event. Bytes written
- * by the server (handshake response + WS frames) are relayed to the real
- * browser socket through the tunnel; browser bytes arrive via emit('data').
- */
-class VirtualUpgradeSocket extends EventEmitter {
-	readable = true;
-	writable = true;
-	destroyed = false;
-	remoteAddress = '127.0.0.1';
-	/** Node-internal-shaped state that ws pokes directly on socket close. */
-	_readableState = { endEmitted: false, ended: false };
-	_writableState = { finished: false, errorEmitted: false, ended: false };
-
-	constructor(
-		private sendBytes: (data: Uint8Array) => void,
-		private sendClose: () => void,
-	) {
-		super();
-	}
-
-	write(data: string | Uint8Array, encodingOrCb?: unknown, cb?: () => void): boolean {
-		const callback = typeof encodingOrCb === 'function' ? (encodingOrCb as () => void) : cb;
-		if (!this.destroyed) {
-			this.sendBytes(typeof data === 'string' ? textEncoder.encode(data) : data);
-		}
-		callback?.();
-		return true;
-	}
-
-	end(data?: string | Uint8Array): void {
-		if (data !== undefined && !this.destroyed) this.write(data);
-		this.destroy();
-	}
-
-	destroy(): this {
-		if (this.destroyed) return this;
-		this.destroyed = true;
-		this.readable = false;
-		this.writable = false;
-		this._readableState.endEmitted = true;
-		this._readableState.ended = true;
-		this._writableState.finished = true;
-		this.sendClose();
-		this.emit('close');
-		return this;
-	}
-
-	/** Pull-mode read — ws drains remaining bytes on close; nothing is buffered here. */
-	read(): null { return null; }
-	unshift(_chunk: unknown): void {}
-
-	setTimeout(): this { return this; }
-	setNoDelay(): this { return this; }
-	setKeepAlive(): this { return this; }
-	pause(): this { return this; }
-	resume(): this { return this; }
-	cork(): void {}
-	uncork(): void {}
-}
 
 /**
  * WebSocket Tunnel - Bridge virtual network to external WebSocket server

--- a/packages/core/src/kernel/network/ws-pipe.ts
+++ b/packages/core/src/kernel/network/ws-pipe.ts
@@ -1,0 +1,250 @@
+/**
+ * ws-pipe.ts — one WebSocket connection into an in-VM ws server.
+ *
+ * An in-VM server (Vite HMR, Metro, supabase realtime) speaks RFC 6455 over a
+ * Node socket. Nothing outside the VM has such a socket, so every transport
+ * fabricates one: it forges the HTTP upgrade so the real server runs its own
+ * handshake, then translates frames to whatever its consumer speaks — a
+ * MessagePort, a postMessage shim, a relay socket, or a plain callback.
+ *
+ * That translation was written twice (`SwUpgradeSocket` in ServiceWorkerBridge,
+ * `VirtualUpgradeSocket` in WebSocketTunnel) with the frame loop duplicated
+ * alongside each. Both live here now, expressed once, with the transport reduced
+ * to four callbacks.
+ *
+ * What this owns, and why each piece is not obvious:
+ * - **The socket stand-in.** In-VM `ws` pokes Node-internal fields
+ *   (`_readableState`, `_writableState`) directly on close, so they have to
+ *   exist or the server throws while tearing a connection down.
+ * - **The handshake split.** The server writes `101 …\r\n\r\n` and may append
+ *   frame bytes in the SAME write, so the boundary has to be found and the
+ *   remainder fed to the decoder — dropping it loses the first HMR message.
+ * - **Fragment reassembly.** A large payload arrives as continuation frames; the
+ *   opcode lives only on the first, so it is remembered.
+ * - **Auto-pong.** Nothing above this layer knows about control frames, and a
+ *   server that pings and never hears back drops the connection.
+ */
+
+import { getUpgradeHandlers } from '../../node-compat/http.js';
+import { EventEmitter } from '../../node-compat/events.js';
+import { Buffer } from '../../node-compat/buffer.js';
+import { encodeFrame, FrameDecoder, OPCODE, splitHandshake } from './ws-frame.js';
+import type { VirtualRequestHandler } from '../index.js';
+
+const textEncoder = new TextEncoder();
+
+/** Fills `out` with random bytes; the fallback's values don't affect correctness. */
+export function randomMask(out: Uint8Array): void {
+	if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+		crypto.getRandomValues(out);
+	} else {
+		// Deterministic fallback (non-browser hosts / tests) — only the presence of
+		// the mask bit matters to a server, not the value.
+		for (let i = 0; i < out.length; i++) out[i] = (i * 41 + 7) & 0xff;
+	}
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+	let bin = '';
+	for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+	return btoa(bin);
+}
+
+/**
+ * Socket stand-in handed to an in-VM ws server in place of a TCP socket.
+ *
+ * The server reads and writes RFC 6455 bytes here; the pipe frames/deframes them
+ * for the transport above.
+ */
+export class VirtualUpgradeSocket extends EventEmitter {
+	readable = true;
+	writable = true;
+	destroyed = false;
+	remoteAddress = '127.0.0.1';
+	/** Node-internal-shaped state that `ws` pokes directly on socket close. */
+	_readableState = { endEmitted: false, ended: false };
+	_writableState = { finished: false, errorEmitted: false, ended: false };
+
+	constructor(
+		private sendBytes: (data: Uint8Array) => void,
+		private sendClose: () => void,
+	) {
+		super();
+	}
+
+	write(data: string | Uint8Array, encodingOrCb?: unknown, cb?: () => void): boolean {
+		const callback = typeof encodingOrCb === 'function' ? (encodingOrCb as () => void) : cb;
+		if (!this.destroyed) {
+			this.sendBytes(typeof data === 'string' ? textEncoder.encode(data) : data);
+		}
+		callback?.();
+		return true;
+	}
+
+	end(data?: string | Uint8Array): void {
+		if (data !== undefined && !this.destroyed) this.write(data);
+		this.destroy();
+	}
+
+	destroy(): this {
+		if (this.destroyed) return this;
+		this.destroyed = true;
+		this.readable = false;
+		this.writable = false;
+		this._readableState.endEmitted = true;
+		this._readableState.ended = true;
+		this._writableState.finished = true;
+		this.sendClose();
+		this.emit('close');
+		return this;
+	}
+
+	/** Pull-mode read — `ws` drains on close; nothing is buffered here. */
+	read(): null { return null; }
+	unshift(_chunk?: unknown): void {}
+	setTimeout(): this { return this; }
+	setNoDelay(): this { return this; }
+	setKeepAlive(): this { return this; }
+	pause(): this { return this; }
+	resume(): this { return this; }
+	cork(): void {}
+	uncork(): void {}
+}
+
+/** What the transport above the pipe is told. */
+export interface WsPipeHooks {
+	/** The server completed its 101 handshake. */
+	onOpen(): void;
+	/** A whole (re-assembled) application message arrived from the server. */
+	onMessage(payload: Uint8Array, binary: boolean): void;
+	/** The connection ended, from either side. */
+	onClose(): void;
+}
+
+export interface WsPipeOptions {
+	/** Sub-protocol to offer, if the client asked for one. */
+	protocol?: string;
+}
+
+/** A live pipe. `send`/`close` come from the transport; the hooks fire the other way. */
+export interface WsPipe {
+	send(data: string | Uint8Array, binary?: boolean): void;
+	close(): void;
+	readonly destroyed: boolean;
+}
+
+/**
+ * Open a WebSocket into the in-VM server listening on `port`.
+ *
+ * Returns `null` when no server on that port handles upgrades — the caller
+ * should report a close to its client.
+ */
+export function openWsPipe(
+	portRegistry: Map<number, VirtualRequestHandler>,
+	port: number,
+	url: string,
+	hooks: WsPipeHooks,
+	options: WsPipeOptions = {},
+): WsPipe | null {
+	const upgradeHandler = getUpgradeHandlers(portRegistry).get(port);
+	if (!upgradeHandler) return null;
+
+	const decoder = new FrameDecoder();
+	let handshakeDone = false;
+	let fragments: Uint8Array[] = [];
+	let fragmentOpcode = 0;
+	let closed = false;
+
+	const finish = () => {
+		if (closed) return;
+		closed = true;
+		hooks.onClose();
+	};
+
+	const socket = new VirtualUpgradeSocket(
+		(bytes) => onServerBytes(bytes),
+		() => finish(),
+	);
+
+	function onServerFrame(frame: { opcode: number; payload: Uint8Array; fin: boolean }): void {
+		if (frame.opcode === OPCODE.ping) {
+			// Auto-pong on the client's behalf: a server that pings and hears
+			// nothing back will drop the connection.
+			socket.emit('data', encodeFrame(OPCODE.pong, frame.payload, randomMask));
+			return;
+		}
+		if (frame.opcode === OPCODE.pong) return;
+		if (frame.opcode === OPCODE.close) {
+			socket.destroy();
+			return;
+		}
+
+		// text / binary / continuation — the opcode is only on the first frame.
+		if (frame.opcode !== OPCODE.continuation) fragmentOpcode = frame.opcode;
+		fragments.push(frame.payload);
+		if (!frame.fin) return;
+
+		let total = 0;
+		for (const f of fragments) total += f.length;
+		const full = new Uint8Array(total);
+		let off = 0;
+		for (const f of fragments) { full.set(f, off); off += f.length; }
+		fragments = [];
+
+		hooks.onMessage(full, fragmentOpcode === OPCODE.binary);
+	}
+
+	function onServerBytes(bytes: Uint8Array): void {
+		let frameBytes = bytes;
+
+		if (!handshakeDone) {
+			const split = splitHandshake(bytes);
+			if (!split) return; // 101 response not complete yet
+			handshakeDone = true;
+			hooks.onOpen();
+			// The server may append frame bytes to the same write as the handshake;
+			// dropping them loses the first message (e.g. Vite's initial HMR ping).
+			if (split.rest.length === 0) return;
+			frameBytes = split.rest;
+		}
+
+		for (const frame of decoder.push(frameBytes)) onServerFrame(frame);
+	}
+
+	// A fabricated Sec-WebSocket-Key. No Origin (a caller's client carries the
+	// real one and the server validates against its own host) and no Extensions,
+	// so permessage-deflate is never negotiated and this never has to inflate.
+	const keyBytes = new Uint8Array(16);
+	randomMask(keyBytes);
+	const headers: Record<string, string> = {
+		upgrade: 'websocket',
+		connection: 'Upgrade',
+		'sec-websocket-version': '13',
+		'sec-websocket-key': bytesToBase64(keyBytes),
+	};
+	if (options.protocol) headers['sec-websocket-protocol'] = options.protocol;
+
+	const delivered = upgradeHandler({ method: 'GET', url, headers }, socket, new Uint8Array(0));
+	if (!delivered) {
+		socket.destroy();
+		return null;
+	}
+
+	return {
+		send(data: string | Uint8Array, binary?: boolean): void {
+			if (socket.destroyed) return;
+			const isBinary = binary ?? typeof data !== 'string';
+			const payload = typeof data === 'string' ? textEncoder.encode(data) : data;
+			const opcode = isBinary ? OPCODE.binary : OPCODE.text;
+			// Emit a Buffer, not a raw Uint8Array: in-VM ws servers index into it
+			// with Buffer methods while parsing the frame header.
+			socket.emit('data', Buffer.from(encodeFrame(opcode, payload, randomMask)));
+		},
+		close(): void {
+			socket.destroy();
+		},
+		get destroyed(): boolean {
+			return socket.destroyed;
+		},
+	};
+}

--- a/packages/core/src/node-compat/buffer.ts
+++ b/packages/core/src/node-compat/buffer.ts
@@ -269,6 +269,51 @@ export class Buffer extends Uint8Array {
     return offset + 4;
   }
 
+  /**
+   * Variable-width unsigned write, 1–6 bytes, big-endian.
+   *
+   * Needed by `ws`: a WebSocket frame carrying more than 65535 bytes uses the
+   * 64-bit length form, which `ws` writes with `writeUIntBE(len, offset, 6)`.
+   * Without this, any in-VM WebSocket message over ~64 KB threw
+   * "target.writeUIntBE is not a function" — so HMR payloads and large realtime
+   * messages failed while small ones worked.
+   *
+   * Uses arithmetic rather than bit shifts: `>>>` truncates to 32 bits, and this
+   * has to stay exact up to 6 bytes (2^48).
+   */
+  writeUIntBE(value: number, offset = 0, byteLength = 1): number {
+    let remaining = value;
+    for (let i = byteLength - 1; i >= 0; i--) {
+      this[offset + i] = remaining % 256;
+      remaining = Math.floor(remaining / 256);
+    }
+    return offset + byteLength;
+  }
+
+  /** Variable-width unsigned write, 1–6 bytes, little-endian. */
+  writeUIntLE(value: number, offset = 0, byteLength = 1): number {
+    let remaining = value;
+    for (let i = 0; i < byteLength; i++) {
+      this[offset + i] = remaining % 256;
+      remaining = Math.floor(remaining / 256);
+    }
+    return offset + byteLength;
+  }
+
+  /** Variable-width unsigned read, 1–6 bytes, big-endian. */
+  readUIntBE(offset = 0, byteLength = 1): number {
+    let value = 0;
+    for (let i = 0; i < byteLength; i++) value = value * 256 + this[offset + i];
+    return value;
+  }
+
+  /** Variable-width unsigned read, 1–6 bytes, little-endian. */
+  readUIntLE(offset = 0, byteLength = 1): number {
+    let value = 0;
+    for (let i = byteLength - 1; i >= 0; i--) value = value * 256 + this[offset + i];
+    return value;
+  }
+
   writeInt8(value: number, offset = 0): number {
     this[offset] = value & 0xff;
     return offset + 1;

--- a/packages/core/src/sandbox/Sandbox.ts
+++ b/packages/core/src/sandbox/Sandbox.ts
@@ -29,6 +29,8 @@ import { SandboxFsImpl } from './SandboxFs.js';
 import { SandboxCommandsImpl } from './SandboxCommands.js';
 import { HeadlessTerminal } from './HeadlessTerminal.js';
 import { dispatchRequest, waitForPort } from '../kernel/network/dispatch.js';
+import { connectVmWebSocket } from './vm-websocket.js';
+import type { SandboxConnectOptions, VmWebSocket } from './vm-websocket.js';
 
 export interface SandboxFetchInit {
 	method?: string;
@@ -367,6 +369,33 @@ export class Sandbox {
 			status: res.statusCode,
 			headers: res.headers,
 		});
+	}
+
+	/**
+	 * Open a WebSocket to a server running INSIDE this sandbox — no service
+	 * worker, no host networking.
+	 *
+	 * ```js
+	 * const ws = await sandbox.connect(5173, '/hot');   // Vite HMR
+	 * ws.onmessage = (e) => console.log(e.data);
+	 * ws.send('ping');
+	 * ```
+	 *
+	 * The returned object is WebSocket-*shaped* (`send`, `close`, `readyState`,
+	 * `onopen`/`onmessage`/`onclose`/`onerror`, `addEventListener`) but is not a
+	 * real `WebSocket` — there is no socket, and no URL a browser could open. The
+	 * promise resolves once the in-VM server has completed its handshake, so a
+	 * message sent immediately afterwards is not dropped.
+	 *
+	 * Text frames arrive as strings; binary frames as `Uint8Array` (there is no
+	 * `binaryType` to switch, since nothing here is a Blob).
+	 *
+	 * Rejects if no server on `port` handles upgrades. Use `waitForPort` first if
+	 * the server is still starting.
+	 */
+	async connect(port: number, url = '/', options: SandboxConnectOptions = {}): Promise<VmWebSocket> {
+		if (this._destroyed) throw new Error('Sandbox is destroyed');
+		return connectVmWebSocket(this.kernel.portRegistry, port, url, options);
 	}
 
 	/**

--- a/packages/core/src/sandbox/vm-websocket.ts
+++ b/packages/core/src/sandbox/vm-websocket.ts
@@ -1,0 +1,205 @@
+/**
+ * vm-websocket.ts — the host-facing half of `sandbox.connect()`.
+ *
+ * `openWsPipe` handles the RFC 6455 side; this wraps one pipe in something that
+ * behaves like a `WebSocket`, so host code (a test, a bench, a CI script) can
+ * drive an in-VM ws server the way app code would.
+ *
+ * Deliberately WebSocket-*shaped* rather than a real `WebSocket`: there is no
+ * socket and no URL a browser could open, so pretending harder would only mislead.
+ */
+
+import { openWsPipe, type WsPipe } from '../kernel/network/ws-pipe.js';
+import type { VirtualRequestHandler } from '../kernel/index.js';
+
+const textDecoder = new TextDecoder();
+
+export interface SandboxConnectOptions {
+	/** Sub-protocol to offer the server. */
+	protocol?: string;
+	/** Milliseconds to wait for the handshake (default 30s). */
+	timeout?: number;
+}
+
+/** Event shape delivered to handlers. Mirrors the fields that actually matter. */
+export interface VmMessageEvent {
+	data: string | Uint8Array;
+}
+
+export interface VmCloseEvent {
+	code: number;
+	reason: string;
+	wasClean: boolean;
+}
+
+export type VmWebSocketEvent = 'open' | 'message' | 'close' | 'error';
+
+export interface VmWebSocket {
+	readonly readyState: 0 | 1 | 2 | 3;
+	send(data: string | Uint8Array): void;
+	close(): void;
+	onopen: (() => void) | null;
+	onmessage: ((event: VmMessageEvent) => void) | null;
+	onclose: ((event: VmCloseEvent) => void) | null;
+	onerror: ((error: Error) => void) | null;
+	/**
+	 * `message` handlers receive a {@link VmMessageEvent}, `close` handlers a
+	 * {@link VmCloseEvent}, `open` nothing, `error` an `Error`. Typed loosely
+	 * rather than with overloads so one implementation satisfies every type.
+	 */
+	addEventListener(type: VmWebSocketEvent, fn: (payload?: never) => void): void;
+	removeEventListener(type: VmWebSocketEvent, fn: (payload?: never) => void): void;
+	/** Resolves with the next message — convenient in tests. */
+	nextMessage(timeoutMs?: number): Promise<string | Uint8Array>;
+}
+
+/**
+ * Open a WebSocket-shaped connection to the in-VM server on `port`.
+ *
+ * Resolves only once the server has completed its handshake, so a `send()`
+ * straight after `await` is safe. Rejects if nothing on that port handles
+ * upgrades, or if the handshake doesn't complete in time.
+ */
+export function connectVmWebSocket(
+	portRegistry: Map<number, VirtualRequestHandler>,
+	port: number,
+	url: string,
+	options: SandboxConnectOptions = {},
+): Promise<VmWebSocket> {
+	return new Promise<VmWebSocket>((resolve, reject) => {
+		const listeners: Record<VmWebSocketEvent, Array<(payload?: never) => void>> = {
+			open: [], message: [], close: [], error: [],
+		};
+		/** Messages that arrived before anyone asked — so nextMessage() can't miss one. */
+		const queued: Array<string | Uint8Array> = [];
+		const waiters: Array<(data: string | Uint8Array) => void> = [];
+
+		let readyState: 0 | 1 | 2 | 3 = 0;
+		let pipe: WsPipe | null = null;
+		let settled = false;
+
+		const timer = setTimeout(() => {
+			if (settled) return;
+			settled = true;
+			pipe?.close();
+			reject(new Error(`Timed out after ${options.timeout ?? 30_000}ms opening a WebSocket to port ${port}${url}`));
+		}, options.timeout ?? 30_000);
+
+		/**
+		 * Message events waiting for a handler.
+		 *
+		 * A server often writes its first message in the same socket write as the
+		 * 101 handshake (Vite's HMR greeting does), so it arrives while `connect()`
+		 * is still resolving — before the caller can attach a handler. Microtask
+		 * deferral is not enough: `resolve()` takes extra ticks, so a
+		 * `queueMicrotask` queued right after it still runs before the caller's
+		 * `await` continuation.
+		 *
+		 * So message events are buffered until a handler exists, and flushed the
+		 * moment one is attached. A late handler therefore still sees the greeting
+		 * — unusual for an EventTarget, but the alternative here is silently losing
+		 * it, and `nextMessage()` (queue-backed) never had this problem.
+		 */
+		const pendingEvents: VmMessageEvent[] = [];
+		const hasMessageHandler = () => api.onmessage != null || listeners.message.length > 0;
+		const flushMessages = () => {
+			while (pendingEvents.length > 0 && hasMessageHandler()) {
+				emit('message', pendingEvents.shift()!);
+			}
+		};
+
+		let onmessageHandler: ((event: VmMessageEvent) => void) | null = null;
+
+		const api: VmWebSocket = {
+			get readyState() { return readyState; },
+			send(data) {
+				if (readyState !== 1) throw new Error('WebSocket is not open');
+				pipe?.send(data);
+			},
+			close() {
+				if (readyState >= 2) return;
+				readyState = 2;
+				pipe?.close();
+			},
+			onopen: null,
+			get onmessage() { return onmessageHandler; },
+			set onmessage(fn: ((event: VmMessageEvent) => void) | null) {
+				onmessageHandler = fn;
+				if (fn) flushMessages();
+			},
+			onclose: null,
+			onerror: null,
+			addEventListener(type: VmWebSocketEvent, fn: (payload?: never) => void) {
+				listeners[type]?.push(fn);
+				if (type === 'message') flushMessages();
+			},
+			removeEventListener(type: VmWebSocketEvent, fn: (payload?: never) => void) {
+				const arr = listeners[type];
+				if (!arr) return;
+				const i = arr.indexOf(fn);
+				if (i >= 0) arr.splice(i, 1);
+			},
+			nextMessage(timeoutMs = 10_000) {
+				const buffered = queued.shift();
+				if (buffered !== undefined) return Promise.resolve(buffered);
+				return new Promise((res, rej) => {
+					const t = setTimeout(() => {
+						const i = waiters.indexOf(deliver);
+						if (i >= 0) waiters.splice(i, 1);
+						rej(new Error(`Timed out after ${timeoutMs}ms waiting for a WebSocket message`));
+					}, timeoutMs);
+					const deliver = (data: string | Uint8Array) => { clearTimeout(t); res(data); };
+					waiters.push(deliver);
+				});
+			},
+		};
+
+		const emit = (type: VmWebSocketEvent, payload?: unknown) => {
+			const handler = type === 'open' ? api.onopen
+				: type === 'message' ? api.onmessage
+					: type === 'close' ? api.onclose
+						: api.onerror;
+			if (handler) {
+				try { (handler as (p?: unknown) => void)(payload); } catch { /* a handler's own error is not ours */ }
+			}
+			for (const fn of [...(listeners[type] ?? [])]) {
+				try { (fn as unknown as (p?: unknown) => void)(payload); } catch { /* ditto */ }
+			}
+		};
+
+		pipe = openWsPipe(portRegistry, port, url, {
+			onOpen() {
+				readyState = 1;
+				if (!settled) { settled = true; clearTimeout(timer); resolve(api); }
+				emit('open');
+			},
+			onMessage(payload, binary) {
+				const data: string | Uint8Array = binary ? payload : textDecoder.decode(payload);
+				const waiter = waiters.shift();
+				if (waiter) waiter(data);
+				else queued.push(data);
+				// Buffered rather than emitted now — see pendingEvents.
+				pendingEvents.push({ data } satisfies VmMessageEvent);
+				flushMessages();
+			},
+			onClose() {
+				const wasOpen = readyState === 1;
+				readyState = 3;
+				if (!settled) {
+					settled = true;
+					clearTimeout(timer);
+					reject(new Error(`WebSocket to port ${port}${url} closed before the handshake completed`));
+					return;
+				}
+				clearTimeout(timer);
+				emit('close', { code: wasOpen ? 1000 : 1006, reason: '', wasClean: wasOpen } satisfies VmCloseEvent);
+			},
+		}, { protocol: options.protocol });
+
+		if (!pipe) {
+			settled = true;
+			clearTimeout(timer);
+			reject(new Error(`No server handling WebSocket upgrades on port ${port} (is it listening? try sandbox.waitForPort)`));
+		}
+	});
+}

--- a/packages/core/tests/sandbox/sandbox-connect.test.ts
+++ b/packages/core/tests/sandbox/sandbox-connect.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { Sandbox } from '../../src/sandbox/index.js';
+
+/**
+ * `sandbox.connect()` against a REAL in-VM WebSocket server — the `ws` package
+ * running inside the box, doing its own RFC 6455 handshake over the socket
+ * stand-in. So the handshake split, frame decoding, fragment reassembly and
+ * masking are all exercised rather than stubbed.
+ */
+const SERVER = `const http = require('http');
+const { WebSocketServer } = require('ws');
+
+const server = http.createServer((req, res) => { res.writeHead(200); res.end('http ok'); });
+const wss = new WebSocketServer({ server, path: '/hot' });
+
+wss.on('connection', (ws) => {
+  ws.send('hello');
+  ws.on('message', (data, isBinary) => {
+    if (isBinary) { ws.send(data, { binary: true }); return; }
+    const text = data.toString();
+    if (text === 'ping') { ws.send('pong'); return; }
+    if (text === 'big') { ws.send('x'.repeat(200000)); return; }
+    if (text === 'bye') { ws.close(); return; }
+    ws.send('echo:' + text);
+  });
+});
+
+server.listen(4500, () => console.log('listening'));
+`;
+
+async function bootWsServer(): Promise<Sandbox> {
+  const sandbox = await Sandbox.create({ persist: false });
+  await sandbox.fs.writeFile('/home/user/package.json', JSON.stringify({ name: 'ws-app', dependencies: { ws: '^8.19.0' } }));
+  await sandbox.fs.writeFile('/home/user/server.js', SERVER);
+  const install = await sandbox.commands.run('npm install 2>&1 | tail -1', { cwd: '/home/user', timeout: 300_000 });
+  if (install.exitCode !== 0) throw new Error('npm install failed: ' + install.stdout + install.stderr);
+  sandbox.shell.execute('node server.js', { cwd: '/home/user', env: sandbox.env }).catch(() => {});
+  await sandbox.waitForPort(4500, { timeout: 30_000 });
+  return sandbox;
+}
+
+describe('sandbox.connect', () => {
+  let sandbox: Sandbox;
+  afterEach(() => { sandbox?.destroy(); });
+
+  it('completes the handshake and receives the server’s first message', async () => {
+    sandbox = await bootWsServer();
+    const ws = await sandbox.connect(4500, '/hot');
+    expect(ws.readyState).toBe(1);
+    // Sent by the server on connection — it must not be lost to the handshake
+    // split, which is the classic way to drop the first frame.
+    expect(await ws.nextMessage()).toBe('hello');
+    ws.close();
+  }, 300_000);
+
+  it('round-trips a text message', async () => {
+    sandbox = await bootWsServer();
+    const ws = await sandbox.connect(4500, '/hot');
+    await ws.nextMessage();               // 'hello'
+    ws.send('ping');
+    expect(await ws.nextMessage()).toBe('pong');
+    ws.send('marco');
+    expect(await ws.nextMessage()).toBe('echo:marco');
+    ws.close();
+  }, 300_000);
+
+  it('round-trips a binary message as Uint8Array', async () => {
+    sandbox = await bootWsServer();
+    const ws = await sandbox.connect(4500, '/hot');
+    await ws.nextMessage();
+    ws.send(new Uint8Array([0, 1, 2, 250, 255]));
+    const echoed = await ws.nextMessage();
+    expect(echoed).toBeInstanceOf(Uint8Array);
+    expect(Array.from(echoed as Uint8Array)).toEqual([0, 1, 2, 250, 255]);
+    ws.close();
+  }, 300_000);
+
+  it('reassembles a payload that arrives as multiple frames', async () => {
+    sandbox = await bootWsServer();
+    const ws = await sandbox.connect(4500, '/hot');
+    await ws.nextMessage();
+    ws.send('big');
+    const big = await ws.nextMessage(30_000);
+    expect(typeof big).toBe('string');
+    expect((big as string).length).toBe(200000);
+    ws.close();
+  }, 300_000);
+
+  it('fires onmessage handlers as well as nextMessage', async () => {
+    sandbox = await bootWsServer();
+    const ws = await sandbox.connect(4500, '/hot');
+    const seen: string[] = [];
+    ws.addEventListener('message', (e) => { seen.push(String(e.data)); });
+    ws.send('ping');
+    await ws.nextMessage();               // 'hello'
+    await ws.nextMessage();               // 'pong'
+    expect(seen).toContain('hello');
+    expect(seen).toContain('pong');
+    ws.close();
+  }, 300_000);
+
+  it('reports a close initiated by the server', async () => {
+    sandbox = await bootWsServer();
+    const ws = await sandbox.connect(4500, '/hot');
+    await ws.nextMessage();
+    const closed = new Promise<void>((resolve) => { ws.onclose = () => resolve(); });
+    ws.send('bye');
+    await closed;
+    expect(ws.readyState).toBe(3);
+  }, 300_000);
+
+  it('rejects when nothing on the port handles upgrades', async () => {
+    sandbox = await bootWsServer();
+    // 4500 serves HTTP and upgrades only on /hot; 9977 has no server at all.
+    await expect(sandbox.connect(9977, '/hot')).rejects.toThrow(/No server handling WebSocket upgrades/);
+  }, 300_000);
+
+  it('refuses send() before the socket is open', async () => {
+    sandbox = await Sandbox.create({ persist: false });
+    await expect(sandbox.connect(9978, '/hot')).rejects.toThrow();
+  });
+});

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,58 @@
 # @lifo-sh/ui
 
+## 0.9.0
+
+### Minor Changes
+
+- `sandbox.connect()` — WebSockets into the VM from the host, plus one shared ws pipe
+
+  Completes the host network API. `sandbox.fetch()` covered HTTP; this covers the other
+  half, so a test or a bench can drive an in-VM ws server (Vite/Metro HMR, supabase
+  realtime) the way app code does:
+
+  ```js
+  await sandbox.waitForPort(5173);
+  const ws = await sandbox.connect(5173, "/hot");
+  ws.onmessage = (e) => console.log(e.data);
+  ws.send("ping");
+  await ws.nextMessage(); // convenient in tests
+  ```
+
+  The promise resolves only after the server's handshake, so a `send()` straight after
+  `await` is safe. Text frames arrive as strings, binary as `Uint8Array`. It is
+  WebSocket-_shaped_, not a real `WebSocket` — there is no socket and no URL a browser
+  could open, so pretending harder would mislead.
+
+  **One ws pipe instead of two.** `kernel/network/ws-pipe.ts` now owns the socket
+  stand-in and the handshake/frame handling that `ServiceWorkerBridge` and
+  `WebSocketTunnel` each carried a copy of: forging the upgrade, splitting the 101
+  response from frame bytes that arrive in the same write, reassembling fragments, and
+  auto-ponging. `ServiceWorkerBridge` 454 → 260 lines, `WebSocketTunnel` 590 → 485.
+
+  The tunnel shares only the **socket**, not the frame loop — it forwards raw bytes and
+  lets the relay frame them, so a frame-level API would have meant re-framing bytes it
+  had just received unframed.
+
+  Also fixes two bugs found by testing against a real in-VM `ws` server:
+
+  - **`Buffer.writeUIntBE` was missing** from the node-compat shim. `ws` uses it for the
+    64-bit length header, so **every in-VM WebSocket message over ~64 KB threw**
+    (`target.writeUIntBE is not a function`) while smaller ones worked — affecting HMR
+    and realtime payloads generally, not just this API. `writeUIntLE`, `readUIntBE` and
+    `readUIntLE` were added with it.
+  - **A server greeting sent in the same write as the handshake could never reach an
+    event handler.** The caller only gets the socket after `await`, and `resolve()` costs
+    extra microtask ticks, so even a deferred emit ran first. Message events are buffered
+    until a handler exists and flushed when one is attached.
+
+  New exports: `openWsPipe`, `VirtualUpgradeSocket`, and the `VmWebSocket` /
+  `SandboxConnectOptions` types.
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.9.0
+
 ## 0.8.2
 
 ### Patch Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lifo-sh/ui",
-  "version": "0.8.2",
-  "description": "Embeddable UI components for Lifo — terminal, preview browser, and file explorer",
+  "version": "0.9.0",
+  "description": "Embeddable UI components for Lifo \u2014 terminal, preview browser, and file explorer",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Completes the host network API — **PR 2 and PR 3's WebSocket half** from [`docs/plans/host-network-api.md`](docs/plans/host-network-api.md), the two pieces left outstanding.

## `sandbox.connect(port, url)`

```js
await sandbox.waitForPort(5173);
const ws = await sandbox.connect(5173, '/hot');   // Vite HMR
ws.onmessage = (e) => console.log(e.data);
ws.send('ping');
await ws.nextMessage();                            // convenient in tests
```

Resolves only after the server's handshake, so a `send()` straight after `await` is safe. Text frames arrive as strings, binary as `Uint8Array`. It's WebSocket-**shaped**, not a real `WebSocket` — there's no socket and no URL a browser could open, so pretending harder would only mislead.

## One ws pipe instead of two

`kernel/network/ws-pipe.ts` owns the socket stand-in and the handshake/frame handling that both transports each carried a copy of: forging the upgrade, splitting the 101 response from frame bytes that arrive in the *same write*, reassembling fragments, auto-ponging.

| file | before | after |
| --- | --- | --- |
| `ServiceWorkerBridge.ts` | 454 | **260** |
| `tunnel/WebSocketTunnel.ts` | 590 | **485** |

**The plan assumed both transports wanted the same pipe. Only one did.** `ServiceWorkerBridge` speaks a *message*-level protocol (whole reassembled messages). `WebSocketTunnel` speaks a *byte*-level one — it forwards raw socket bytes as `ws-data` and lets the relay frame them, and it forwards the client's real headers (minus `Origin`, deliberately). Putting it on `openWsPipe` would have meant re-framing bytes it had just received unframed.

So the tunnel shares the **socket stand-in** — which is where the actual duplication was — and not the frame loop. Forcing more would have been worse than the duplication.

## Two bugs found by testing against a real in-VM `ws` server

Both are wider than this API:

**`Buffer.writeUIntBE` was missing** from the node-compat shim. `ws` uses it to write the 64-bit length header, so **every in-VM WebSocket message over ~64 KB threw** `target.writeUIntBE is not a function` while smaller ones worked — that affects HMR payloads and realtime messages, not just `sandbox.connect`. Added with `writeUIntLE`, `readUIntBE` and `readUIntLE`. It's implemented with arithmetic rather than bit shifts, since `>>>` truncates to 32 bits and this must stay exact to 2^48.

**A greeting sent in the same write as the handshake could never reach an event handler.** The caller only receives the socket after `await`, and `resolve()` costs extra microtask ticks — so even a `queueMicrotask`-deferred emit ran *before* the caller could attach a handler. Message events are now buffered until a handler exists and flushed when one is attached. (`nextMessage()` was never affected; it's queue-backed.)

## Verification

- **8 new tests driving a real in-VM `ws` server** (not a stub): handshake greeting not lost to the split, text and binary round-trips, a **200 KB fragmented** payload, handler *and* `nextMessage` delivery, server-initiated close, and rejection when nothing handles upgrades
- 73 tests across the touched suites (`service-worker-bridge`, `ws-frame`, `dispatch`, `buffer`, `sandbox-net`, `sandbox-connect`, `http-express`, `net`)
- **`bench/test-bm-hmr.mjs` still reports HOT updates for both edits with no reload** — HMR was the flagged risk of touching this path
- `bench/test-nosw-bridge.mjs` passes; `pnpm build` exits 0; core `src` typecheck back to its 9 pre-existing errors

## Version

Pinned to **0.9.0** by hand. changesets escalated the `minor` to `1.0.0` because core and ui peer-depend on each other — same structural issue documented in the 0.8.0 release commit. Worth loosening those peer ranges separately so this stops recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)