### PR TITLE
feat: publish in-VM ports on the host + one portable snapshot format (0.10.0)

### DIFF
--- a/bench/test-snapshot-portability.mjs
+++ b/bench/test-snapshot-portability.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * test-snapshot-portability.mjs — one snapshot format, every environment.
+ *
+ * Saves a snapshot through the REAL CLI (daemon + Unix socket + `lifo snapshot
+ * save`) and restores that exact file into a plain `@lifo-sh/core` box — the same
+ * code path the browser playground uses. Then does the reverse.
+ *
+ * This is the property the format exists for. Before the manifest, the CLI wrote
+ * a zip wrapping a JSON-serialized VFS while core wrote a tar.gz of files, so
+ * neither could read the other's snapshots.
+ *
+ * Run: node bench/test-snapshot-portability.mjs
+ */
+import { spawn, execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as net from 'node:net';
+import { Sandbox, readSnapshotMetadata } from '../packages/core/dist/index.js';
+
+const CLI = path.join(process.cwd(), 'packages/cli/dist/index.js');
+const results = [];
+const check = (name, ok, detail = '') => {
+  results.push({ name, ok });
+  console.log(`${ok ? 'ok  ' : 'FAIL'} ${name}${detail ? ` — ${detail}` : ''}`);
+};
+
+const sessionId = 'snapport';
+const sessionsDir = path.join(os.homedir(), '.lifo', 'sessions');
+const sockPath = path.join(sessionsDir, `${sessionId}.sock`);
+const hostDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lifo-snapport-'));
+const outFile = path.join(os.tmpdir(), `snapport-${Date.now()}.tar.gz`);
+
+/** Type a line into the live session over the daemon socket. */
+function sendInput(line) {
+  return new Promise((resolve, reject) => {
+    const c = net.connect(sockPath, () => {
+      c.write(JSON.stringify({ type: 'input', data: line + '\r' }) + '\n');
+      setTimeout(() => { c.end(); resolve(); }, 1500);
+    });
+    c.on('error', reject);
+  });
+}
+
+console.log('booting a CLI session…');
+const daemon = spawn('node', [CLI, '--daemon', '--id', sessionId, '--mount', hostDir], {
+  stdio: ['ignore', 'ignore', 'pipe'],
+});
+let daemonErr = '';
+daemon.stderr.on('data', (d) => { daemonErr += String(d); });
+
+// Wait for the session socket to appear.
+for (let i = 0; i < 60; i++) {
+  if (fs.existsSync(sockPath)) break;
+  await new Promise((r) => setTimeout(r, 250));
+}
+if (!fs.existsSync(sockPath)) {
+  console.log('daemon never came up:\n' + daemonErr.slice(-500));
+  process.exit(2);
+}
+
+// Create state INSIDE the CLI box: a file, a cwd and an env var.
+await sendInput('mkdir -p /home/user/from-cli');
+await sendInput('echo "written in the CLI" > /home/user/from-cli/note.txt');
+await sendInput('cd /home/user/from-cli');
+await sendInput('export FROM_CLI=yes');
+await new Promise((r) => setTimeout(r, 1000));
+
+console.log('saving a snapshot through the CLI…');
+try {
+  execFileSync('node', [CLI, 'snapshot', 'save', sessionId, '--output', outFile], { stdio: 'pipe' });
+} catch (e) {
+  console.log('snapshot save failed:', String(e.stdout || '') + String(e.stderr || ''));
+  process.exit(2);
+}
+check('lifo snapshot save writes an archive', fs.existsSync(outFile), `${fs.statSync(outFile).size} bytes`);
+
+const bytes = new Uint8Array(fs.readFileSync(outFile));
+check('the file is gzip (tar.gz), not a zip', bytes[0] === 0x1f && bytes[1] === 0x8b);
+
+const manifest = await readSnapshotMetadata(bytes);
+check('it carries a manifest with cwd + env',
+  manifest?.cwd === '/home/user/from-cli' && manifest?.env?.FROM_CLI === 'yes',
+  `cwd=${manifest?.cwd} FROM_CLI=${manifest?.env?.FROM_CLI}`);
+check('the manifest records the host mount path', typeof manifest?.mountPath === 'string', manifest?.mountPath);
+
+// ── the actual point: restore the CLI's file into a core box ────────────────
+console.log('restoring that same file into a @lifo-sh/core box…');
+const box = await Sandbox.create({ persist: false });
+const restored = await box.importSnapshot(bytes);
+
+check('a CLI snapshot restores into a core/browser box',
+  (await box.fs.readFile('/home/user/from-cli/note.txt')).trim() === 'written in the CLI');
+check('cwd from the CLI session is applied', box.cwd === '/home/user/from-cli', box.cwd);
+check('env from the CLI session is applied', box.env.FROM_CLI === 'yes');
+check('importSnapshot returns the manifest', restored?.version === 1);
+check('the manifest is not restored as a VFS file', !(await box.fs.exists('/lifo-snapshot.json')));
+
+// ── and the reverse: a core snapshot the CLI can read ──────────────────────
+console.log('exporting from core and reading it back the way the CLI does…');
+await box.fs.writeFile('/home/user/from-core.txt', 'written in core');
+box.cwd = '/home/user';
+const coreBytes = await box.exportSnapshot();
+const coreManifest = await readSnapshotMetadata(coreBytes);
+check('a core snapshot carries the same manifest shape',
+  coreManifest?.version === 1 && coreManifest?.cwd === '/home/user',
+  `cwd=${coreManifest?.cwd}`);
+
+const roundTrip = await Sandbox.create({ persist: false });
+await roundTrip.importSnapshot(coreBytes);
+check('core → core round trip keeps both files',
+  (await roundTrip.fs.exists('/home/user/from-core.txt')) &&
+  (await roundTrip.fs.exists('/home/user/from-cli/note.txt')));
+
+// ── cleanup ───────────────────────────────────────────────────────────────
+box.destroy();
+roundTrip.destroy();
+try { execFileSync('node', [CLI, 'stop', sessionId], { stdio: 'ignore' }); } catch { /* already gone */ }
+try { daemon.kill(); } catch { /* ok */ }
+for (const p of [outFile]) { try { fs.unlinkSync(p); } catch { /* ok */ } }
+try { fs.rmSync(hostDir, { recursive: true, force: true }); } catch { /* ok */ }
+for (const ext of ['.json', '.sock', '.log']) { try { fs.unlinkSync(path.join(sessionsDir, sessionId + ext)); } catch { /* ok */ } }
+
+const failed = results.filter((r) => !r.ok);
+console.log('');
+console.log(failed.length === 0
+  ? `PASS — ${results.length} checks: one snapshot format across the CLI and core/browser`
+  : `FAIL — ${failed.length}/${results.length}: ${failed.map((f) => f.name).join('; ')}`);
+process.exit(failed.length === 0 ? 0 : 1);

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,72 @@
 # lifo-sh
 
+## 0.10.0
+
+### Minor Changes
+
+- Publish in-VM ports on the host, one portable snapshot format, and two CLI fixes
+
+  **`exposePort()` / `lifo --expose`** — bind a real host port to a server inside the
+  box. A box's ports are entries in a map, so nothing outside the process could reach
+  them; in the browser that's what the service worker or blob preview is for, but on a
+  host with real sockets neither is needed.
+
+  ```bash
+  lifo --expose 3000            # in-VM 3000 → http://127.0.0.1:3000
+  lifo --expose 3000:5000       # in-VM 3000 → http://127.0.0.1:5000
+  lifo --detach --expose 5173   # background sessions too
+  ```
+
+  Forwards HTTP through the shared dispatcher and WebSockets at the byte level (the
+  client's socket goes to the in-VM server, which does its own handshake — so HMR
+  works and nothing between has to parse a frame). Loopback-only by default, since a
+  box runs project code. Binding doesn't require the server to exist yet: requests get
+  `404` + `x-lifo: no-server` until it's live, which reads better than a refused
+  connection while a dev server boots. `node:http` is injected rather than imported,
+  as `NativeFsProvider` does with `fs`, so the browser bundle is unaffected.
+
+  This is **not** `tunnel`: the in-shell `tunnel` shares a port PUBLICLY via the
+  `tunnel.lifo.sh` relay, while `--expose` binds a local socket with no relay and no
+  network. They compose — expose locally, then `lifo tunnel <hostPort>`.
+
+  **One snapshot format everywhere.** There were two: core wrote a `.tar.gz` of files
+  while the CLI wrote a zip wrapping a JSON-serialized VFS — because the tar had
+  nowhere to keep `cwd`/`env`/`mountPath`. So a snapshot saved by the CLI could not be
+  opened in the browser, and vice versa, which is a strange gap for a project whose
+  point is running the same VM everywhere.
+
+  Snapshots now carry a `lifo-snapshot.json` manifest beside the files (VFS paths all
+  start with `/`, so a relative entry can't collide, and it's never restored as a
+  file). `sandbox.exportSnapshot()` embeds `cwd` + `env` automatically;
+  `importSnapshot()` applies them and returns the manifest. `readSnapshotMetadata()`
+  reads it without a VFS, for decisions that come before you have anywhere to restore
+  into. `{ metadata: false }` gives a files-only archive — which is also exactly how
+  pre-manifest snapshots behave, so old `.tar.gz` files keep restoring.
+
+  The CLI now emits and reads that archive (built by the daemon, which owns the
+  filesystem). **The zip format is gone**; a zip written by lifo ≤ 0.9.0 is rejected
+  with a clear message rather than half-working, and `adm-zip` is no longer a
+  dependency.
+
+  **Two pre-existing CLI bugs**, found because `--expose` couldn't be demonstrated
+  without fixing them:
+
+  - **`lifo --detach` / `lifo new` crashed on startup.** `new Shell(...)` was called
+    with 4 arguments but needs 5 — `processRegistry` was missing, so `shell.start()`
+    threw `Cannot read properties of undefined (reading 'spawn')`. Confirmed identical
+    without any new flag.
+  - **`ps` / `top` / `kill` threw** `processRegistry.getAll is not a function`: the CLI
+    passed `shell.getJobTable()` where a `ProcessRegistry` was expected.
+
+  Both are the same class of stale wiring the failing `shell.test.ts` /
+  `system-extra.test.ts` suites point at (lifo#69). `Sandbox.create` had it right; the
+  CLI wasn't updated when the signature changed.
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.10.0
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-sh",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Run Lifo (a Linux-like OS) in your terminal -- npx lifo-sh",
   "license": "MIT",
   "repository": {
@@ -39,11 +39,9 @@
   },
   "dependencies": {
     "@lifo-sh/core": "workspace:*",
-    "adm-zip": "^0.5.10",
     "ws": "^8.19.0"
   },
   "devDependencies": {
-    "@types/adm-zip": "^0.5.5",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.18.1",
     "tsup": "^8.0.0",

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -82,7 +82,14 @@ function getSpawnExecutable(): { executable: string; prefixArgs: string[] } {
  * @returns            The session ID (hex string) once the daemon is ready.
  * @throws             If the daemon fails to become ready within 5 seconds.
  */
-export async function startDaemon(mountPath: string, port?: number, snapshotPath?: string, scriptPath?: string): Promise<string> {
+export async function startDaemon(
+  mountPath: string,
+  port?: number,
+  snapshotPath?: string,
+  scriptPath?: string,
+  /** `--expose vmPort:hostPort` mappings to forward to the daemon process. */
+  expose?: Array<{ vmPort: number; hostPort: number }>,
+): Promise<string> {
   const id = generateId();
   const jsonPath = path.join(SESSIONS_DIR, `${id}.json`);
   const daemonLogPath = logPath(id);
@@ -94,6 +101,12 @@ export async function startDaemon(mountPath: string, port?: number, snapshotPath
   const extraArgs: string[] = [];
   if (port !== undefined) extraArgs.push('--port', String(port));
   if (snapshotPath !== undefined) extraArgs.push('--snapshot', snapshotPath);
+  // The forwarders have to be bound by the DAEMON, since that's the process
+  // holding the kernel — so the mappings are passed through rather than acted on
+  // here.
+  for (const { vmPort, hostPort } of expose ?? []) {
+    extraArgs.push('--expose', `${vmPort}:${hostPort}`);
+  }
 
   // Redirect daemon stderr to a log file so startup errors aren't silently lost.
   // The log is cleaned up by deleteSession() on normal shutdown; if the daemon

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,21 @@
  *
  *   lifo login / logout / whoami  Auth helpers (see auth.ts).
  *
+ * Port forwarding
+ * ───────────────
+ *   --expose <vmPort>[:<hostPort>]   Publish an in-VM port on a real host port.
+ *                                    Repeatable. hostPort defaults to vmPort.
+ *
+ *     lifo --expose 3000             in-VM 3000 -> http://127.0.0.1:3000
+ *     lifo --expose 3000:5000        in-VM 3000 -> http://127.0.0.1:5000
+ *     lifo --detach --expose 5173    works for background sessions too
+ *
+ *   Loopback only, and forwards HTTP and WebSockets (so a dev server's HMR
+ *   works). This is NOT the same as `tunnel`: the in-shell `tunnel` command
+ *   shares an in-VM port PUBLICLY through the lifo.sh relay, whereas --expose
+ *   binds a local socket with no relay and no network. They compose — expose a
+ *   port locally, then `lifo tunnel <hostPort>` to share it.
+ *
  * Internal flag (not user-facing):
  *   lifo --daemon --id <id> --mount <path>
  *                                 Runs as the background daemon process.
@@ -53,7 +68,13 @@ import {
 	createNodeCommand,
 	createCurlCommand,
 	rehydrateGlobalPackages,
+	exposePort,
+	exportVfsSnapshot,
+	importVfsSnapshot,
+	readSnapshotMetadata,
 } from '@lifo-sh/core';
+import type { ExposedPort } from '@lifo-sh/core';
+import * as nodeHttp from 'node:http';
 import { NodeTerminal } from './NodeTerminal.js';
 import { DaemonTerminal } from './DaemonTerminal.js';
 import { TOKEN_PATH, readToken, handleLogin, handleLogout, handleWhoami } from './auth.js';
@@ -63,8 +84,8 @@ import { attachToSession, attachViaTcp } from './attach.js';
 import {
 	SNAPSHOTS_DIR,
 	requestSnapshot,
-	writeSnapshotZip,
-	readSnapshotZip,
+	writeSnapshotArchive,
+	readSnapshotArchive,
 	listSnapshots,
 } from './snapshot.js';
 import { handleTunnel, createHostTunnelCommand } from './tunnel.js';
@@ -109,6 +130,52 @@ interface CliOptions {
 	id?: string;
 	/** Internal flag — path to a snapshot JSON file to restore on daemon boot. */
 	snapshot?: string;
+	/**
+	 * Publish in-VM ports on real host ports: `--expose 3000` or
+	 * `--expose 3000:8080` (vmPort:hostPort). Repeatable.
+	 */
+	expose?: Array<{ vmPort: number; hostPort: number }>;
+}
+
+/** Parse `--expose 3000` / `--expose 3000:8080`. hostPort defaults to vmPort. */
+function parseExpose(spec: string): { vmPort: number; hostPort: number } | null {
+	const [left, right] = spec.split(':');
+	const vmPort = Number(left);
+	const hostPort = right === undefined ? vmPort : Number(right);
+	const valid = (n: number) => Number.isInteger(n) && n >= 1 && n <= 65535;
+	if (!valid(vmPort) || !valid(hostPort)) return null;
+	return { vmPort, hostPort };
+}
+
+/**
+ * Publish each `--expose vmPort[:hostPort]` mapping on the host.
+ *
+ * Bound BEFORE the shell starts, so a forwarder is already listening when the
+ * user runs their dev server — a request that arrives first gets a 404 with
+ * `x-lifo: no-server` rather than a connection refused, which reads better while
+ * a server is still booting.
+ *
+ * A mapping that can't bind (port in use) is reported and skipped rather than
+ * taking the whole session down: losing one forward shouldn't cost you the box.
+ */
+async function startExposedPorts(
+	kernel: Kernel,
+	mappings: Array<{ vmPort: number; hostPort: number }> | undefined,
+	write: (text: string) => void,
+): Promise<ExposedPort[]> {
+	if (!mappings || mappings.length === 0) return [];
+	const opened: ExposedPort[] = [];
+	for (const { vmPort, hostPort } of mappings) {
+		try {
+			const exposed = await exposePort(kernel.portRegistry, { vmPort, hostPort, http: nodeHttp });
+			opened.push(exposed);
+			write(`Exposed in-VM port ${vmPort} at ${exposed.url}\n`);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			write(`Warning: could not expose ${vmPort} on host port ${hostPort}: ${message}\n`);
+		}
+	}
+	return opened;
 }
 
 function parseArgs(args: string[]): CliOptions {
@@ -126,6 +193,14 @@ function parseArgs(args: string[]): CliOptions {
 				process.exit(1);
 			}
 			opts.port = p;
+			i++;
+		} else if (args[i] === '--expose' && args[i + 1]) {
+			const mapping = parseExpose(args[i + 1]!);
+			if (!mapping) {
+				console.error(`Error: --expose expects <vmPort> or <vmPort>:<hostPort>, got "${args[i + 1]}"`);
+				process.exit(1);
+			}
+			(opts.expose ??= []).push(mapping);
 			i++;
 		} else if (args[i] === '--daemon') {
 			opts.daemon = true;
@@ -218,7 +293,14 @@ function handleStop(id: string): void {
  *   SIGTERM / SIGHUP → close socket server + delete session files + exit.
  *   `exit` typed in the shell → disconnects all clients, VM keeps running.
  */
-async function runDaemon(id: string, mountPath: string, port?: number, snapshotPath?: string): Promise<void> {
+async function runDaemon(
+	id: string,
+	mountPath: string,
+	port?: number,
+	snapshotPath?: string,
+	/** `--expose` mappings; bound here because the daemon owns the kernel. */
+	expose?: Array<{ vmPort: number; hostPort: number }>,
+): Promise<void> {
 	const socketPath = path.join(SESSIONS_DIR, `${id}.sock`);
 
 	fs.mkdirSync(SESSIONS_DIR, { recursive: true });
@@ -232,13 +314,16 @@ async function runDaemon(id: string, mountPath: string, port?: number, snapshotP
 	const kernel = new Kernel();
 	await kernel.boot({ persist: false }); // in-memory VFS; state lives in this process
 
-	// Read snapshot file ONCE up-front, then immediately delete it.
-	// The daemon only needs it during startup — it should not linger on disk.
-	interface SnapPayload { vfs: any; cwd?: string; env?: Record<string, string> }
-	let snap: SnapPayload | null = null;
+	// Host port forwards for a detached session. Messages go to stderr because
+	// stdout belongs to the daemon protocol.
+	const exposedPorts = await startExposedPorts(kernel, expose, (t) => process.stderr.write(t));
+
+	// Read the snapshot archive ONCE up-front, then immediately delete it: the
+	// daemon only needs it during startup and it shouldn't linger on disk.
+	let snapshotBytes: Uint8Array | null = null;
 	if (snapshotPath) {
 		try {
-			snap = JSON.parse(fs.readFileSync(snapshotPath, 'utf-8')) as SnapPayload;
+			snapshotBytes = readSnapshotArchive(snapshotPath);
 		} catch (err: any) {
 			process.stderr.write(`Warning: failed to read snapshot: ${err.message}\n`);
 		} finally {
@@ -247,11 +332,14 @@ async function runDaemon(id: string, mountPath: string, port?: number, snapshotP
 	}
 
 	// Restore VFS from snapshot before mounting the host directory.
-	if (snap) {
+	// Restored with the same importVfsSnapshot() the browser uses, so a snapshot
+	// taken in either place restores in the other. The manifest carries cwd/env.
+	let restored: Awaited<ReturnType<typeof importVfsSnapshot>> = null;
+	if (snapshotBytes) {
 		try {
-			kernel.vfs.loadFromSerialized(deserialize(snap.vfs));
+			restored = await importVfsSnapshot(kernel.vfs, snapshotBytes);
 		} catch (err: any) {
-			process.stderr.write(`Warning: failed to restore snapshot VFS: ${err.message}\n`);
+			process.stderr.write(`Warning: failed to restore snapshot: ${err.message}\n`);
 		}
 	}
 
@@ -268,9 +356,9 @@ async function runDaemon(id: string, mountPath: string, port?: number, snapshotP
 	env.PWD = MOUNT_PATH;          // start the shell inside the mounted directory
 	env.LIFO_HOST_DIR = mountPath; // expose host path for scripts that need it
 
-	// Overlay saved env vars — reuse already-parsed snap, no second file read.
-	if (snap?.env && typeof snap.env === 'object') {
-		for (const [k, v] of Object.entries(snap.env)) {
+	// Overlay env from the snapshot manifest, if the archive carried one.
+	if (restored?.env && typeof restored.env === 'object') {
+		for (const [k, v] of Object.entries(restored.env)) {
 			if (k !== 'LIFO_HOST_DIR' && k !== 'LIFO_AUTH_TOKEN' && k !== 'LIFO_TOKEN_PATH') {
 				env[k] = v;
 			}
@@ -281,12 +369,14 @@ async function runDaemon(id: string, mountPath: string, port?: number, snapshotP
 	if (token) env.LIFO_AUTH_TOKEN = token;
 	env.LIFO_TOKEN_PATH = TOKEN_PATH;
 
-	const shell = new Shell(daemonTerminal, kernel.vfs, registry, env);
+	const shell = new Shell(daemonTerminal, kernel.vfs, registry, env, kernel.processRegistry);
 
-	const jobTable = shell.getJobTable();
-	registry.register('ps', createPsCommand(jobTable));
-	registry.register('top', createTopCommand(jobTable));
-	registry.register('kill', createKillCommand(jobTable));
+	// ps/top/kill take the PROCESS REGISTRY, not the job table — passing the job
+	// table made them throw `processRegistry.getAll is not a function`.
+	const processRegistry = shell.getProcessRegistry();
+	registry.register('ps', createPsCommand(processRegistry));
+	registry.register('top', createTopCommand(processRegistry));
+	registry.register('kill', createKillCommand(processRegistry));
 	registry.register('watch', createWatchCommand(registry));
 	registry.register('help', createHelpCommand(registry));
 	registry.register('node', createNodeCommand(kernel));
@@ -311,8 +401,8 @@ async function runDaemon(id: string, mountPath: string, port?: number, snapshotP
 	await shell.sourceFile('/etc/profile');
 	await shell.sourceFile(env.HOME + '/.bashrc');
 
-	// Restore CWD from snapshot — only if the path actually exists in the VFS.
-	const snapshotCwd = snap?.cwd;
+	// Restore CWD from the snapshot manifest — only if it exists in the VFS.
+	const snapshotCwd = restored?.cwd;
 	if (snapshotCwd && kernel.vfs.exists(snapshotCwd)) {
 		shell.setCwd(snapshotCwd);
 	}
@@ -330,17 +420,29 @@ async function runDaemon(id: string, mountPath: string, port?: number, snapshotP
 	// Uses setImmediate to yield the event loop before the CPU-heavy serialize()
 	// so in-flight shell output isn't delayed for other attached clients.
 	daemonTerminal.onSnapshot((socket) => {
-		setImmediate(() => {
-			const data = {
-				type: 'snapshot-data',
-				vfs: serialize(kernel.vfs.getRoot()),
-				cwd: shell.getCwd(),
-				env: shell.getEnv(),
-				mountPath,  // save original mount path so restore can reuse it
-			};
-			socket.write(JSON.stringify(data) + '\n');
-			socket.end();
-		});
+		// The archive is built HERE, in the process that owns the VFS, using the
+		// same exportVfsSnapshot() the browser uses — so one format serves every
+		// environment. base64 because the daemon protocol is newline-delimited JSON.
+		void (async () => {
+			try {
+				const bytes = await exportVfsSnapshot(kernel.vfs, {
+					metadata: { cwd: shell.getCwd(), env: shell.getEnv(), mountPath },
+				});
+				socket.write(JSON.stringify({
+					type: 'snapshot-data',
+					format: 'tar.gz',
+					data: Buffer.from(bytes).toString('base64'),
+					cwd: shell.getCwd(),
+					env: shell.getEnv(),
+					mountPath,
+				}) + '\n');
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				socket.write(JSON.stringify({ type: 'snapshot-error', error: message }) + '\n');
+			} finally {
+				socket.end();
+			}
+		})();
 	});
 
 	// ── Socket server ─────────────────────────────────────────────────────────
@@ -394,6 +496,7 @@ async function runDaemon(id: string, mountPath: string, port?: number, snapshotP
 
 	// ── Shutdown handler ──────────────────────────────────────────────────────
 	function shutdown() {
+		for (const exposed of exposedPorts) void exposed.close();
 		server.close();           // stop accepting new connections on Unix socket
 		tcpServer?.close();       // stop accepting new connections on TCP (if any)
 		deleteSession(id);        // clean up ~/.lifo/sessions/<id>.{json,sock}
@@ -436,6 +539,10 @@ async function runInteractive(opts: CliOptions): Promise<void> {
 	const kernel = new Kernel();
 	await kernel.boot({ persist: false });
 
+	// Host port forwards, bound before the shell so they're already listening
+	// when the user starts a dev server.
+	const exposedPorts = await startExposedPorts(kernel, opts.expose, (t) => process.stdout.write(t));
+
 	const MOUNT_PATH = '/mnt/host';
 	kernel.vfs.mkdir('/mnt', { recursive: true });
 	const nativeProvider = new NativeFsProvider(hostDir, fs);
@@ -452,12 +559,14 @@ async function runInteractive(opts: CliOptions): Promise<void> {
 	if (token) env.LIFO_AUTH_TOKEN = token;
 	env.LIFO_TOKEN_PATH = TOKEN_PATH;
 
-	const shell = new Shell(terminal, kernel.vfs, registry, env);
+	const shell = new Shell(terminal, kernel.vfs, registry, env, kernel.processRegistry);
 
-	const jobTable = shell.getJobTable();
-	registry.register('ps', createPsCommand(jobTable));
-	registry.register('top', createTopCommand(jobTable));
-	registry.register('kill', createKillCommand(jobTable));
+	// ps/top/kill take the PROCESS REGISTRY, not the job table — passing the job
+	// table made them throw `processRegistry.getAll is not a function`.
+	const processRegistry = shell.getProcessRegistry();
+	registry.register('ps', createPsCommand(processRegistry));
+	registry.register('top', createTopCommand(processRegistry));
+	registry.register('kill', createKillCommand(processRegistry));
 	registry.register('watch', createWatchCommand(registry));
 	registry.register('help', createHelpCommand(registry));
 	registry.register('node', createNodeCommand(kernel));
@@ -504,6 +613,7 @@ async function runInteractive(opts: CliOptions): Promise<void> {
 	);
 
 	function cleanup() {
+		for (const exposed of exposedPorts) void exposed.close();
 		terminal.destroy();
 		if (isTempSession) {
 			// Clean up the throwaway temp directory we created above.
@@ -590,7 +700,7 @@ async function main() {
 
 		if (sub === 'save') {
 			const id = args[2];
-			if (!id) { console.error('Usage: lifo snapshot save <id> [--output <file.zip>]'); process.exit(1); }
+			if (!id) { console.error('Usage: lifo snapshot save <id> [--output <file.tar.gz>]'); process.exit(1); }
 
 			// Parse --output from remaining args
 			let outputPath: string | undefined;
@@ -602,7 +712,7 @@ async function main() {
 			}
 			if (!outputPath) {
 				fs.mkdirSync(SNAPSHOTS_DIR, { recursive: true });
-				outputPath = path.join(SNAPSHOTS_DIR, `${id}-${Date.now()}.zip`);
+				outputPath = path.join(SNAPSHOTS_DIR, `${id}-${Date.now()}.tar.gz`);
 			}
 
 			const session = readSession(id);
@@ -610,9 +720,10 @@ async function main() {
 
 			console.log(`Requesting snapshot from VM ${id}...`);
 			try {
-				const data = await requestSnapshot(session.socketPath);
-				writeSnapshotZip(data, outputPath);
+				const archive = await requestSnapshot(session.socketPath);
+				writeSnapshotArchive(archive.bytes, outputPath);
 				console.log(`Snapshot saved to ${outputPath}`);
+				console.log('Portable: this file also restores in the browser playground.');
 			} catch (err: any) {
 				console.error(`Failed to save snapshot: ${err.message}`);
 				process.exit(1);
@@ -622,7 +733,7 @@ async function main() {
 
 		if (sub === 'restore') {
 			const zipPath = args[2] ? path.resolve(args[2]) : undefined;
-			if (!zipPath) { console.error('Usage: lifo snapshot restore <file.zip> [--mount <path>]'); process.exit(1); }
+			if (!zipPath) { console.error('Usage: lifo snapshot restore <file.tar.gz> [--mount <path>]'); process.exit(1); }
 			if (!fs.existsSync(zipPath)) { console.error(`File not found: ${zipPath}`); process.exit(1); }
 
 			// Parse --mount from remaining args
@@ -634,9 +745,11 @@ async function main() {
 				}
 			}
 
-			let data: ReturnType<typeof readSnapshotZip>;
+			let archiveBytes: Uint8Array;
+			let manifest: Awaited<ReturnType<typeof readSnapshotMetadata>> = null;
 			try {
-				data = readSnapshotZip(zipPath);
+				archiveBytes = readSnapshotArchive(zipPath);
+				manifest = await readSnapshotMetadata(archiveBytes);
 			} catch (err: any) {
 				console.error(`Failed to read snapshot: ${err.message}`);
 				process.exit(1);
@@ -644,17 +757,18 @@ async function main() {
 
 			// Determine mount path: explicit flag > saved path (if it still exists) > new temp dir
 			if (!mountPath) {
-				if (data.mountPath && fs.existsSync(data.mountPath) && fs.statSync(data.mountPath).isDirectory()) {
-					mountPath = data.mountPath;
+				if (manifest?.mountPath && fs.existsSync(manifest.mountPath) && fs.statSync(manifest.mountPath).isDirectory()) {
+					mountPath = manifest.mountPath;
 					console.log(`Using original mount path: ${mountPath}`);
 				} else {
 					mountPath = fs.mkdtempSync(path.join(os.tmpdir(), 'lifo-'));
 				}
 			}
 
-			// Write snapshot data to a temp file for the daemon process to read on boot.
-			const tmpSnap = path.join(os.tmpdir(), `lifo-snap-${Date.now()}.json`);
-			fs.writeFileSync(tmpSnap, JSON.stringify({ vfs: data.vfs, cwd: data.cwd, env: data.env }), 'utf-8');
+			// Hand the archive itself to the daemon — no re-encoding, so the file the
+			// user restores is byte-for-byte the one importVfsSnapshot() reads.
+			const tmpSnap = path.join(os.tmpdir(), `lifo-snap-${Date.now()}.tar.gz`);
+			fs.writeFileSync(tmpSnap, archiveBytes);
 
 			try {
 				const id = await startDaemon(mountPath, undefined, tmpSnap);
@@ -696,7 +810,7 @@ async function main() {
 			mountPath = fs.mkdtempSync(path.join(os.tmpdir(), 'lifo-'));
 		}
 		try {
-			const id = await startDaemon(mountPath, newOpts.port);
+			const id = await startDaemon(mountPath, newOpts.port, undefined, undefined, newOpts.expose);
 			if (newOpts.port !== undefined) {
 				console.log(`Started VM ${id} (TCP port: ${newOpts.port})`);
 			} else {
@@ -718,7 +832,7 @@ async function main() {
 	if (opts.daemon) {
 		if (!opts.id) { console.error('--daemon requires --id'); process.exit(1); }
 		if (!opts.mount) { console.error('--daemon requires --mount'); process.exit(1); }
-		await runDaemon(opts.id, opts.mount, opts.port, opts.snapshot);
+		await runDaemon(opts.id, opts.mount, opts.port, opts.snapshot, opts.expose);
 		return;
 	}
 
@@ -743,7 +857,7 @@ async function main() {
 		}
 
 		try {
-			const id = await startDaemon(mountPath, opts.port);
+			const id = await startDaemon(mountPath, opts.port, undefined, undefined, opts.expose);
 			const portSuffix = opts.port !== undefined ? `, TCP port: ${opts.port}` : '';
 			if (isTempMount) {
 				console.log(`Started VM ${id} (temp mount: ${mountPath}${portSuffix})`);

--- a/packages/cli/src/snapshot.ts
+++ b/packages/cli/src/snapshot.ts
@@ -1,12 +1,20 @@
 /**
- * snapshot.ts — save and restore VM state as a portable .zip file
+ * snapshot.ts — save and restore VM state as a portable .tar.gz
  *
- * Format: a zip containing a single `snapshot.json` with:
- *   { version, savedAt, cwd, env, vfs }
+ * ONE format across every environment. A snapshot is the archive
+ * `exportVfsSnapshot()` produces: the VFS as tar entries, plus a
+ * `lifo-snapshot.json` manifest carrying `cwd`, `env` and `mountPath`. So a file
+ * saved here opens in the browser playground, and a file saved there restores
+ * here.
+ *
+ * Previously this wrote a zip wrapping a JSON-serialized VFS — a second,
+ * incompatible format, invented because the tar had nowhere to put session
+ * state. That format is gone; an old zip is rejected with a clear message rather
+ * than half-working.
  *
  * Commands:
- *   lifo snapshot save <id> [--output <file.zip>]
- *   lifo snapshot restore <file.zip> [--mount <path>]
+ *   lifo snapshot save <id> [--output <file.tar.gz>]
+ *   lifo snapshot restore <file.tar.gz|file.zip> [--mount <path>]
  *   lifo snapshot list
  */
 
@@ -14,33 +22,32 @@ import * as fs from 'node:fs';
 import * as net from 'node:net';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import AdmZip from 'adm-zip';
-import type { SerializedNode } from '@lifo-sh/core';
 
 export const SNAPSHOTS_DIR = path.join(os.homedir(), '.lifo', 'snapshots');
 
-export interface SnapshotData {
-  vfs: SerializedNode;
-  cwd: string;
-  env: Record<string, string>;
-  /** Original host mount path at snapshot time. Used as restore default on same machine. */
+/** A `.tar.gz` snapshot as produced by `exportVfsSnapshot()`. */
+export interface SnapshotArchive {
+  kind: 'archive';
+  bytes: Uint8Array;
+  /** Read from the manifest, when present. */
+  cwd?: string;
+  env?: Record<string, string>;
   mountPath?: string;
 }
 
-interface SnapshotFile {
-  version: 1;
-  savedAt: string;
-  cwd: string;
-  env: Record<string, string>;
-  vfs: SerializedNode;
-  mountPath?: string;
+/**
+ * gzip magic. Only used to give a clear error for a file that isn't a snapshot
+ * archive (an old zip, say) instead of a confusing gunzip failure.
+ */
+function isGzip(buf: Buffer): boolean {
+  return buf.length > 2 && buf[0] === 0x1f && buf[1] === 0x8b;
 }
 
 /**
  * Connects to a running daemon's Unix socket, sends a snapshot request, and
  * returns the VFS/cwd/env data. Times out after 10 seconds.
  */
-export function requestSnapshot(socketPath: string): Promise<SnapshotData> {
+export function requestSnapshot(socketPath: string): Promise<SnapshotArchive> {
   return new Promise((resolve, reject) => {
     const socket = net.createConnection(socketPath);
     let lineBuffer = '';
@@ -70,7 +77,20 @@ export function requestSnapshot(socketPath: string): Promise<SnapshotData> {
             done = true;
             clearTimeout(timeout);
             socket.destroy();
-            resolve({ vfs: msg.vfs, cwd: msg.cwd, env: msg.env, mountPath: msg.mountPath });
+            if (msg.format !== 'tar.gz' || typeof msg.data !== 'string') {
+              reject(new Error(
+                'This session was started by an older lifo build that returns the removed zip ' +
+                'snapshot format. Restart the session to snapshot it.',
+              ));
+              return;
+            }
+            resolve({
+              kind: 'archive',
+              bytes: new Uint8Array(Buffer.from(msg.data, 'base64')),
+              cwd: msg.cwd,
+              env: msg.env,
+              mountPath: msg.mountPath,
+            });
           }
         } catch {
           // ignore malformed lines
@@ -96,40 +116,27 @@ export function requestSnapshot(socketPath: string): Promise<SnapshotData> {
   });
 }
 
-/** Serializes snapshot data into a zip file at the given path. */
-export function writeSnapshotZip(data: SnapshotData, outputPath: string): void {
-  const payload: SnapshotFile = {
-    version: 1,
-    savedAt: new Date().toISOString(),
-    cwd: data.cwd,
-    env: data.env,
-    vfs: data.vfs,
-    mountPath: data.mountPath,
-  };
-
-  const zip = new AdmZip();
-  zip.addFile('snapshot.json', Buffer.from(JSON.stringify(payload), 'utf-8'));
-  zip.writeZip(outputPath);
+/** Writes a `.tar.gz` snapshot archive to disk. */
+export function writeSnapshotArchive(bytes: Uint8Array, outputPath: string): void {
+  fs.writeFileSync(outputPath, bytes);
 }
 
-/** Reads and validates a snapshot zip, returning the inner data. */
-export function readSnapshotZip(zipPath: string): SnapshotData {
-  const zip = new AdmZip(zipPath);
-  const entry = zip.getEntry('snapshot.json');
-  if (!entry) {
-    throw new Error(`Invalid snapshot: no snapshot.json found in ${zipPath}`);
+/**
+ * Reads a `.tar.gz` snapshot archive.
+ *
+ * The manifest is not parsed here — the daemon calls `importVfsSnapshot()`,
+ * which reads it while restoring. This only validates that the file is an
+ * archive at all, so a stale zip fails with something actionable.
+ */
+export function readSnapshotArchive(archivePath: string): Uint8Array {
+  const buf = fs.readFileSync(archivePath);
+  if (!isGzip(buf)) {
+    throw new Error(
+      `Not a lifo snapshot archive: ${archivePath}\n` +
+      `Snapshots are .tar.gz files. Zip snapshots written by lifo <= 0.9.0 are no longer supported.`,
+    );
   }
-  const raw = entry.getData().toString('utf-8');
-  const parsed: SnapshotFile = JSON.parse(raw);
-
-  if (parsed.version !== 1) {
-    throw new Error(`Unsupported snapshot version: ${parsed.version}`);
-  }
-  if (!parsed.vfs || !parsed.cwd || !parsed.env) {
-    throw new Error('Invalid snapshot: missing required fields (vfs, cwd, env)');
-  }
-
-  return { vfs: parsed.vfs, cwd: parsed.cwd, env: parsed.env, mountPath: parsed.mountPath };
+  return new Uint8Array(buf);
 }
 
 /** Lists all .zip files in ~/.lifo/snapshots/. */

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,72 @@
 # @lifo-sh/core
 
+## 0.10.0
+
+### Minor Changes
+
+- Publish in-VM ports on the host, one portable snapshot format, and two CLI fixes
+
+  **`exposePort()` / `lifo --expose`** — bind a real host port to a server inside the
+  box. A box's ports are entries in a map, so nothing outside the process could reach
+  them; in the browser that's what the service worker or blob preview is for, but on a
+  host with real sockets neither is needed.
+
+  ```bash
+  lifo --expose 3000            # in-VM 3000 → http://127.0.0.1:3000
+  lifo --expose 3000:5000       # in-VM 3000 → http://127.0.0.1:5000
+  lifo --detach --expose 5173   # background sessions too
+  ```
+
+  Forwards HTTP through the shared dispatcher and WebSockets at the byte level (the
+  client's socket goes to the in-VM server, which does its own handshake — so HMR
+  works and nothing between has to parse a frame). Loopback-only by default, since a
+  box runs project code. Binding doesn't require the server to exist yet: requests get
+  `404` + `x-lifo: no-server` until it's live, which reads better than a refused
+  connection while a dev server boots. `node:http` is injected rather than imported,
+  as `NativeFsProvider` does with `fs`, so the browser bundle is unaffected.
+
+  This is **not** `tunnel`: the in-shell `tunnel` shares a port PUBLICLY via the
+  `tunnel.lifo.sh` relay, while `--expose` binds a local socket with no relay and no
+  network. They compose — expose locally, then `lifo tunnel <hostPort>`.
+
+  **One snapshot format everywhere.** There were two: core wrote a `.tar.gz` of files
+  while the CLI wrote a zip wrapping a JSON-serialized VFS — because the tar had
+  nowhere to keep `cwd`/`env`/`mountPath`. So a snapshot saved by the CLI could not be
+  opened in the browser, and vice versa, which is a strange gap for a project whose
+  point is running the same VM everywhere.
+
+  Snapshots now carry a `lifo-snapshot.json` manifest beside the files (VFS paths all
+  start with `/`, so a relative entry can't collide, and it's never restored as a
+  file). `sandbox.exportSnapshot()` embeds `cwd` + `env` automatically;
+  `importSnapshot()` applies them and returns the manifest. `readSnapshotMetadata()`
+  reads it without a VFS, for decisions that come before you have anywhere to restore
+  into. `{ metadata: false }` gives a files-only archive — which is also exactly how
+  pre-manifest snapshots behave, so old `.tar.gz` files keep restoring.
+
+  The CLI now emits and reads that archive (built by the daemon, which owns the
+  filesystem). **The zip format is gone**; a zip written by lifo ≤ 0.9.0 is rejected
+  with a clear message rather than half-working, and `adm-zip` is no longer a
+  dependency.
+
+  **Two pre-existing CLI bugs**, found because `--expose` couldn't be demonstrated
+  without fixing them:
+
+  - **`lifo --detach` / `lifo new` crashed on startup.** `new Shell(...)` was called
+    with 4 arguments but needs 5 — `processRegistry` was missing, so `shell.start()`
+    threw `Cannot read properties of undefined (reading 'spawn')`. Confirmed identical
+    without any new flag.
+  - **`ps` / `top` / `kill` threw** `processRegistry.getAll is not a function`: the CLI
+    passed `shell.getJobTable()` where a `ProcessRegistry` was expected.
+
+  Both are the same class of stale wiring the failing `shell.test.ts` /
+  `system-extra.test.ts` suites point at (lifo#69). `Sandbox.create` had it right; the
+  CLI wasn't updated when the signature changed.
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/ui@0.10.0
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/core",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Linux-like OS engine for JavaScript -- kernel, shell, VFS, and 60+ commands",
   "license": "MIT",
   "repository": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,11 @@ export type { DispatchInit, DispatchOptions, DispatchedResponse } from './kernel
 // service-worker/preview transport and the tunnel's socket stand-in.
 export { openWsPipe, VirtualUpgradeSocket } from './kernel/network/ws-pipe.js';
 export type { WsPipe, WsPipeHooks, WsPipeOptions } from './kernel/network/ws-pipe.js';
+
+// Publish an in-VM port on a real host port (Node hosts — the CLI). `node:http`
+// is injected rather than imported so this entry stays browser-safe.
+export { exposePort } from './kernel/network/expose.js';
+export type { ExposePortOptions, ExposedPort, HostHttpModule, HostHttpServer } from './kernel/network/expose.js';
 export type {
 	VmWebSocket,
 	VmMessageEvent,
@@ -86,7 +91,8 @@ export {
 export type { VfsChange, SyncOptions } from './kernel/vfs/sync.js';
 
 // VFS snapshot (tar.gz), operable on any VFS — non-blocking (yields)
-export { exportVfsSnapshot, importVfsSnapshot } from './kernel/vfs/snapshot.js';
+export { exportVfsSnapshot, importVfsSnapshot, readSnapshotMetadata, SNAPSHOT_MANIFEST_ENTRY } from './kernel/vfs/snapshot.js';
+export type { SnapshotMetadata } from './kernel/vfs/snapshot.js';
 export { pruneExpoModules } from './sandbox/prune.js';
 export type { PruneOptions, PruneResult } from './sandbox/prune.js';
 export type { VfsSnapshotOptions } from './kernel/vfs/snapshot.js';

--- a/packages/core/src/kernel/network/expose.ts
+++ b/packages/core/src/kernel/network/expose.ts
@@ -1,0 +1,186 @@
+/**
+ * expose.ts — publish an in-VM port on a real host port.
+ *
+ * The VM's ports are objects in a `Map`, not sockets, so nothing outside the
+ * process can reach them: in a browser that's what the service worker or the
+ * blob preview is for, and over the network it's what a tunnel is for. On a host
+ * with real sockets (the CLI) neither is needed — bind a port and forward.
+ *
+ * ```ts
+ * import * as http from 'node:http';
+ *
+ * const exposed = await exposePort(sandbox.kernel.portRegistry, {
+ *   vmPort: 3000,
+ *   hostPort: 3000,      // omit for an OS-assigned port
+ *   http,
+ * });
+ * // → curl http://127.0.0.1:3000/  reaches the server inside the VM
+ * await exposed.close();
+ * ```
+ *
+ * `http` is INJECTED rather than imported, the same way `NativeFsProvider` takes
+ * its `fs` module. `@lifo-sh/core` is bundled for the browser, and a static
+ * `node:http` import would either break that build or have to be externalised;
+ * passing the module keeps this file environment-agnostic and directly testable.
+ *
+ * HTTP goes through `dispatchRequest`, so slow servers, timeouts and unbound
+ * ports behave exactly as they do for every other transport.
+ *
+ * WebSockets are forwarded at the BYTE level: the client's socket is handed to
+ * the in-VM server, which performs its own RFC 6455 handshake and framing. So
+ * there is no `Sec-WebSocket-Accept` to compute here and no frame to parse — the
+ * bytes the in-VM `ws` writes are already exactly what the client expects.
+ */
+
+import { dispatchRequest } from './dispatch.js';
+import { VirtualUpgradeSocket } from './ws-pipe.js';
+import { getUpgradeHandlers } from '../../node-compat/http.js';
+import type { VirtualRequestHandler } from '../index.js';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/** The slice of `node:http` this needs. Structural, so the real module satisfies it. */
+export interface HostHttpModule {
+	createServer(handler: (req: any, res: any) => void): HostHttpServer;
+}
+
+export interface HostHttpServer {
+	listen(port: number, host: string, cb: () => void): void;
+	close(cb?: (err?: Error) => void): void;
+	on(event: string, listener: (...args: any[]) => void): void;
+	address(): { port: number } | string | null;
+}
+
+export interface ExposePortOptions {
+	/** The in-VM port to publish. */
+	vmPort: number;
+	/** Host port to bind. Omit or 0 for an OS-assigned free port. */
+	hostPort?: number;
+	/**
+	 * Interface to bind. Defaults to `127.0.0.1` — loopback only, deliberately:
+	 * the VM runs untrusted project code, so publishing it to every interface is
+	 * something a caller should have to ask for.
+	 */
+	host?: string;
+	/** `node:http` (or a compatible module). */
+	http: HostHttpModule;
+	/** Passed through to `dispatchRequest` (default 120s). */
+	timeoutMs?: number;
+	/** Optional hook for logging each forwarded request. */
+	onRequest?: (method: string, url: string, status: number) => void;
+}
+
+export interface ExposedPort {
+	/** The port actually bound (resolved, if the OS assigned it). */
+	readonly hostPort: number;
+	/** Convenience URL for the bound address. */
+	readonly url: string;
+	/** Stop listening. Resolves once the host server has closed. */
+	close(): Promise<void>;
+}
+
+/**
+ * Bind `hostPort` on the host and forward everything to the in-VM server on
+ * `vmPort`.
+ *
+ * Does NOT require the in-VM server to be listening yet — a request that arrives
+ * first gets `dispatchRequest`'s `404` with `x-lifo: no-server`, so a forwarder
+ * can be set up before the dev server starts. Rejects if the host port is already
+ * in use.
+ */
+export function exposePort(
+	portRegistry: Map<number, VirtualRequestHandler>,
+	options: ExposePortOptions,
+): Promise<ExposedPort> {
+	const { vmPort, hostPort = 0, host = '127.0.0.1', http, timeoutMs, onRequest } = options;
+
+	return new Promise<ExposedPort>((resolve, reject) => {
+		const server = http.createServer((req: any, res: any) => {
+			const chunks: Uint8Array[] = [];
+			req.on('data', (chunk: Uint8Array) => chunks.push(chunk));
+			req.on('end', () => {
+				let body: Uint8Array | undefined;
+				if (chunks.length > 0) {
+					let total = 0;
+					for (const c of chunks) total += c.length;
+					body = new Uint8Array(total);
+					let off = 0;
+					for (const c of chunks) { body.set(c, off); off += c.length; }
+				}
+
+				const headers: Record<string, string> = {};
+				for (const [key, value] of Object.entries(req.headers ?? {})) {
+					headers[key] = Array.isArray(value) ? value.join(', ') : String(value);
+				}
+
+				dispatchRequest(
+					portRegistry,
+					vmPort,
+					{ method: req.method ?? 'GET', url: req.url ?? '/', headers, body },
+					{ timeoutMs },
+				).then((vRes) => {
+					onRequest?.(req.method ?? 'GET', req.url ?? '/', vRes.statusCode);
+					res.writeHead(vRes.statusCode, vRes.headers);
+					res.end(vRes.bodyBytes);
+				}).catch((error: unknown) => {
+					// dispatchRequest resolves rather than throws, so reaching here means
+					// something in this forwarder failed — report it as a 502 rather than
+					// leaving the client hanging.
+					const message = error instanceof Error ? error.message : String(error);
+					res.writeHead(502, { 'content-type': 'text/plain' });
+					res.end(`Bad gateway forwarding to in-VM port ${vmPort}: ${message}`);
+				});
+			});
+		});
+
+		// WebSocket (and any other) upgrade: forward raw bytes both ways and let the
+		// in-VM server own the handshake, so nothing here has to speak RFC 6455.
+		server.on('upgrade', (req: any, socket: any, head: Uint8Array) => {
+			const upgradeHandler = getUpgradeHandlers(portRegistry).get(vmPort);
+			if (!upgradeHandler) {
+				socket.end('HTTP/1.1 502 Bad Gateway\r\n\r\n');
+				return;
+			}
+
+			const vmSocket = new VirtualUpgradeSocket(
+				(bytes) => { try { socket.write(bytes); } catch { /* client vanished */ } },
+				() => { try { socket.destroy(); } catch { /* already gone */ } },
+			);
+
+			socket.on('data', (chunk: Uint8Array) => vmSocket.emit('data', chunk));
+			socket.on('close', () => vmSocket.destroy());
+			socket.on('error', () => vmSocket.destroy());
+
+			const headers: Record<string, string> = {};
+			for (const [key, value] of Object.entries(req.headers ?? {})) {
+				headers[key] = Array.isArray(value) ? value.join(', ') : String(value);
+			}
+
+			const delivered = upgradeHandler(
+				{ method: req.method ?? 'GET', url: req.url ?? '/', headers },
+				vmSocket,
+				head && head.length > 0 ? head : new Uint8Array(0),
+			);
+			if (!delivered) {
+				socket.end('HTTP/1.1 502 Bad Gateway\r\n\r\n');
+				vmSocket.destroy();
+			}
+		});
+
+		server.on('error', (error: Error) => reject(error));
+
+		server.listen(hostPort, host, () => {
+			const address = server.address();
+			const bound = typeof address === 'object' && address ? address.port : hostPort;
+			resolve({
+				hostPort: bound,
+				url: `http://${host}:${bound}`,
+				close() {
+					return new Promise<void>((res, rej) => {
+						server.close((err) => (err ? rej(err) : res()));
+					});
+				},
+			});
+		});
+	});
+}

--- a/packages/core/src/kernel/vfs/snapshot.ts
+++ b/packages/core/src/kernel/vfs/snapshot.ts
@@ -12,9 +12,40 @@ const YIELD_EVERY = 200;
 const EMPTY = new Uint8Array(0);
 const yieldToEventLoop = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
 
+/**
+ * Reserved tar entry carrying session state alongside the files.
+ *
+ * Every VFS path starts with `/`, so a relative entry name cannot collide with a
+ * real file. It exists so ONE format serves every environment: before this, the
+ * CLI needed somewhere to keep `cwd`/`env`/`mountPath` and so invented a
+ * different container (a zip wrapping a JSON-serialized VFS), which meant a
+ * snapshot saved by the CLI could not be opened in the browser and vice versa.
+ */
+export const SNAPSHOT_MANIFEST_ENTRY = 'lifo-snapshot.json';
+
+/** Session state travelling with a snapshot. All fields optional but `version`. */
+export interface SnapshotMetadata {
+  version: 1;
+  /** ISO timestamp, stamped on export. */
+  savedAt: string;
+  /** Working directory to restore. */
+  cwd?: string;
+  /** Environment to restore. */
+  env?: Record<string, string>;
+  /** Host directory this box had mounted, so a restore can reuse it (CLI). */
+  mountPath?: string;
+  /** Version of @lifo-sh/core that wrote it, for diagnosing odd restores. */
+  lifoVersion?: string;
+}
+
 export interface VfsSnapshotOptions {
   /** Path segments to skip, e.g. `['node_modules', '.git']`. */
   exclude?: string[];
+  /**
+   * Session state to embed. Omit for a files-only snapshot — which is exactly
+   * what pre-manifest snapshots are, so they keep restoring unchanged.
+   */
+  metadata?: Omit<Partial<SnapshotMetadata>, 'version' | 'savedAt'>;
 }
 
 /**
@@ -43,6 +74,22 @@ export async function exportVfsSnapshot(vfs: VFS, opts: VfsSnapshotOptions = {})
   };
 
   await walk('/');
+
+  // Manifest last, so a reader streaming entries has already seen the files.
+  if (opts.metadata) {
+    const manifest: SnapshotMetadata = {
+      version: 1,
+      savedAt: new Date().toISOString(),
+      ...opts.metadata,
+    };
+    entries.push({
+      path: SNAPSHOT_MANIFEST_ENTRY,
+      data: new TextEncoder().encode(JSON.stringify(manifest, null, 2)),
+      type: 'file',
+      mode: 0o644,
+      mtime: Math.floor(Date.now() / 1000),
+    });
+  }
   const tar = createTar(entries);
   return compressGzip(tar);
 }
@@ -52,11 +99,27 @@ export async function exportVfsSnapshot(vfs: VFS, opts: VfsSnapshotOptions = {})
  * then files; skips writing a file over an existing directory so a restore can
  * never throw mid-way. Yields periodically to stay responsive.
  */
-export async function importVfsSnapshot(vfs: VFS, data: Uint8Array): Promise<void> {
+export async function importVfsSnapshot(vfs: VFS, data: Uint8Array): Promise<SnapshotMetadata | null> {
   const tar = await decompressGzip(data);
   const entries = parseTar(tar);
   const dirs = entries.filter((e) => e.type === 'directory');
-  const files = entries.filter((e) => e.type === 'file');
+
+  // The manifest is metadata, not a file to restore — without this it would be
+  // written into the VFS as /lifo-snapshot.json, since the loop below prefixes
+  // any relative entry with '/'.
+  let metadata: SnapshotMetadata | null = null;
+  const files = entries.filter((e) => {
+    if (e.type !== 'file') return false;
+    if (e.path === SNAPSHOT_MANIFEST_ENTRY || e.path === '/' + SNAPSHOT_MANIFEST_ENTRY) {
+      try {
+        metadata = JSON.parse(new TextDecoder().decode(e.data)) as SnapshotMetadata;
+      } catch {
+        // A corrupt manifest must not cost you the files.
+      }
+      return false;
+    }
+    return true;
+  });
 
   for (const entry of dirs) {
     const path = entry.path.startsWith('/') ? entry.path : '/' + entry.path;
@@ -72,4 +135,27 @@ export async function importVfsSnapshot(vfs: VFS, data: Uint8Array): Promise<voi
     vfs.writeFile(path, entry.data);
     if (++count % YIELD_EVERY === 0) await yieldToEventLoop();
   }
+
+  return metadata;
+}
+
+/**
+ * Read just the manifest from a snapshot archive, without touching a VFS.
+ *
+ * A restorer often has to make decisions BEFORE it has somewhere to restore into
+ * — the CLI picks which host directory to mount based on `mountPath` — so the
+ * metadata has to be readable on its own.
+ */
+export async function readSnapshotMetadata(data: Uint8Array): Promise<SnapshotMetadata | null> {
+  const tar = await decompressGzip(data);
+  for (const entry of parseTar(tar)) {
+    if (entry.path === SNAPSHOT_MANIFEST_ENTRY || entry.path === '/' + SNAPSHOT_MANIFEST_ENTRY) {
+      try {
+        return JSON.parse(new TextDecoder().decode(entry.data)) as SnapshotMetadata;
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
 }

--- a/packages/core/src/sandbox/Sandbox.ts
+++ b/packages/core/src/sandbox/Sandbox.ts
@@ -29,6 +29,7 @@ import { SandboxFsImpl } from './SandboxFs.js';
 import { SandboxCommandsImpl } from './SandboxCommands.js';
 import { HeadlessTerminal } from './HeadlessTerminal.js';
 import { dispatchRequest, waitForPort } from '../kernel/network/dispatch.js';
+import type { SnapshotMetadata } from '../kernel/vfs/snapshot.js';
 import { connectVmWebSocket } from './vm-websocket.js';
 import type { SandboxConnectOptions, VmWebSocket } from './vm-websocket.js';
 
@@ -410,18 +411,41 @@ export class Sandbox {
 	}
 
 	/**
-	 * Export the VFS as a tar.gz snapshot. Pass `{ exclude: ['node_modules'] }`
+	 * Export the box as a `tar.gz` snapshot. Pass `{ exclude: ['node_modules'] }`
 	 * to skip subtrees (smaller snapshot; restore then needs a reinstall).
+	 *
+	 * The archive carries the working directory and environment in a
+	 * `lifo-snapshot.json` manifest beside the files, so the SAME file restores in
+	 * the browser, in Node and through the CLI. Pass `{ metadata: false }` for a
+	 * files-only archive.
 	 */
-	async exportSnapshot(options?: SnapshotOptions): Promise<Uint8Array> {
-		return this.fs.exportSnapshot(options);
+	async exportSnapshot(options: SnapshotOptions = {}): Promise<Uint8Array> {
+		const { metadata, ...rest } = options;
+		return this.fs.exportSnapshot({
+			...rest,
+			metadata: metadata === false
+				? undefined
+				: { cwd: this.cwd, env: this.env, ...(typeof metadata === 'object' ? metadata : {}) },
+		});
 	}
 
 	/**
-	 * Restore VFS from a tar.gz snapshot.
+	 * Restore the box from a `tar.gz` snapshot.
+	 *
+	 * Files are always restored. `cwd` and `env` are applied when the archive
+	 * carries a manifest — a files-only archive (anything written before manifests
+	 * existed) restores exactly as it used to. Returns the manifest, or `null`.
 	 */
-	async importSnapshot(data: Uint8Array): Promise<void> {
-		return this.fs.importSnapshot(data);
+	async importSnapshot(data: Uint8Array): Promise<SnapshotMetadata | null> {
+		if (this._destroyed) throw new Error('Sandbox is destroyed');
+		const metadata = await this.fs.importSnapshot(data);
+		if (metadata?.env) {
+			for (const [key, value] of Object.entries(metadata.env)) this.env[key] = value;
+		}
+		if (metadata?.cwd && this.kernel.vfs.exists(metadata.cwd)) {
+			this.shell.setCwd(metadata.cwd);
+		}
+		return metadata;
 	}
 
 	/**

--- a/packages/core/src/sandbox/SandboxFs.ts
+++ b/packages/core/src/sandbox/SandboxFs.ts
@@ -2,6 +2,7 @@ import type { VFS } from '../kernel/vfs/index.js';
 import type { SandboxFs as ISandboxFs } from './types.js';
 import { resolve } from '../utils/path.js';
 import { exportVfsSnapshot, importVfsSnapshot } from '../kernel/vfs/snapshot.js';
+import type { SnapshotMetadata } from '../kernel/vfs/snapshot.js';
 import type { SnapshotOptions } from './types.js';
 
 /**
@@ -88,10 +89,16 @@ export class SandboxFsImpl implements ISandboxFs {
 
   /** Directories to skip during export (virtual providers) */
   async exportSnapshot(options: SnapshotOptions = {}): Promise<Uint8Array> {
-    return exportVfsSnapshot(this.vfs, options);
+    // `metadata: false` is a Sandbox-level convenience meaning "files only";
+    // the VFS layer just takes an optional object.
+    const { metadata, ...rest } = options;
+    return exportVfsSnapshot(this.vfs, {
+      ...rest,
+      metadata: metadata === false ? undefined : metadata,
+    });
   }
 
-  async importSnapshot(data: Uint8Array): Promise<void> {
+  async importSnapshot(data: Uint8Array): Promise<SnapshotMetadata | null> {
     return importVfsSnapshot(this.vfs, data);
   }
 }

--- a/packages/core/src/sandbox/types.ts
+++ b/packages/core/src/sandbox/types.ts
@@ -1,5 +1,6 @@
 import type { Command } from '../commands/types.js';
 import type { Kernel } from '../kernel/index.js';
+import type { SnapshotMetadata } from '../kernel/vfs/snapshot.js';
 import type { Shell } from '../shell/Shell.js';
 import type { ITerminal } from '../terminal/ITerminal.js';
 import type { NativeFsModule } from '../kernel/vfs/providers/NativeFsProvider.js';
@@ -78,6 +79,14 @@ export interface SnapshotOptions {
    * box must reinstall (`npm install`) before it can run.
    */
   exclude?: string[];
+  /**
+   * Session state to embed in the archive's `lifo-snapshot.json` manifest.
+   *
+   * Defaults to the box's `cwd` + `env`, which is what makes one snapshot file
+   * portable across the browser, Node and the CLI. Pass extra fields to add to
+   * it, or `false` for a files-only archive.
+   */
+  metadata?: false | Omit<Partial<SnapshotMetadata>, 'version' | 'savedAt'>;
 }
 
 export interface SandboxFs {
@@ -95,7 +104,7 @@ export interface SandboxFs {
   /** Export the VFS as a tar.gz snapshot (optionally excluding paths). */
   exportSnapshot(options?: SnapshotOptions): Promise<Uint8Array>;
   /** Restore VFS from a tar.gz snapshot */
-  importSnapshot(data: Uint8Array): Promise<void>;
+  importSnapshot(data: Uint8Array): Promise<SnapshotMetadata | null>;
 }
 
 // ─── Internal types for Sandbox internals ───

--- a/packages/core/tests/kernel/expose.test.ts
+++ b/packages/core/tests/kernel/expose.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as http from 'node:http';
+import { Sandbox } from '../../src/sandbox/index.js';
+import { exposePort, type ExposedPort } from '../../src/kernel/network/expose.js';
+import { LIFO_HEADER } from '../../src/kernel/network/dispatch.js';
+
+/**
+ * `exposePort` publishes an in-VM port on a REAL host port, so these tests use
+ * the host's own `fetch` and `ws` — nothing in the assertion path knows about
+ * Lifo. If these pass, `curl` works.
+ */
+const SERVER = `const http = require('http');
+const { WebSocketServer } = require('ws');
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/json') { res.writeHead(200, {'content-type':'application/json'}); return res.end(JSON.stringify({ from: 'inside the vm' })); }
+  if (req.url === '/binary') { res.writeHead(200, {'content-type':'application/octet-stream'}); return res.end(Buffer.from([0,1,2,250,255])); }
+  if (req.method === 'POST' && req.url === '/echo') {
+    let body = '';
+    req.on('data', (c) => { body += c.toString(); });
+    req.on('end', () => { res.writeHead(201, {'content-type':'application/json'}); res.end(JSON.stringify({ got: body, len: req.headers['content-length'] || null })); });
+    return;
+  }
+  res.writeHead(404, {'content-type':'text/plain'});
+  res.end('nope');
+});
+
+const wss = new WebSocketServer({ server, path: '/ws' });
+wss.on('connection', (ws) => {
+  ws.send('greeting');
+  ws.on('message', (data) => ws.send('echo:' + data.toString()));
+});
+
+server.listen(4600, () => console.log('listening'));
+`;
+
+async function bootBox(): Promise<Sandbox> {
+  const sandbox = await Sandbox.create({ persist: false });
+  await sandbox.fs.writeFile('/home/user/package.json', JSON.stringify({ name: 'e', dependencies: { ws: '^8.19.0' } }));
+  await sandbox.fs.writeFile('/home/user/server.js', SERVER);
+  const install = await sandbox.commands.run('npm install 2>&1 | tail -1', { cwd: '/home/user', timeout: 300_000 });
+  if (install.exitCode !== 0) throw new Error('npm install failed: ' + install.stdout);
+  sandbox.shell.execute('node server.js', { cwd: '/home/user', env: sandbox.env }).catch(() => {});
+  await sandbox.waitForPort(4600, { timeout: 30_000 });
+  return sandbox;
+}
+
+describe('exposePort', () => {
+  let sandbox: Sandbox | undefined;
+  let exposed: ExposedPort | undefined;
+
+  afterEach(async () => {
+    await exposed?.close();
+    exposed = undefined;
+    sandbox?.destroy();
+    sandbox = undefined;
+  });
+
+  it('serves an in-VM server over a real host port', async () => {
+    sandbox = await bootBox();
+    exposed = await exposePort(sandbox.kernel.portRegistry, { vmPort: 4600, http });
+    // The host's own fetch — no Lifo in the request path.
+    const res = await fetch(`${exposed.url}/json`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ from: 'inside the vm' });
+  }, 300_000);
+
+  // vmPort and hostPort are independent: in-VM 4600 published on host 5137.
+  it('maps an in-VM port to a DIFFERENT host port', async () => {
+    sandbox = await bootBox();
+    exposed = await exposePort(sandbox.kernel.portRegistry, { vmPort: 4600, hostPort: 5137, http });
+    expect(exposed.hostPort).toBe(5137);
+    expect(exposed.url).toBe('http://127.0.0.1:5137');
+
+    const res = await fetch('http://127.0.0.1:5137/json');
+    expect(await res.json()).toEqual({ from: 'inside the vm' });
+
+    // Nothing is listening on the VM's own number on the host — the mapping is
+    // the only route in.
+    await expect(fetch('http://127.0.0.1:4600/json')).rejects.toThrow();
+  }, 300_000);
+
+  it('assigns a free port when none is given, and reports it', async () => {
+    sandbox = await bootBox();
+    exposed = await exposePort(sandbox.kernel.portRegistry, { vmPort: 4600, http });
+    expect(exposed.hostPort).toBeGreaterThan(0);
+    expect(exposed.url).toContain(String(exposed.hostPort));
+  }, 300_000);
+
+  it('forwards a POST body and its content-length', async () => {
+    sandbox = await bootBox();
+    exposed = await exposePort(sandbox.kernel.portRegistry, { vmPort: 4600, http });
+    const res = await fetch(`${exposed.url}/echo`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ hi: 'there' }),
+    });
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({ got: '{"hi":"there"}', len: '14' });
+  }, 300_000);
+
+  it('preserves a binary body byte-for-byte', async () => {
+    sandbox = await bootBox();
+    exposed = await exposePort(sandbox.kernel.portRegistry, { vmPort: 4600, http });
+    const res = await fetch(`${exposed.url}/binary`);
+    expect(Array.from(new Uint8Array(await res.arrayBuffer()))).toEqual([0, 1, 2, 250, 255]);
+  }, 300_000);
+
+  it('passes the app’s own 404 through unchanged', async () => {
+    sandbox = await bootBox();
+    exposed = await exposePort(sandbox.kernel.portRegistry, { vmPort: 4600, http });
+    const res = await fetch(`${exposed.url}/missing`);
+    expect(res.status).toBe(404);
+    expect(await res.text()).toBe('nope');
+    expect(res.headers.get(LIFO_HEADER)).toBeNull();
+  }, 300_000);
+
+  it('can be bound before the in-VM server exists, answering 404 + x-lifo until then', async () => {
+    sandbox = await Sandbox.create({ persist: false });
+    exposed = await exposePort(sandbox.kernel.portRegistry, { vmPort: 4699, http });
+    const res = await fetch(`${exposed.url}/`);
+    expect(res.status).toBe(404);
+    expect(res.headers.get(LIFO_HEADER)).toBe('no-server');
+  }, 60_000);
+
+  it('proxies a WebSocket, letting the in-VM server do the handshake', async () => {
+    sandbox = await bootBox();
+    exposed = await exposePort(sandbox.kernel.portRegistry, { vmPort: 4600, http });
+
+    // A real ws client against the host port — it must see a valid RFC 6455
+    // handshake, which the in-VM server produced.
+    const { WebSocket } = await import('ws');
+    const client = new WebSocket(`ws://127.0.0.1:${exposed.hostPort}/ws`);
+    const messages: string[] = [];
+    await new Promise<void>((resolve, reject) => {
+      client.on('message', (d: Buffer) => {
+        messages.push(d.toString());
+        if (messages.length === 2) resolve();
+      });
+      client.on('open', () => client.send('marco'));
+      client.on('error', reject);
+      setTimeout(() => reject(new Error('ws timed out; got ' + JSON.stringify(messages))), 20_000);
+    });
+    client.close();
+    expect(messages[0]).toBe('greeting');
+    expect(messages[1]).toBe('echo:marco');
+  }, 300_000);
+
+  it('rejects when the host port is already taken', async () => {
+    sandbox = await Sandbox.create({ persist: false });
+    exposed = await exposePort(sandbox.kernel.portRegistry, { vmPort: 4600, http });
+    await expect(
+      exposePort(sandbox.kernel.portRegistry, { vmPort: 4600, hostPort: exposed.hostPort, http }),
+    ).rejects.toThrow(/EADDRINUSE|address already in use/i);
+  }, 60_000);
+
+  it('stops serving after close()', async () => {
+    sandbox = await bootBox();
+    const e = await exposePort(sandbox.kernel.portRegistry, { vmPort: 4600, http });
+    const url = `${e.url}/json`;
+    expect((await fetch(url)).status).toBe(200);
+    await e.close();
+    await expect(fetch(url)).rejects.toThrow();
+  }, 300_000);
+});

--- a/packages/core/tests/sandbox/snapshot.test.ts
+++ b/packages/core/tests/sandbox/snapshot.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { Sandbox } from '../../src/sandbox/index.js';
+import { readSnapshotMetadata, SNAPSHOT_MANIFEST_ENTRY } from '../../src/kernel/vfs/snapshot.js';
 
 describe('Snapshot import/export', () => {
   let sandbox: Sandbox;
@@ -148,5 +149,83 @@ describe('Snapshot import/export', () => {
 
     const content = await sandbox.fs.readFile('/home/user/test.txt');
     expect(content).toBe('via sandbox');
+  });
+});
+
+describe('snapshot portability (one format everywhere)', () => {
+  // The point of the manifest: a snapshot carries session state, so the SAME file
+  // restores in the browser, in Node and through the CLI. Before it existed the
+  // CLI needed cwd/env and so invented a second, incompatible container.
+  it('carries cwd and env in the archive, and restores them', async () => {
+    const a = await Sandbox.create({ persist: false, env: { MY_VAR: 'set-in-box-a' } });
+    await a.fs.mkdir('/home/user/project', { recursive: true });
+    await a.fs.writeFile('/home/user/project/app.js', 'console.log(1)');
+    a.cwd = '/home/user/project';
+
+    const bytes = await a.exportSnapshot();
+
+    const b = await Sandbox.create({ persist: false });
+    expect(b.cwd).not.toBe('/home/user/project');
+
+    const manifest = await b.importSnapshot(bytes);
+    expect(manifest?.version).toBe(1);
+    expect(manifest?.cwd).toBe('/home/user/project');
+    expect(manifest?.env?.MY_VAR).toBe('set-in-box-a');
+
+    // Applied, not merely reported.
+    expect(b.cwd).toBe('/home/user/project');
+    expect(b.env.MY_VAR).toBe('set-in-box-a');
+    expect(await b.fs.readFile('/home/user/project/app.js')).toBe('console.log(1)');
+
+    a.destroy(); b.destroy();
+  });
+
+  it('readSnapshotMetadata reads the manifest without a VFS', async () => {
+    // The CLI needs mountPath BEFORE it has anywhere to restore into.
+    const a = await Sandbox.create({ persist: false });
+    const bytes = await a.exportSnapshot({ metadata: { mountPath: '/host/dir' } });
+    const manifest = await readSnapshotMetadata(bytes);
+    expect(manifest?.mountPath).toBe('/host/dir');
+    expect(manifest?.savedAt).toBeTruthy();
+    a.destroy();
+  });
+
+  it('the manifest is not restored as a file in the VFS', async () => {
+    const a = await Sandbox.create({ persist: false });
+    const bytes = await a.exportSnapshot();
+    const b = await Sandbox.create({ persist: false });
+    await b.importSnapshot(bytes);
+    // It would land at /lifo-snapshot.json, since importVfsSnapshot prefixes
+    // relative tar entries with '/'.
+    expect(await b.fs.exists('/lifo-snapshot.json')).toBe(false);
+    expect(await b.fs.exists('/' + SNAPSHOT_MANIFEST_ENTRY)).toBe(false);
+    a.destroy(); b.destroy();
+  });
+
+  it('a files-only archive still restores (pre-manifest snapshots keep working)', async () => {
+    const a = await Sandbox.create({ persist: false });
+    await a.fs.writeFile('/home/user/only-files.txt', 'hello');
+    const bytes = await a.exportSnapshot({ metadata: false });
+
+    expect(await readSnapshotMetadata(bytes)).toBeNull();
+
+    const b = await Sandbox.create({ persist: false });
+    const cwdBefore = b.cwd;
+    const manifest = await b.importSnapshot(bytes);
+    expect(manifest).toBeNull();
+    expect(b.cwd).toBe(cwdBefore);                       // nothing to apply
+    expect(await b.fs.readFile('/home/user/only-files.txt')).toBe('hello');
+    a.destroy(); b.destroy();
+  });
+
+  it('caller-supplied metadata merges with cwd/env rather than replacing them', async () => {
+    const a = await Sandbox.create({ persist: false });
+    const bytes = await a.exportSnapshot({ metadata: { mountPath: '/host/x', lifoVersion: 'test' } });
+    const manifest = await readSnapshotMetadata(bytes);
+    expect(manifest?.mountPath).toBe('/host/x');
+    expect(manifest?.lifoVersion).toBe('test');
+    expect(manifest?.cwd).toBeTruthy();     // still stamped automatically
+    expect(manifest?.env).toBeTruthy();
+    a.destroy();
   });
 });

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,72 @@
 # @lifo-sh/ui
 
+## 0.10.0
+
+### Minor Changes
+
+- Publish in-VM ports on the host, one portable snapshot format, and two CLI fixes
+
+  **`exposePort()` / `lifo --expose`** — bind a real host port to a server inside the
+  box. A box's ports are entries in a map, so nothing outside the process could reach
+  them; in the browser that's what the service worker or blob preview is for, but on a
+  host with real sockets neither is needed.
+
+  ```bash
+  lifo --expose 3000            # in-VM 3000 → http://127.0.0.1:3000
+  lifo --expose 3000:5000       # in-VM 3000 → http://127.0.0.1:5000
+  lifo --detach --expose 5173   # background sessions too
+  ```
+
+  Forwards HTTP through the shared dispatcher and WebSockets at the byte level (the
+  client's socket goes to the in-VM server, which does its own handshake — so HMR
+  works and nothing between has to parse a frame). Loopback-only by default, since a
+  box runs project code. Binding doesn't require the server to exist yet: requests get
+  `404` + `x-lifo: no-server` until it's live, which reads better than a refused
+  connection while a dev server boots. `node:http` is injected rather than imported,
+  as `NativeFsProvider` does with `fs`, so the browser bundle is unaffected.
+
+  This is **not** `tunnel`: the in-shell `tunnel` shares a port PUBLICLY via the
+  `tunnel.lifo.sh` relay, while `--expose` binds a local socket with no relay and no
+  network. They compose — expose locally, then `lifo tunnel <hostPort>`.
+
+  **One snapshot format everywhere.** There were two: core wrote a `.tar.gz` of files
+  while the CLI wrote a zip wrapping a JSON-serialized VFS — because the tar had
+  nowhere to keep `cwd`/`env`/`mountPath`. So a snapshot saved by the CLI could not be
+  opened in the browser, and vice versa, which is a strange gap for a project whose
+  point is running the same VM everywhere.
+
+  Snapshots now carry a `lifo-snapshot.json` manifest beside the files (VFS paths all
+  start with `/`, so a relative entry can't collide, and it's never restored as a
+  file). `sandbox.exportSnapshot()` embeds `cwd` + `env` automatically;
+  `importSnapshot()` applies them and returns the manifest. `readSnapshotMetadata()`
+  reads it without a VFS, for decisions that come before you have anywhere to restore
+  into. `{ metadata: false }` gives a files-only archive — which is also exactly how
+  pre-manifest snapshots behave, so old `.tar.gz` files keep restoring.
+
+  The CLI now emits and reads that archive (built by the daemon, which owns the
+  filesystem). **The zip format is gone**; a zip written by lifo ≤ 0.9.0 is rejected
+  with a clear message rather than half-working, and `adm-zip` is no longer a
+  dependency.
+
+  **Two pre-existing CLI bugs**, found because `--expose` couldn't be demonstrated
+  without fixing them:
+
+  - **`lifo --detach` / `lifo new` crashed on startup.** `new Shell(...)` was called
+    with 4 arguments but needs 5 — `processRegistry` was missing, so `shell.start()`
+    threw `Cannot read properties of undefined (reading 'spawn')`. Confirmed identical
+    without any new flag.
+  - **`ps` / `top` / `kill` threw** `processRegistry.getAll is not a function`: the CLI
+    passed `shell.getJobTable()` where a `ProcessRegistry` was expected.
+
+  Both are the same class of stale wiring the failing `shell.test.ts` /
+  `system-extra.test.ts` suites point at (lifo#69). `Sandbox.create` had it right; the
+  CLI wasn't updated when the signature changed.
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.10.0
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/ui",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Embeddable UI components for Lifo \u2014 terminal, preview browser, and file explorer",
   "license": "MIT",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,16 +161,10 @@ importers:
       '@lifo-sh/core':
         specifier: workspace:*
         version: link:../core
-      adm-zip:
-        specifier: ^0.5.10
-        version: 0.5.16
       ws:
         specifier: ^8.19.0
         version: 8.19.0
     devDependencies:
-      '@types/adm-zip':
-        specifier: ^0.5.5
-        version: 0.5.7
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.11
@@ -2285,9 +2279,6 @@ packages:
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
 
-  '@types/adm-zip@0.5.7':
-    resolution: {integrity: sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==}
-
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
 
@@ -2430,10 +2421,6 @@ packages:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  adm-zip@0.5.16:
-    resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
-    engines: {node: '>=12.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -6419,10 +6406,6 @@ snapshots:
       minimatch: 10.2.1
       path-browserify: 1.0.1
 
-  '@types/adm-zip@0.5.7':
-    dependencies:
-      '@types/node': 22.19.11
-
   '@types/argparse@1.0.38': {}
 
   '@types/babel__core@7.20.5':
@@ -6604,8 +6587,6 @@ snapshots:
       negotiator: 1.0.0
 
   acorn@8.17.0: {}
-
-  adm-zip@0.5.16: {}
 
   agent-base@7.1.4: {}
 


### PR DESCRIPTION
Answers two questions directly: **does the CLI map a box port to the host?** (it didn't) and **are snapshots portable across environments?** (they weren't).

## 1. `exposePort()` / `lifo --expose`

```bash
lifo --expose 3000            # in-VM 3000 → http://127.0.0.1:3000
lifo --expose 3000:5000       # in-VM 3000 → http://127.0.0.1:5000
lifo --detach --expose 5173   # background sessions too
```

A box's ports are entries in a `Map`, so nothing outside the process could reach them. In the browser that's what the [service worker](https://lifo.sh/docs/previews) or blob preview is for — on a host with real sockets, neither is needed.

- **HTTP** through the shared dispatcher, so slow servers/timeouts/unbound ports behave as everywhere else.
- **WebSockets** forwarded at the **byte** level: the client's socket is handed to the in-VM server, which does its own RFC 6455 handshake. HMR works and nothing in between parses a frame.
- **Loopback-only by default** — a box runs project code; publishing on every interface should be asked for.
- **Binding doesn't require the server to exist yet.** Requests get `404` + `x-lifo: no-server` until it's live, which reads better than a refused connection while a dev server boots. The CLI binds forwards *before* the shell starts for that reason.
- `node:http` is **injected**, as `NativeFsProvider` does with `fs`, so the browser bundle is untouched.

**Not the same as `tunnel`** — worth stating since it looks similar:

| | reaches | needs |
| --- | --- | --- |
| `--expose` | a **local** host port | nothing; no relay, no network, offline |
| in-shell `tunnel 5173` | a **public** URL | `tunnel.lifo.sh` relay, network, maybe auth |

They compose: expose locally, then `lifo tunnel <hostPort>`. (Host-side `lifo tunnel` proxies a *host* port and can't reach into a box on its own — that's the gap this closes.)

## 2. One snapshot format everywhere

There were **two**. core wrote a `.tar.gz` of files; the CLI wrote a **zip wrapping a JSON-serialized VFS** — because the tar had nowhere to keep `cwd`/`env`/`mountPath`. So a snapshot saved by the CLI could not be opened in the browser, or the reverse. A strange gap for a project whose point is running the same VM everywhere.

Snapshots now carry a `lifo-snapshot.json` manifest beside the files:

```bash
tar tzf box.tar.gz | head -2
#   lifo-snapshot.json      ← { version, savedAt, cwd, env, mountPath }
#   /home/user/…            ← the filesystem
```

Every VFS path starts with `/`, so a relative entry can't collide — and it's never restored *as* a file (it would otherwise land at `/lifo-snapshot.json`, since the importer prefixes relative entries; there's a test pinning that).

- `sandbox.exportSnapshot()` embeds `cwd` + `env` automatically
- `importSnapshot()` applies them and returns the manifest
- `readSnapshotMetadata()` reads it **without a VFS** — the CLI needs `mountPath` before it has anywhere to restore into
- `{ metadata: false }` gives a files-only archive, which is also exactly how pre-manifest snapshots behave, so **old `.tar.gz` files keep restoring**

The CLI emits and reads that archive (built by the daemon, which owns the filesystem). **The zip format is gone** — a zip from lifo ≤ 0.9.0 is rejected with an actionable message rather than half-working, and `adm-zip` is dropped as a dependency.

## 3. Two pre-existing CLI bugs

Found because `--expose` couldn't be demonstrated without fixing them, and **both reproduce without any new flag**:

- **`lifo --detach` / `lifo new` crashed at startup.** `new Shell(...)` was called with 4 arguments but needs 5 — `processRegistry` was missing, so `shell.start()` threw `Cannot read properties of undefined (reading 'spawn')`.
- **`ps` / `top` / `kill` threw** `processRegistry.getAll is not a function` — the CLI passed `shell.getJobTable()` where a `ProcessRegistry` was expected.

Same stale-wiring class as the failing suites in #69. `Sandbox.create` had it right; the CLI wasn't updated when the signature changed. `ps` prints a table again, and the daemon boots.

## Verification

- **10 `exposePort` tests** using the host's own `fetch` and `ws` — nothing in the assertion path knows about Lifo. Covers the 3000→5000 mapping (including that the VM's own number *isn't* reachable on the host), OS-assigned ports, POST bodies with `content-length`, binary integrity, an app's own 404 passing through, a WebSocket round trip, `EADDRINUSE`, and `close()`.
- **10 snapshot tests**, 5 of them new: manifest round trip, `readSnapshotMetadata` without a VFS, the manifest not landing in the VFS, files-only archives, metadata merging.
- **`bench/test-snapshot-portability.mjs` — 11 checks.** Saves through the **real CLI** (daemon + Unix socket + `lifo snapshot save`), then restores that byte-identical file into a plain `@lifo-sh/core` box with `cwd` and `env` intact — and the reverse.
- **End to end through the built binary:** `curl http://127.0.0.1:5099/hello-from-host` → `{"hello":"from inside the box","url":"/hello-from-host"}`.
- No regressions: `dispatch`, `service-worker-bridge`, `sandbox`, `sandbox-net`, `sandbox-connect`, `vfs` suites and the nosw bench all pass; `pnpm build` exits 0; core `src` typecheck at its 9 pre-existing errors.

Docs in the companion website PR: a **Snapshots** guide (what's in the archive, excluding `node_modules`, files-only, browser + CLI usage) and **Publishing a port on the host**, plus the `tunnel` distinction spelled out.

## Version

Pinned to **0.10.0** by hand — changesets escalates a `minor` to `1.0.0` because core and ui peer-depend on each other. Worth loosening those ranges so this stops recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)