### PR TITLE
test(cli): first tests for the CLI package + fix snapshot list finding nothing

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "build:ui": "pnpm --filter @lifo-sh/ui build",
     "build:cli": "pnpm --filter lifo-sh build",
     "typecheck": "pnpm --filter @lifo-sh/core typecheck",
-    "test": "pnpm --filter @lifo-sh/core test && pnpm --filter lifo-pkg-git test",
+    "test": "pnpm --filter @lifo-sh/core test && pnpm --filter lifo-pkg-git test && pnpm --filter lifo-sh test",
     "dev": "pnpm --filter @lifo-sh/playground dev",
     "dev:cli": "pnpm --filter lifo-sh dev",
     "changeset": "changeset",
     "version": "changeset version",
-    "release": "pnpm build && pnpm changeset publish"
+    "release": "pnpm build && pnpm changeset publish",
+    "test:cli": "pnpm --filter lifo-sh test"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,42 @@
 # lifo-sh
 
+## 0.10.1
+
+### Patch Changes
+
+- Fix `lifo snapshot list` finding nothing, and add tests to the CLI package
+
+  `listSnapshots()` filtered `.zip` while `snapshot save` writes `.tar.gz`, so
+  `lifo snapshot list` reported "No snapshots found" however many you had — a bug
+  introduced with the format change in 0.10.0. It now matches `.tar.gz`, and takes an
+  optional directory so it's testable without writing into a real home directory.
+
+  The CLI package also has tests for the first time — **22 across 4 files**, spawning
+  the built binary the way a user invokes it. That absence is why three bugs shipped:
+  this one, `new Shell()` called with 4 arguments instead of 5 (which crashed every
+  detached session at startup), and `ps`/`top`/`kill` handed a job table where a
+  `ProcessRegistry` was expected. Each was re-introduced deliberately to confirm the
+  new tests fail on it.
+
+  Coverage: a session boots and stays alive with nothing thrown; commands run; `ps`
+  lists the shell; `top`/`kill` don't throw; the host mount works both directions;
+  `--expose` answers `404 x-lifo: no-server` before the in-VM server exists, then
+  forwards to it on a different host port, reports each mapping, and keeps the session
+  alive when one mapping can't bind; `snapshot save` writes an archive whose manifest
+  carries the session's cwd and env, and that archive restores into a core box.
+
+  `parseExpose` moved to `src/args.ts` — `index.ts` runs `main()` at import time, so
+  nothing exported from it can be unit-tested.
+
+  Two things worth knowing for anyone extending these:
+
+  - Tests spawn `dist/index.js`, not the TypeScript source. `tsx src/index.ts` dies on
+    a `browser-metro` named export that the bundle resolves fine, which also means the
+    package's own `dev` script is currently broken.
+  - The child's `NODE_OPTIONS` is stripped. vitest puts its module loader there, and a
+    CLI booting under it resolves `browser-metro` differently and fails an ESM
+    named-export check — the child has to run like a user's shell, not a test worker.
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-sh",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Run Lifo (a Linux-like OS) in your terminal -- npx lifo-sh",
   "license": "MIT",
   "repository": {
@@ -35,7 +35,9 @@
   "scripts": {
     "build": "tsup",
     "dev": "NODE_ENV=development tsx src/index.ts",
-    "prepublishOnly": "node ../../scripts/ensure-pnpm-publish.mjs"
+    "prepublishOnly": "node ../../scripts/ensure-pnpm-publish.mjs",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@lifo-sh/core": "workspace:*",
@@ -46,6 +48,7 @@
     "@types/ws": "^8.18.1",
     "tsup": "^8.0.0",
     "tsx": "^4.0.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -1,0 +1,35 @@
+/**
+ * args.ts — argument parsing helpers, kept out of index.ts so they can be tested.
+ *
+ * `index.ts` calls `main()` at import time, so anything exported from there is
+ * unreachable from a test without booting the CLI. Pure parsing lives here
+ * instead.
+ */
+
+/** An `--expose vmPort[:hostPort]` mapping. */
+export interface ExposeMapping {
+	vmPort: number;
+	hostPort: number;
+}
+
+const isPort = (n: number): boolean => Number.isInteger(n) && n >= 1 && n <= 65535;
+
+/**
+ * Parse `--expose 3000` or `--expose 3000:8080`.
+ *
+ * `hostPort` defaults to `vmPort`, so the common case needs no colon. Returns
+ * `null` for anything unparseable — the caller reports it and exits, rather than
+ * silently forwarding a port nobody asked for.
+ */
+export function parseExpose(spec: string): ExposeMapping | null {
+	const parts = spec.split(':');
+	if (parts.length > 2) return null;
+
+	const [left, right] = parts;
+	if (!left) return null;
+
+	const vmPort = Number(left);
+	const hostPort = right === undefined || right === '' ? vmPort : Number(right);
+	if (!isPort(vmPort) || !isPort(hostPort)) return null;
+	return { vmPort, hostPort };
+}

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -23,6 +23,7 @@
 
 import * as cp from 'node:child_process';
 import * as fs from 'node:fs';
+import type { ExposeMapping } from './args.js';
 import * as path from 'node:path';
 import { randomBytes } from 'node:crypto';
 import { SESSIONS_DIR } from './session.js';
@@ -88,7 +89,7 @@ export async function startDaemon(
   snapshotPath?: string,
   scriptPath?: string,
   /** `--expose vmPort:hostPort` mappings to forward to the daemon process. */
-  expose?: Array<{ vmPort: number; hostPort: number }>,
+  expose?: ExposeMapping[],
 ): Promise<string> {
   const id = generateId();
   const jsonPath = path.join(SESSIONS_DIR, `${id}.json`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -89,6 +89,7 @@ import {
 	listSnapshots,
 } from './snapshot.js';
 import { handleTunnel, createHostTunnelCommand } from './tunnel.js';
+import { parseExpose, type ExposeMapping } from './args.js';
 import { serialize, deserialize } from '@lifo-sh/core';
 
 // ─── CLI argument parsing ──────────────────────────────────────────────────────
@@ -134,17 +135,7 @@ interface CliOptions {
 	 * Publish in-VM ports on real host ports: `--expose 3000` or
 	 * `--expose 3000:8080` (vmPort:hostPort). Repeatable.
 	 */
-	expose?: Array<{ vmPort: number; hostPort: number }>;
-}
-
-/** Parse `--expose 3000` / `--expose 3000:8080`. hostPort defaults to vmPort. */
-function parseExpose(spec: string): { vmPort: number; hostPort: number } | null {
-	const [left, right] = spec.split(':');
-	const vmPort = Number(left);
-	const hostPort = right === undefined ? vmPort : Number(right);
-	const valid = (n: number) => Number.isInteger(n) && n >= 1 && n <= 65535;
-	if (!valid(vmPort) || !valid(hostPort)) return null;
-	return { vmPort, hostPort };
+	expose?: ExposeMapping[];
 }
 
 /**
@@ -160,7 +151,7 @@ function parseExpose(spec: string): { vmPort: number; hostPort: number } | null 
  */
 async function startExposedPorts(
 	kernel: Kernel,
-	mappings: Array<{ vmPort: number; hostPort: number }> | undefined,
+	mappings: ExposeMapping[] | undefined,
 	write: (text: string) => void,
 ): Promise<ExposedPort[]> {
 	if (!mappings || mappings.length === 0) return [];
@@ -299,7 +290,7 @@ async function runDaemon(
 	port?: number,
 	snapshotPath?: string,
 	/** `--expose` mappings; bound here because the daemon owns the kernel. */
-	expose?: Array<{ vmPort: number; hostPort: number }>,
+	expose?: ExposeMapping[],
 ): Promise<void> {
 	const socketPath = path.join(SESSIONS_DIR, `${id}.sock`);
 

--- a/packages/cli/src/snapshot.ts
+++ b/packages/cli/src/snapshot.ts
@@ -139,11 +139,21 @@ export function readSnapshotArchive(archivePath: string): Uint8Array {
   return new Uint8Array(buf);
 }
 
-/** Lists all .zip files in ~/.lifo/snapshots/. */
-export function listSnapshots(): string[] {
-  if (!fs.existsSync(SNAPSHOTS_DIR)) return [];
+/**
+ * Lists snapshot archives in `~/.lifo/snapshots/`.
+ *
+ * Matches `.tar.gz`, the extension `snapshot save` writes. It used to match
+ * `.zip` — which meant that once saves moved to `.tar.gz`, `lifo snapshot list`
+ * reported "No snapshots found" no matter how many you had. Zip snapshots are no
+ * longer readable, so listing them would only offer files that can't be restored.
+ *
+ * `dir` is a parameter so this is testable without writing into a real home
+ * directory.
+ */
+export function listSnapshots(dir: string = SNAPSHOTS_DIR): string[] {
+  if (!fs.existsSync(dir)) return [];
   return fs
-    .readdirSync(SNAPSHOTS_DIR)
-    .filter((f) => f.endsWith('.zip'))
-    .map((f) => path.join(SNAPSHOTS_DIR, f));
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.tar.gz'))
+    .map((f) => path.join(dir, f));
 }

--- a/packages/cli/tests/args.test.ts
+++ b/packages/cli/tests/args.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { parseExpose } from '../src/args.js';
+
+/**
+ * Pure parsing for `--expose`. Fast, so the mapping rules are pinned here rather
+ * than only through a booted session.
+ */
+describe('parseExpose', () => {
+  it('maps a bare port to the same port on the host', () => {
+    expect(parseExpose('3000')).toEqual({ vmPort: 3000, hostPort: 3000 });
+  });
+
+  it('maps vmPort:hostPort', () => {
+    expect(parseExpose('3000:5000')).toEqual({ vmPort: 3000, hostPort: 5000 });
+    expect(parseExpose('5173:8080')).toEqual({ vmPort: 5173, hostPort: 8080 });
+  });
+
+  it('accepts the edges of the port range', () => {
+    expect(parseExpose('1')).toEqual({ vmPort: 1, hostPort: 1 });
+    expect(parseExpose('65535:65535')).toEqual({ vmPort: 65535, hostPort: 65535 });
+  });
+
+  it('rejects out-of-range ports', () => {
+    expect(parseExpose('0')).toBeNull();
+    expect(parseExpose('65536')).toBeNull();
+    expect(parseExpose('3000:0')).toBeNull();
+    expect(parseExpose('3000:70000')).toBeNull();
+    expect(parseExpose('-1')).toBeNull();
+  });
+
+  it('rejects non-numeric and malformed input', () => {
+    expect(parseExpose('abc')).toBeNull();
+    expect(parseExpose('3000:abc')).toBeNull();
+    expect(parseExpose('3000.5')).toBeNull();
+    expect(parseExpose('')).toBeNull();
+    expect(parseExpose(':5000')).toBeNull();
+    // Three parts is a mistake, not a mapping — better refused than half-read.
+    expect(parseExpose('3000:5000:7000')).toBeNull();
+  });
+
+  it('treats a trailing colon as "same port", not an error', () => {
+    expect(parseExpose('3000:')).toEqual({ vmPort: 3000, hostPort: 3000 });
+  });
+});

--- a/packages/cli/tests/expose.test.ts
+++ b/packages/cli/tests/expose.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { startSession, freePort, type Session } from './helpers/session.js';
+
+/**
+ * `--expose` end to end: the host's own `fetch` reaching a server inside the box.
+ * Nothing in the assertion path knows about Lifo, so if these pass, `curl` works.
+ */
+describe('lifo --expose', () => {
+  let session: Session | undefined;
+
+  afterEach(async () => {
+    await session?.stop();
+    session = undefined;
+  });
+
+  it('answers 404 with x-lifo: no-server before the in-VM server starts', async () => {
+    // Binding early is deliberate: a request that arrives while a dev server is
+    // still booting should get a status, not a refused connection.
+    const hostPort = await freePort();
+    session = await startSession({ expose: [`3000:${hostPort}`] });
+
+    const res = await fetch(`http://127.0.0.1:${hostPort}/`);
+    expect(res.status).toBe(404);
+    expect(res.headers.get('x-lifo')).toBe('no-server');
+  });
+
+  it('forwards to an in-VM server once it is listening, on a DIFFERENT host port', async () => {
+    const hostPort = await freePort();
+    session = await startSession({ expose: [`3000:${hostPort}`] });
+
+    const { writeFileSync } = await import('node:fs');
+    writeFileSync(`${session.mountDir}/server.js`, `
+      const http = require('http');
+      http.createServer((req, res) => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ from: 'inside the box', url: req.url }));
+      }).listen(3000, () => console.log('up'));
+    `);
+    await session.run('node /mnt/host/server.js &', 2500);
+
+    // Poll: the server binds asynchronously inside the box.
+    let body: unknown;
+    for (let i = 0; i < 30; i++) {
+      const res = await fetch(`http://127.0.0.1:${hostPort}/hello`);
+      if (res.status === 200) { body = await res.json(); break; }
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    expect(body).toEqual({ from: 'inside the box', url: '/hello' });
+  });
+
+  it('reports each mapping on startup', async () => {
+    const a = await freePort();
+    const b = await freePort();
+    session = await startSession({ expose: [`3000:${a}`, `4000:${b}`] });
+
+    const output = session.stderr();
+    expect(output).toContain(`Exposed in-VM port 3000 at http://127.0.0.1:${a}`);
+    expect(output).toContain(`Exposed in-VM port 4000 at http://127.0.0.1:${b}`);
+  });
+
+  it('keeps the session alive when a mapping cannot bind', async () => {
+    // Hold a port so the forwarder fails on it, then check the box still boots:
+    // losing one forward should not cost you the VM.
+    const taken = await freePort();
+    const net = await import('node:net');
+    const blocker = net.createServer();
+    await new Promise<void>((resolve) => blocker.listen(taken, '127.0.0.1', () => resolve()));
+
+    try {
+      const ok = await freePort();
+      session = await startSession({ expose: [`3000:${taken}`, `4000:${ok}`] });
+
+      expect(session.alive()).toBe(true);
+      expect(session.stderr()).toMatch(/could not expose 3000/);
+      // …and the mapping that could bind still works.
+      const res = await fetch(`http://127.0.0.1:${ok}/`);
+      expect(res.headers.get('x-lifo')).toBe('no-server');
+      expect(await session.run('echo still-here')).toContain('still-here');
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+    }
+  });
+});

--- a/packages/cli/tests/helpers/session.ts
+++ b/packages/cli/tests/helpers/session.ts
@@ -1,0 +1,161 @@
+/**
+ * session.ts — boot a real lifo session and talk to it, for the CLI tests.
+ *
+ * The CLI is spawned as a child process rather than imported: `index.ts` calls
+ * `main()` at import time, and more importantly the thing worth testing is the
+ * entry point as a user invokes it. Two bugs shipped because nothing ever did
+ * that — `new Shell()` missing an argument, and `ps` handed the wrong object.
+ *
+ * Runs through `tsx` so a test loop needs no build step.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as net from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CLI_ENTRY = path.resolve(HERE, '../../dist/index.js');
+const SESSIONS_DIR = path.join(os.homedir(), '.lifo', 'sessions');
+
+/** Strip ANSI so assertions read the text a user sees. */
+export const stripAnsi = (s: string): string => s.replace(/\[[0-9;]*[a-zA-Z]/g, '');
+
+export interface Session {
+  id: string;
+  socketPath: string;
+  /** Host directory mounted at /mnt/host. */
+  mountDir: string;
+  /** Everything the daemon wrote to stderr — where a boot crash shows up. */
+  stderr(): string;
+  alive(): boolean;
+  /** Type a line into the shell and collect what comes back. */
+  run(command: string, settleMs?: number): Promise<string>;
+  stop(): Promise<void>;
+}
+
+let counter = 0;
+
+/**
+ * Boot a detached daemon and wait for its socket.
+ *
+ * Uses the internal `--daemon` flag directly rather than `--detach`, so the test
+ * owns the child process and can read its stderr — `--detach` forks away and the
+ * failure output would be lost.
+ */
+export async function startSession(options: { expose?: string[] } = {}): Promise<Session> {
+  const id = `t${process.pid.toString(36)}${(counter++).toString(36)}`;
+  const mountDir = fs.mkdtempSync(path.join(os.tmpdir(), `lifo-test-${id}-`));
+  const socketPath = path.join(SESSIONS_DIR, `${id}.sock`);
+
+  const args = [CLI_ENTRY, '--daemon', '--id', id, '--mount', mountDir];
+  for (const spec of options.expose ?? []) args.push('--expose', spec);
+
+  if (!fs.existsSync(CLI_ENTRY)) {
+    throw new Error(`${CLI_ENTRY} is missing — build the CLI first (pnpm --filter lifo-sh build).`);
+  }
+
+  // NODE_OPTIONS must NOT be inherited: vitest puts its own module loader there,
+  // and a child booting under it resolves `browser-metro` differently, failing an
+  // ESM named-export check that a plain `node dist/index.js` passes. The child has
+  // to run the way a user's shell would, not the way a test worker does.
+  const env = { ...process.env };
+  delete env.NODE_OPTIONS;
+  delete env.NODE_V8_COVERAGE;
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('VITEST')) delete env[key];
+  }
+
+  const child: ChildProcess = spawn(process.execPath, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    cwd: path.resolve(HERE, '../..'),
+    env,
+  });
+
+  let stderr = '';
+  let stdout = '';
+  child.stderr?.on('data', (d) => { stderr += String(d); });
+  child.stdout?.on('data', (d) => { stdout += String(d); });
+
+  let exited = false;
+  child.on('exit', () => { exited = true; });
+
+  // Wait for the socket the daemon creates after listen() succeeds.
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(socketPath)) break;
+    if (exited) {
+      throw new Error(`daemon exited before creating its socket.\nstderr:\n${stderr}\nstdout:\n${stdout}`);
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  if (!fs.existsSync(socketPath)) {
+    throw new Error(`daemon never created ${socketPath} within 90s.\nstderr:\n${stderr}`);
+  }
+
+  const session: Session = {
+    id,
+    socketPath,
+    mountDir,
+    stderr: () => stderr + stdout,
+    alive: () => !exited,
+    async run(command: string, settleMs = 1200) {
+      return sendAndCollect(socketPath, command, settleMs);
+    },
+    async stop() {
+      try { child.kill('SIGTERM'); } catch { /* already gone */ }
+      await new Promise((r) => setTimeout(r, 300));
+      try { child.kill('SIGKILL'); } catch { /* already gone */ }
+      for (const ext of ['.json', '.sock', '.log']) {
+        try { fs.unlinkSync(path.join(SESSIONS_DIR, id + ext)); } catch { /* fine */ }
+      }
+      try { fs.rmSync(mountDir, { recursive: true, force: true }); } catch { /* fine */ }
+    },
+  };
+  return session;
+}
+
+/**
+ * Send one line to the shell and return the output that follows.
+ *
+ * A carriage return, not a newline: the shell reads keystrokes from a terminal
+ * and submits on CR.
+ */
+export function sendAndCollect(socketPath: string, command: string, settleMs = 1200): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let out = '';
+    let buffer = '';
+    const socket = net.connect(socketPath, () => {
+      socket.write(JSON.stringify({ type: 'input', data: command + '\r' }) + '\n');
+      setTimeout(() => { socket.end(); resolve(stripAnsi(out)); }, settleMs);
+    });
+    socket.on('data', (chunk) => {
+      buffer += String(chunk);
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg.type === 'output' && typeof msg.data === 'string') out += msg.data;
+        } catch { /* not a protocol line */ }
+      }
+    });
+    socket.on('error', reject);
+  });
+}
+
+/** Pick a free host port, so parallel-ish runs don't collide. */
+export async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      srv.close(() => resolve(port));
+    });
+  });
+}

--- a/packages/cli/tests/session.test.ts
+++ b/packages/cli/tests/session.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { startSession, type Session } from './helpers/session.js';
+
+/**
+ * Smoke tests for a real session, spawned the way a user invokes it.
+ *
+ * These exist because two bugs shipped in the CLI that no test could have caught,
+ * since the package had no tests at all:
+ *
+ *   1. `new Shell(...)` was called with 4 arguments but needs 5 — so every
+ *      detached session died at `shell.start()` with
+ *      "Cannot read properties of undefined (reading 'spawn')".
+ *   2. `ps`/`top`/`kill` were handed `shell.getJobTable()` where a
+ *      `ProcessRegistry` was expected, so they threw
+ *      "processRegistry.getAll is not a function".
+ *
+ * Neither is subtle. Both survived because nothing ever booted the thing.
+ */
+describe('lifo session', () => {
+  let session: Session | undefined;
+
+  afterEach(async () => {
+    await session?.stop();
+    session = undefined;
+  });
+
+  // Regression for bug 1. The daemon used to write its session file and then
+  // crash, so "the socket exists" is not enough — it has to still be running.
+  it('boots and stays alive, with nothing thrown on startup', async () => {
+    session = await startSession();
+    await new Promise((r) => setTimeout(r, 2000));
+
+    expect(session.alive()).toBe(true);
+    const output = session.stderr();
+    expect(output).not.toMatch(/TypeError/);
+    expect(output).not.toMatch(/Cannot read properties of undefined/);
+  });
+
+  it('runs a command and returns its output', async () => {
+    session = await startSession();
+    const out = await session.run('echo hello-from-the-box');
+    expect(out).toContain('hello-from-the-box');
+  });
+
+  // Regression for bug 2.
+  it('ps lists the shell process', async () => {
+    session = await startSession();
+    const out = await session.run('ps');
+    expect(out).not.toMatch(/is not a function/);
+    expect(out).toMatch(/PID/);
+    expect(out).toMatch(/shell/);
+  });
+
+  it('top and kill do not throw either', async () => {
+    session = await startSession();
+    const top = await session.run('top');
+    expect(top).not.toMatch(/is not a function/);
+    // Killing PID 1 (the shell) is refused rather than crashing the box.
+    const kill = await session.run('kill 1');
+    expect(kill).not.toMatch(/is not a function/);
+    expect(session.alive()).toBe(true);
+  });
+
+  it('mounts the host directory at /mnt/host', async () => {
+    session = await startSession();
+    const { writeFileSync } = await import('node:fs');
+    writeFileSync(`${session.mountDir}/from-host.txt`, 'written on the host\n');
+
+    const out = await session.run('cat /mnt/host/from-host.txt');
+    expect(out).toContain('written on the host');
+  });
+
+  it('writes through the mount back to the host', async () => {
+    session = await startSession();
+    await session.run('echo written-in-the-box > /mnt/host/from-box.txt');
+
+    const { readFileSync, existsSync } = await import('node:fs');
+    const target = `${session.mountDir}/from-box.txt`;
+    expect(existsSync(target)).toBe(true);
+    expect(readFileSync(target, 'utf8')).toContain('written-in-the-box');
+  });
+});

--- a/packages/cli/tests/snapshot.test.ts
+++ b/packages/cli/tests/snapshot.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { listSnapshots, readSnapshotArchive } from '../src/snapshot.js';
+import { readSnapshotMetadata, Sandbox } from '@lifo-sh/core';
+import { startSession, type Session } from './helpers/session.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.resolve(HERE, '../dist/index.js');
+
+/** Run the CLI the way a user would, without vitest's loader in the child. */
+function cli(args: string[]): string {
+  const env = { ...process.env };
+  delete env.NODE_OPTIONS;
+  for (const key of Object.keys(env)) if (key.startsWith('VITEST')) delete env[key];
+  return execFileSync(process.execPath, [CLI, ...args], { encoding: 'utf8', env });
+}
+
+describe('listSnapshots', () => {
+  let dir: string | undefined;
+  afterEach(() => {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  // Regression: this filtered `.zip` while `snapshot save` wrote `.tar.gz`, so
+  // `lifo snapshot list` always said "No snapshots found".
+  it('finds .tar.gz archives', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lifo-snaplist-'));
+    fs.writeFileSync(path.join(dir, 'a-123.tar.gz'), 'x');
+    fs.writeFileSync(path.join(dir, 'b-456.tar.gz'), 'x');
+
+    const found = listSnapshots(dir).map((p) => path.basename(p)).sort();
+    expect(found).toEqual(['a-123.tar.gz', 'b-456.tar.gz']);
+  });
+
+  it('ignores unrelated files, including zips that can no longer be restored', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lifo-snaplist-'));
+    fs.writeFileSync(path.join(dir, 'real.tar.gz'), 'x');
+    fs.writeFileSync(path.join(dir, 'legacy.zip'), 'x');
+    fs.writeFileSync(path.join(dir, 'notes.txt'), 'x');
+
+    expect(listSnapshots(dir).map((p) => path.basename(p))).toEqual(['real.tar.gz']);
+  });
+
+  it('returns nothing when the directory does not exist', () => {
+    expect(listSnapshots(path.join(os.tmpdir(), 'lifo-does-not-exist-' + Date.now()))).toEqual([]);
+  });
+});
+
+describe('readSnapshotArchive', () => {
+  it('rejects a file that is not an archive, with an actionable message', () => {
+    const f = path.join(os.tmpdir(), `not-a-snapshot-${Date.now()}.zip`);
+    fs.writeFileSync(f, 'PK pretend zip');
+    try {
+      expect(() => readSnapshotArchive(f)).toThrow(/Not a lifo snapshot archive/);
+      expect(() => readSnapshotArchive(f)).toThrow(/no longer supported/);
+    } finally {
+      fs.unlinkSync(f);
+    }
+  });
+});
+
+describe('lifo snapshot save', () => {
+  let session: Session | undefined;
+  let outFile: string | undefined;
+
+  afterEach(async () => {
+    await session?.stop();
+    session = undefined;
+    if (outFile) { try { fs.unlinkSync(outFile); } catch { /* fine */ } }
+    outFile = undefined;
+  });
+
+  it('writes an archive whose manifest carries the session cwd and env', async () => {
+    session = await startSession();
+    await session.run('mkdir -p /home/user/work');
+    await session.run('echo saved-by-the-cli > /home/user/work/note.txt');
+    await session.run('export SNAP_TEST=from-cli');
+    await session.run('cd /home/user/work');
+
+    outFile = path.join(os.tmpdir(), `cli-snap-${Date.now()}.tar.gz`);
+    const out = cli(['snapshot', 'save', session.id, '--output', outFile]);
+    expect(out).toContain('Snapshot saved to');
+    expect(fs.existsSync(outFile)).toBe(true);
+
+    const bytes = readSnapshotArchive(outFile);   // also asserts it's gzip
+    const manifest = await readSnapshotMetadata(bytes);
+    expect(manifest?.version).toBe(1);
+    expect(manifest?.cwd).toBe('/home/user/work');
+    expect(manifest?.env?.SNAP_TEST).toBe('from-cli');
+    expect(typeof manifest?.mountPath).toBe('string');
+  });
+
+  // The reason the format was unified: a CLI snapshot has to open elsewhere.
+  it('produces an archive a core box can restore, cwd and env included', async () => {
+    session = await startSession();
+    await session.run('mkdir -p /home/user/portable');
+    await session.run('echo crosses-environments > /home/user/portable/proof.txt');
+    await session.run('export PORTABLE=yes');
+    await session.run('cd /home/user/portable');
+
+    outFile = path.join(os.tmpdir(), `cli-snap-${Date.now()}.tar.gz`);
+    cli(['snapshot', 'save', session.id, '--output', outFile]);
+
+    const box = await Sandbox.create({ persist: false });
+    try {
+      await box.importSnapshot(readSnapshotArchive(outFile));
+      expect((await box.fs.readFile('/home/user/portable/proof.txt')).trim()).toBe('crosses-environments');
+      expect(box.cwd).toBe('/home/user/portable');
+      expect(box.env.PORTABLE).toBe('yes');
+      // The manifest is metadata, not a file to restore.
+      expect(await box.fs.exists('/lifo-snapshot.json')).toBe(false);
+    } finally {
+      box.destroy();
+    }
+  });
+});

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Every test here boots a real VM in a child process — a few seconds each,
+    // and slower on a cold cache.
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+    // Sessions are global state (~/.lifo/sessions + host ports), so files must
+    // not race each other. Unique ids and ports are still used per test.
+    fileParallelism: false,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(supports-color@8.1.1)(tsx@4.21.0)
 
   packages/core:
     dependencies:
@@ -8666,7 +8669,7 @@ snapshots:
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.5
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2


### PR DESCRIPTION
The `cli` package had **no tests at all**. That's why three bugs shipped — and all three are pinned here. Each was **re-introduced deliberately** to confirm the new test actually fails on it, rather than assuming coverage.

## The bug reported upstream

`lifo snapshot list` reported *"No snapshots found"* however many you had: `listSnapshots()` filtered `.zip` while `snapshot save` writes `.tar.gz`. **I introduced that** with the format change in 0.10.0 — thanks to whoever spotted it.

```diff
- .filter((f) => f.endsWith('.zip'))
+ .filter((f) => f.endsWith('.tar.gz'))
```

It now also takes an optional directory, so it's testable without writing into a real home directory. Zips aren't listed because they can no longer be restored — offering files that fail is worse than not listing them.

## The two it would also have caught

| bug | symptom |
| --- | --- |
| `new Shell()` called with 4 args instead of 5 | every detached session died at `shell.start()` with `Cannot read properties of undefined (reading 'spawn')` |
| `ps`/`top`/`kill` handed a job table where a `ProcessRegistry` was expected | `processRegistry.getAll is not a function` |

Reintroducing each makes the suite fail — the first takes down all 6 session tests, the second exactly the `ps` one, the third exactly the two `listSnapshots` ones.

## What's covered — 22 tests, 4 files

Tests spawn the **built binary** the way a user invokes it:

- **`session`** — boots and stays alive with nothing thrown on startup; commands run; `ps` lists the shell; `top`/`kill` don't throw; the host mount works in **both** directions
- **`expose`** — `404` + `x-lifo: no-server` *before* the in-VM server exists; then forwards to it on a **different** host port; reports each mapping; keeps the session alive when one mapping can't bind
- **`snapshot`** — `save` writes an archive whose manifest carries the session's `cwd` and `env`, and that archive **restores into a core box** (the portability property the format exists for); plus `readSnapshotArchive` rejecting a non-archive
- **`args`** — `parseExpose` mapping rules, port ranges, malformed input

`parseExpose` moved to `src/args.ts`, since `index.ts` calls `main()` at import time and nothing exported from it can be unit-tested.

## Two environment details that cost real time

Both are documented in the helper so the next person doesn't rediscover them:

- **Tests spawn `dist/index.js`, not the TS source.** `tsx src/index.ts` dies on a `browser-metro` named export that the bundle resolves fine — which also means **the package's own `dev` script is currently broken**. Not fixed here; worth its own issue.
- **The child's `NODE_OPTIONS` is stripped.** vitest puts its module loader there, and a CLI booting under it resolves `browser-metro` differently and fails an ESM named-export check. The child has to run like a user's shell, not a test worker. This one presented as "daemon exited before creating its socket" and looked like a product bug.

## Running them

```bash
pnpm test:cli                    # just the CLI
pnpm --filter lifo-sh test       # same thing
```

Root `pnpm test` now includes the CLI, but **the chain still short-circuits on core's pre-existing failures** (#69), so `test:cli` is the one that actually reaches these today. Fixing #69 is what makes `pnpm test` usable as a gate — this PR is the other half of that argument.

Tests clean up after themselves (unique session ids, temp mounts, free host ports; no leftovers in `~/.lifo/sessions`), and run serially since sessions and ports are global state. **`lifo-sh` → 0.10.1**; core and ui unchanged, so no peer escalation this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)