### PR TITLE
feat(pkg): lifo-pkg-orchd — run a workload from orchd.json

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -23,6 +23,7 @@
     "lifo-pkg-less": "workspace:*",
     "lifo-pkg-man": "workspace:*",
     "lifo-pkg-nano": "workspace:*",
+    "lifo-pkg-orchd": "workspace:*",
     "lifo-pkg-vi": "workspace:*",
     "lucide-react": "^0.575.0",
     "monaco-editor": "^0.55.1",

--- a/apps/playground/src/data/templates/orchd.ts
+++ b/apps/playground/src/data/templates/orchd.ts
@@ -1,0 +1,103 @@
+/**
+ * A tiny project carrying an `orchd.json` — the manifest ORCHD uses to describe
+ * a project's workloads across substrates (host process, Docker, a Lifo box).
+ * The `profiles.lifo` block is the point: in a box the mobile workload runs
+ * browser-metro (no node_modules) instead of real Metro.
+ */
+export function orchdProjectFiles(dir: string): Record<string, string> {
+  return {
+    [`${dir}/orchd.json`]: JSON.stringify(
+      {
+        name: 'demo',
+        workloads: [
+          {
+            name: 'mobile',
+            kind: 'node',
+            dir: '.',
+            install: ['npm', 'install'],
+            run: ['npx', 'expo', 'start', '--web', '--port', '$PORT'],
+            profiles: {
+              lifo: { run: ['browser-metro', '.', '--port', '$PORT'] },
+            },
+          },
+          {
+            name: 'api',
+            kind: 'node',
+            dir: 'api',
+            install: ['npm', 'install'],
+            run: ['node', 'index.js'],
+            port_env: 'PORT',
+          },
+        ],
+      },
+      null,
+      2,
+    ) + '\n',
+
+    [`${dir}/package.json`]: JSON.stringify(
+      {
+        name: 'orchd-demo',
+        main: 'index.tsx',
+        dependencies: {
+          expo: '~54.0.0',
+          react: '19.1.0',
+          'react-dom': '19.1.0',
+          'react-native': '0.81.5',
+          'react-native-web': '~0.21.0',
+        },
+      },
+      null,
+      2,
+    ) + '\n',
+
+    [`${dir}/app.json`]: JSON.stringify(
+      { expo: { name: 'orchd-demo', slug: 'orchd-demo', web: { bundler: 'metro' } } },
+      null,
+      2,
+    ) + '\n',
+
+    [`${dir}/index.tsx`]: `import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);
+`,
+
+    [`${dir}/App.tsx`]: `import { StyleSheet, Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Booted from orchd.json</Text>
+      <Text style={styles.body}>
+        The manifest travelled with the project. {'\\n'}
+        \`orchd resolve\` picked the lifo profile.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24, gap: 12 },
+  title: { fontSize: 22, fontWeight: '600' },
+  body: { fontSize: 15, opacity: 0.75, textAlign: 'center', lineHeight: 22 },
+});
+`,
+
+    [`${dir}/api/index.js`]: `const http = require('http');
+
+const port = Number(process.env.PORT) || 3000;
+http
+  .createServer((_req, res) => {
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({ service: 'api', ok: true }));
+  })
+  .listen(port, () => console.log('api listening on ' + port));
+`,
+
+    [`${dir}/api/package.json`]: JSON.stringify(
+      { name: 'orchd-demo-api', private: true, scripts: { start: 'node index.js' } },
+      null,
+      2,
+    ) + '\n',
+  };
+}

--- a/apps/playground/src/data/templates/orchd.ts
+++ b/apps/playground/src/data/templates/orchd.ts
@@ -11,22 +11,26 @@ export function orchdProjectFiles(dir: string): Record<string, string> {
         name: 'demo',
         workloads: [
           {
-            name: 'mobile',
-            kind: 'node',
-            dir: '.',
-            install: ['npm', 'install'],
-            run: ['npx', 'expo', 'start', '--web', '--port', '$PORT'],
-            profiles: {
-              lifo: { run: ['browser-metro', '.', '--port', '$PORT'] },
-            },
-          },
-          {
             name: 'api',
             kind: 'node',
             dir: 'api',
-            install: ['npm', 'install'],
+            port: 3000,
             run: ['node', 'index.js'],
             port_env: 'PORT',
+          },
+          {
+            name: 'mobile',
+            kind: 'node',
+            dir: '.',
+            port: 8081,
+            install: ['npm', 'install'],
+            run: ['npx', 'expo', 'start', '--web', '--port', '$PORT'],
+            // The app learns where the api landed by NAME — on a host that is a
+            // subdomain, in a box it is a port on localhost.
+            env: { EXPO_PUBLIC_API_URL: '${url:api}' },
+            profiles: {
+              lifo: { run: ['browser-metro', '.', '--port', '$PORT'] },
+            },
           },
         ],
       },

--- a/apps/playground/src/examples/orchd.tsx
+++ b/apps/playground/src/examples/orchd.tsx
@@ -1,0 +1,31 @@
+import { ProjectExample } from '@/examples/project-example';
+import { orchdProjectFiles } from '@/data/templates/orchd';
+
+export default function OrchdExample() {
+  return (
+    <ProjectExample
+      title="ORCHD (orchd.json)"
+      subtitle={
+        <>
+          Boot a project from the manifest that ships <em>inside</em> it. Try{' '}
+          <code>orchd list</code>, then <code>orchd resolve --workload mobile --port 8081</code> —
+          it prints <code>browser-metro . --port 8081</code>. Run that line and the preview lights
+          up. No <code>node_modules</code>: the <code>lifo</code> profile swaps real Metro for{' '}
+          <code>browser-metro</code>.
+          <span className="block mt-1.5 text-tokyo-comment/80">
+            The same <code>orchd.json</code> describes this project on a host, in Docker and here —
+            only <code>profiles.lifo</code> differs. Add <code>--json</code> to get{' '}
+            <code>{'{ cwd, argv, env, install }'}</code> for a supervising host. Prefer{' '}
+            <code>resolve</code> over <code>orchd run</code> for dev servers: <code>run</code>{' '}
+            buffers output and can&apos;t be aborted.
+          </span>
+        </>
+      }
+      files={orchdProjectFiles('/home/user/app')}
+      cwd="/home/user/app"
+      previewPort={8081}
+      pkgs={['git', 'orchd']}
+      env={{ EXPO_NO_TELEMETRY: '1', BROWSER: 'none' }}
+    />
+  );
+}

--- a/apps/playground/src/examples/orchd.tsx
+++ b/apps/playground/src/examples/orchd.tsx
@@ -7,17 +7,18 @@ export default function OrchdExample() {
       title="ORCHD (orchd.json)"
       subtitle={
         <>
-          Boot a project from the manifest that ships <em>inside</em> it. Try{' '}
-          <code>orchd list</code>, then <code>orchd resolve --workload mobile --port 8081</code> —
-          it prints <code>browser-metro . --port 8081</code>. Run that line and the preview lights
-          up. No <code>node_modules</code>: the <code>lifo</code> profile swaps real Metro for{' '}
-          <code>browser-metro</code>.
+          Boot a whole project from the manifest that ships <em>inside</em> it. Run{' '}
+          <code>orchd up</code> — it starts the api on port 3000 and the app on 8081, tells the app
+          where the api landed, and hands you back the prompt (<code>jobs</code> lists them). No{' '}
+          <code>node_modules</code>: the <code>lifo</code> profile swaps real Metro for{' '}
+          <code>browser-metro</code>. Also try <code>orchd list</code> and{' '}
+          <code>orchd resolve --all</code>.
           <span className="block mt-1.5 text-tokyo-comment/80">
             The same <code>orchd.json</code> describes this project on a host, in Docker and here —
-            only <code>profiles.lifo</code> differs. Add <code>--json</code> to get{' '}
-            <code>{'{ cwd, argv, env, install }'}</code> for a supervising host. Prefer{' '}
-            <code>resolve</code> over <code>orchd run</code> for dev servers: <code>run</code>{' '}
-            buffers output and can&apos;t be aborted.
+            only <code>profiles.lifo</code> differs. Workloads refer to each other by name:{' '}
+            <code>${'{url:api}'}</code> becomes <code>http://localhost:3000</code>. Add{' '}
+            <code>--json</code> to <code>resolve</code> for{' '}
+            <code>{'{ cwd, argv, env, install }'}</code>, which is what a supervising host runs.
           </span>
         </>
       }

--- a/apps/playground/src/examples/project-example.tsx
+++ b/apps/playground/src/examples/project-example.tsx
@@ -25,6 +25,8 @@ export interface ProjectExampleProps {
   /** Offer "Prune node_modules" in the box menu (Expo projects) — shrinks the
    *  box to just what Metro needs before snapshotting. */
   pruneable?: boolean;
+  /** Extra in-VM packages to register in this example's shells (git is always on). */
+  pkgs?: Array<'git' | 'ffmpeg' | 'orchd'>;
 }
 
 /**
@@ -33,7 +35,7 @@ export interface ProjectExampleProps {
  * preview, split by a resizable handle. The SW bridge serves /_sw/<boxId>/<port>/
  * so each example routes to its own VM.
  */
-export function ProjectExample({ title, subtitle, files, cwd, previewPort, previews, env, pruneable }: ProjectExampleProps) {
+export function ProjectExample({ title, subtitle, files, cwd, previewPort, previews, env, pruneable, pkgs }: ProjectExampleProps) {
   const hasPreview = !!(previews?.length || previewPort);
   // Always present the preview as Chrome-like tabs, even for a single port.
   const previewTabs: PreviewTab[] = previews?.length
@@ -88,7 +90,7 @@ export function ProjectExample({ title, subtitle, files, cwd, previewPort, previ
     if (!sb) return;
     void bootShell(term, sb.kernel, {
       network: true,
-      pkgs: ['git'],
+      pkgs: pkgs ?? ['git'],
       cwd,
       env: { ...browserCorsEnv(), ...env },
     });

--- a/apps/playground/src/examples/registry.tsx
+++ b/apps/playground/src/examples/registry.tsx
@@ -24,6 +24,7 @@ const ExpoSupabaseExample = lazy(() => import('@/examples/expo-supabase'));
 const CliExample = lazy(() => import('@/examples/cli'));
 const LifoPkgExample = lazy(() => import('@/examples/lifo-pkg'));
 const BuildPkgExample = lazy(() => import('@/examples/build-pkg'));
+const OrchdExample = lazy(() => import('@/examples/orchd'));
 
 export type ExampleGroup = 'Examples' | 'Real-World Stacks' | 'Installable Packages' | 'Develop';
 
@@ -61,6 +62,7 @@ export const examples: ExampleConfig[] = [
   // ── Installable Packages ──
   { id: 'git', label: 'Git', group: 'Installable Packages', Component: GitExample },
   { id: 'ffmpeg', label: 'FFmpeg', group: 'Installable Packages', Component: FfmpegExample },
+  { id: 'orchd', label: 'ORCHD (orchd.json)', group: 'Installable Packages', Component: OrchdExample },
   // ── Develop ──
   { id: 'lifo-pkg', label: 'Lifo Package Manager', group: 'Develop', hideCode: true, Component: LifoPkgExample },
   { id: 'build-pkg', label: 'Build Lifo Packages', group: 'Develop', hideCode: true, Component: BuildPkgExample },

--- a/apps/playground/src/lib/shell.ts
+++ b/apps/playground/src/lib/shell.ts
@@ -36,6 +36,7 @@ import viCommand from 'lifo-pkg-vi';
 import calCommand from 'lifo-pkg-cal';
 import bcCommand from 'lifo-pkg-bc';
 import manCommand from 'lifo-pkg-man';
+import orchdCommand from 'lifo-pkg-orchd';
 
 /**
  * CORS-proxy env for every browser box (git clone, expo, etc. can't reach
@@ -59,7 +60,7 @@ export function browserCorsEnv(): Record<string, string> {
 export interface BootShellOptions {
   /** Extra installable-package commands to register. git is always
    *  registered ('git' entries are accepted for back-compat). */
-  pkgs?: Array<'git' | 'ffmpeg'>;
+  pkgs?: Array<'git' | 'ffmpeg' | 'orchd'>;
   /** Register node/curl/tunnel + the network/systemctl command set. */
   network?: boolean;
   /** Boot enabled systemd services after sourcing profile (e.g. tunnel). */
@@ -111,6 +112,7 @@ export async function bootShell(
   registry.register('bc', bcCommand);
   registry.register('man', manCommand);
   if (opts.pkgs?.includes('ffmpeg')) registry.register('ffmpeg', ffmpegCommand);
+  if (opts.pkgs?.includes('orchd')) registry.register('orchd', orchdCommand);
   bootLifoPackages(kernel.vfs, registry);
 
   const env = { ...kernel.getDefaultEnv(), ...browserCorsEnv(), ...opts.env };

--- a/packages/lifo-pkg-orchd/README.md
+++ b/packages/lifo-pkg-orchd/README.md
@@ -1,0 +1,93 @@
+# lifo-pkg-orchd
+
+Run a workload described by an `orchd.json` inside [Lifo](https://lifo.sh).
+Install with `lifo install orchd`, or register it when embedding (see other
+lifo-pkg-* READMEs).
+
+[ORCHD](https://github.com/RapidNative/cloud) provisions per-project workloads
+across substrates — host processes, Docker containers, Lifo sandboxes. The same
+`orchd.json` describes all of them and travels *with* the project (inside a
+snapshot, a tarball, or an image), so whatever boots the project can read one
+file instead of being handed a command line. Inside a Lifo box, that is this
+command.
+
+## Usage
+
+```
+orchd list                            list workloads in the manifest
+orchd resolve [options]               print the resolved command line
+orchd run [options]                   resolve, then run it
+
+  -w, --workload <name>   workload to act on (default: the only one, if unambiguous)
+  -p, --port <n>          port to bind; substituted for $PORT (default: $PORT env)
+      --profile <name>    profile to merge (default: lifo)
+  -c, --config <path>     manifest path (default: ./orchd.json, then /orchd.json)
+      --json              (resolve) emit {cwd, argv, env, install} instead of a line
+      --no-install        skip the install step even if node_modules is missing
+```
+
+## Profiles
+
+The command a workload runs depends on what is executing it. Real Metro wants
+`expo start --web`; a Lifo box usually wants `browser-metro`, which bundles via
+a hosted pre-bundler instead of reading `node_modules`. One manifest, one
+override block:
+
+```jsonc
+{
+  "workloads": [{
+    "name": "mobile",
+    "kind": "node",
+    "dir": "mobile",
+    "install": ["npm", "install"],
+    "run": ["npx", "expo", "start", "--web", "--port", "$PORT"],
+    "profiles": {
+      "lifo": { "run": ["browser-metro", ".", "--port", "$PORT"] }
+    }
+  }]
+}
+```
+
+`run`, `install` and `dir` replace wholesale when a profile overrides them;
+`env` merges key-wise, so a profile can add one variable without restating the
+rest. `$PORT` and `${PORT}` are substituted in argv; a workload with
+`"port_env": "PORT"` gets the port as an environment variable instead.
+
+```console
+$ orchd list
+db      tinbase .
+api     node    api
+mobile  node    mobile  profiles: lifo
+
+$ orchd resolve --workload mobile --port 8082
+browser-metro . --port 8082
+
+$ orchd resolve --workload mobile --port 8082 --json
+{"workload":"mobile","cwd":"/mobile","argv":["browser-metro",".","--port","8082"],"env":{},"install":["npm","install"]}
+```
+
+## `resolve` vs `run`
+
+Prefer **`resolve`** for anything long-running. `run` executes through
+`ctx.executeCapture`, which buffers stdout/stderr and takes no `AbortSignal`, so
+a dev server started that way produces no output until it exits and is not torn
+down when the command is aborted. `run` is a convenience for interactive and
+one-shot use.
+
+A host that supervises the workload should call `resolve --json` and run the
+command itself, keeping its own streaming and abort handling:
+
+```ts
+const spec = JSON.parse(await sandbox.commands.run('orchd resolve -w mobile -p 8082 --json'));
+const ac = new AbortController();
+sandbox.shell.execute(spec.argv.join(' '), { cwd: spec.cwd, env: { ...sandbox.env, ...spec.env }, signal: ac.signal });
+await sandbox.waitForPort(8082);
+```
+
+## Note on `browser-metro` arguments
+
+`browser-metro` drops its first argument (`ctx.args.slice(1)`), unlike
+`systemctl`/`bc`, which read `args[0]` as a real argument. So
+`browser-metro --port 8082` silently loses the flag and binds the default 8081.
+Pass the project directory first — `browser-metro . --port 8082` — as the
+example profile above does.

--- a/packages/lifo-pkg-orchd/README.md
+++ b/packages/lifo-pkg-orchd/README.md
@@ -17,14 +17,49 @@ command.
 orchd list                            list workloads in the manifest
 orchd resolve [options]               print the resolved command line
 orchd run [options]                   resolve, then run it
+orchd up [options]                    start every workload, each on its own port
 
   -w, --workload <name>   workload to act on (default: the only one, if unambiguous)
   -p, --port <n>          port to bind; substituted for $PORT (default: $PORT env)
       --profile <name>    profile to merge (default: lifo)
   -c, --config <path>     manifest path (default: ./orchd.json, then /orchd.json)
+      --all               (resolve) the whole project, not one workload
       --json              (resolve) emit {cwd, argv, env, install} instead of a line
+      --port-base <n>     (up/--all) first port to assign (default: 8080)
+      --settle <ms>       (up) pause before moving the shell to the next
+                          workload's directory (default: 500)
       --no-install        skip the install step even if node_modules is missing
 ```
+
+## Booting the whole project
+
+`orchd up` starts every workload at once:
+
+```console
+$ orchd up
+orchd: api -> PORT=3000 node index.js (cwd /home/user/app/api)
+orchd: mobile -> EXPO_PUBLIC_API_URL=http://localhost:3000 browser-metro . --port 8081 (cwd /home/user/app)
+orchd: 2 workload(s) started; `jobs` to list them
+```
+
+Each workload gets a port — its declared `"port"`, otherwise one counting up
+from `--port-base`. Workloads then refer to each other by **name**, and the port
+is filled in:
+
+```jsonc
+{
+  "name": "mobile",
+  "env": { "EXPO_PUBLIC_API_URL": "${url:api}" }   // -> http://localhost:3000
+}
+```
+
+`${url:<name>}` and `${port:<name>}` are the cross-workload forms. On a host
+those siblings are separate subdomains; in a box everything shares localhost, so
+the manifest names them and `up` resolves the addresses.
+
+Workloads start as **background jobs** — a shell runs one foreground command at
+a time and a dev server never exits, so foregrounding would boot only the first
+one. `up` returns to the prompt with everything running; `jobs` lists them.
 
 ## Profiles
 
@@ -66,7 +101,7 @@ $ orchd resolve --workload mobile --port 8082 --json
 {"workload":"mobile","cwd":"/mobile","argv":["browser-metro",".","--port","8082"],"env":{},"install":["npm","install"]}
 ```
 
-## `resolve` vs `run`
+## `resolve` vs `run` vs `up`
 
 Prefer **`resolve`** for anything long-running. `run` executes through
 `ctx.executeCapture`, which buffers stdout/stderr and takes no `AbortSignal`, so
@@ -74,8 +109,12 @@ a dev server started that way produces no output until it exits and is not torn
 down when the command is aborted. `run` is a convenience for interactive and
 one-shot use.
 
-A host that supervises the workload should call `resolve --json` and run the
-command itself, keeping its own streaming and abort handling:
+`orchd up` avoids that problem by backgrounding, but its jobs' output goes to
+the shell rather than being collected.
+
+A host that supervises the workload should call `resolve --json` (or
+`resolve --all --json` for the whole project) and run the commands itself,
+keeping its own streaming and abort handling:
 
 ```ts
 const spec = JSON.parse(await sandbox.commands.run('orchd resolve -w mobile -p 8082 --json'));
@@ -83,6 +122,21 @@ const ac = new AbortController();
 sandbox.shell.execute(spec.argv.join(' '), { cwd: spec.cwd, env: { ...sandbox.env, ...spec.env }, signal: ac.signal });
 await sandbox.waitForPort(8082);
 ```
+
+## Note on background jobs and the working directory
+
+A backgrounded job resolves its paths when it **starts**, not when it is
+launched. Two consequences, both handled here but worth knowing:
+
+- Passing `executeCapture` a `{cwd}` does not survive backgrounding — the
+  capture restores the previous directory first and the job fails with `ENOENT`.
+  `up` emits `cd <dir> && <cmd> &` instead.
+- A later `cd` can still move the shell out from under a job that has not
+  started yet. `up` pauses `--settle` milliseconds (default 500) before changing
+  directory for the next workload, and returns the shell to where it started.
+
+If lifo captured a job's working directory at spawn time, both workarounds could
+go away.
 
 ## Note on `browser-metro` arguments
 

--- a/packages/lifo-pkg-orchd/package.json
+++ b/packages/lifo-pkg-orchd/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "lifo-pkg-orchd",
+  "version": "0.1.0",
+  "description": "Run a workload described by orchd.json inside Lifo",
+  "license": "MIT",
+  "author": "Sanket Sahu",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "lifo": {
+    "commands": {
+      "orchd": "./dist/index.js"
+    }
+  },
+  "keywords": [
+    "lifo-pkg",
+    "orchd"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepublishOnly": "node ../../scripts/ensure-pnpm-publish.mjs"
+  },
+  "peerDependencies": {
+    "@lifo-sh/core": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@lifo-sh/core": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@lifo-sh/core": "workspace:*",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vite-plugin-dts": "^4.5.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/lifo-pkg-orchd/src/index.ts
+++ b/packages/lifo-pkg-orchd/src/index.ts
@@ -29,6 +29,8 @@ export interface OrchdWorkload {
   run?: string[];
   env?: Record<string, string>;
   port_env?: string;
+  /** Preferred port. Without one, `up` assigns from --port-base by position. */
+  port?: number;
   profiles?: Record<string, Partial<OrchdWorkload>>;
 }
 
@@ -43,13 +45,18 @@ Usage:
   orchd list                            list workloads in the manifest
   orchd resolve [options]               print the resolved command line
   orchd run [options]                   resolve, then run it
+  orchd up [options]                    start every workload, each on its own port
 
 Options:
   -w, --workload <name>   workload to act on (default: the only one, if unambiguous)
   -p, --port <n>          port to bind; substituted for $PORT (default: $PORT env)
       --profile <name>    profile to merge (default: ${DEFAULT_PROFILE})
   -c, --config <path>     manifest path (default: ./orchd.json, then /orchd.json)
+      --all               (resolve) the whole project, not one workload
       --json              (resolve) emit {cwd, argv, env, install} instead of a line
+      --port-base <n>     (up/--all) first port to assign (default: 8080)
+      --settle <ms>       (up) pause before moving the shell to the next
+                          workload's directory (default: 500)
       --no-install        skip the install step even if node_modules is missing
   -h, --help              show this help
 `;
@@ -90,14 +97,50 @@ export function applyProfile(wl: OrchdWorkload, profile: string): OrchdWorkload 
   };
 }
 
-/** Substitute $PORT / ${PORT} (and any other provided var) in an argv. */
+/**
+ * Substitute $PORT / ${PORT}, and the cross-workload forms ${port:<name>} and
+ * ${url:<name>} — which is how one workload learns where another is listening.
+ * On a host those are subdomains; in a box everything shares localhost, so the
+ * manifest refers to siblings by name and the port is filled in here.
+ */
+export function expandVars(value: string, vars: Record<string, string>): string {
+  return value.replace(/\$\{([\w:]+)\}|\$(\w+)/g, (m, braced, bare) => {
+    const key = braced ?? bare;
+    return key in vars ? vars[key] : m;
+  });
+}
+
 export function expandArgv(argv: string[], vars: Record<string, string>): string[] {
-  return argv.map((a) =>
-    a.replace(/\$\{(\w+)\}|\$(\w+)/g, (m, braced, bare) => {
-      const key = braced ?? bare;
-      return key in vars ? vars[key] : m;
-    }),
-  );
+  return argv.map((a) => expandVars(a, vars));
+}
+
+/** Assign a port to every workload: its declared one, else counting from base. */
+export function assignPorts(workloads: OrchdWorkload[], base: number): Record<string, number> {
+  const ports: Record<string, number> = {};
+  const taken = new Set<number>();
+  for (const w of workloads) {
+    if (typeof w.port === 'number') { ports[w.name] = w.port; taken.add(w.port); }
+  }
+  let next = base;
+  for (const w of workloads) {
+    if (ports[w.name] !== undefined) continue;
+    while (taken.has(next)) next++;
+    ports[w.name] = next;
+    taken.add(next);
+    next++;
+  }
+  return ports;
+}
+
+/** The variables visible to one workload: its own $PORT plus every sibling. */
+function varsFor(name: string, ports: Record<string, number>): Record<string, string> {
+  const vars: Record<string, string> = {};
+  for (const [n, p] of Object.entries(ports)) {
+    vars[`port:${n}`] = String(p);
+    vars[`url:${n}`] = `http://localhost:${p}`;
+  }
+  if (ports[name] !== undefined) vars.PORT = String(ports[name]);
+  return vars;
 }
 
 export interface Resolved {
@@ -111,7 +154,11 @@ export interface Resolved {
 /** Resolve a manifest + selection into everything needed to run. */
 export function resolveWorkload(
   man: OrchdManifest,
-  opts: { workload?: string; profile?: string; port?: string; configDir: string },
+  opts: {
+    workload?: string; profile?: string; port?: string; configDir: string;
+    /** Extra substitutions, e.g. the ${port:<name>} map built by resolveAll. */
+    vars?: Record<string, string>;
+  },
 ): Resolved {
   const workloads = man.workloads ?? [];
   if (workloads.length === 0) throw new Error('manifest has no workloads');
@@ -137,13 +184,15 @@ export function resolveWorkload(
     throw new Error(`workload "${merged.name}" has no run command for this profile`);
   }
 
-  const vars: Record<string, string> = {};
+  const vars: Record<string, string> = { ...(opts.vars ?? {}) };
   if (opts.port) vars.PORT = opts.port;
 
-  const env: Record<string, string> = { ...(merged.env ?? {}) };
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(merged.env ?? {})) env[k] = expandVars(v, vars);
   // port_env lets a workload receive its port as an env var (e.g. PORT=8081)
   // rather than an argv flag — both styles appear in real manifests.
-  if (opts.port && merged.port_env) env[merged.port_env] = opts.port;
+  const port = opts.port ?? vars.PORT;
+  if (port && merged.port_env) env[merged.port_env] = port;
 
   return {
     workload: merged,
@@ -154,11 +203,40 @@ export function resolveWorkload(
   };
 }
 
+/**
+ * Resolve every workload in the manifest, with ports assigned up front so each
+ * one can be told where the others are.
+ */
+export function resolveAll(
+  man: OrchdManifest,
+  opts: { profile?: string; portBase?: number; configDir: string },
+): Resolved[] {
+  const workloads = man.workloads ?? [];
+  if (workloads.length === 0) throw new Error('manifest has no workloads');
+  const ports = assignPorts(workloads, opts.portBase ?? 8080);
+  return workloads.map((w) =>
+    resolveWorkload(man, {
+      workload: w.name,
+      profile: opts.profile,
+      port: String(ports[w.name]),
+      configDir: opts.configDir,
+      vars: varsFor(w.name, ports),
+    }),
+  );
+}
+
+/** Render a resolved workload as a shell line, env assignments included. */
+export function shellLine(r: Resolved): string {
+  const assigns = Object.entries(r.env).map(([k, v]) => `${k}=${shellQuote(v)}`);
+  return [...assigns, ...r.argv.map(shellQuote)].join(' ');
+}
+
 function parseArgs(args: string[]) {
   const out: {
     cmd?: string; workload?: string; port?: string; profile?: string;
     config?: string; install: boolean; help: boolean; json: boolean;
-  } = { install: true, help: false, json: false };
+    all: boolean; portBase?: number; settle?: number;
+  } = { install: true, help: false, json: false, all: false };
 
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
@@ -169,6 +247,9 @@ function parseArgs(args: string[]) {
       case '--profile': out.profile = args[++i]; break;
       case '-c': case '--config': out.config = args[++i]; break;
       case '--json': out.json = true; break;
+      case '--all': out.all = true; break;
+      case '--port-base': out.portBase = Number(args[++i]); break;
+      case '--settle': out.settle = Number(args[++i]); break;
       case '--no-install': out.install = false; break;
       default:
         if (a.startsWith('-')) throw new Error(`unknown option: ${a}`);
@@ -226,6 +307,95 @@ const orchd: Command = async (ctx: CommandContext): Promise<number> => {
     return 0;
   }
 
+  if (opts.cmd === 'up' || (opts.cmd === 'resolve' && opts.all)) {
+    let all: Resolved[];
+    try {
+      all = resolveAll(man, {
+        profile: opts.profile,
+        portBase: opts.portBase,
+        configDir: dirOf(manifestPath),
+      });
+    } catch (e) {
+      ctx.stderr.write(`orchd: ${(e as Error).message}\n`);
+      return 1;
+    }
+
+    if (opts.cmd === 'resolve') {
+      if (opts.json) {
+        ctx.stdout.write(JSON.stringify(all.map((r) => ({
+          workload: r.workload.name,
+          cwd: r.cwd,
+          argv: r.argv,
+          env: r.env,
+          install: r.install ?? null,
+        }))) + '\n');
+      } else {
+        for (const r of all) ctx.stdout.write(`${r.workload.name}\t${shellLine(r)}\n`);
+      }
+      return 0;
+    }
+
+    // up: start everything at once. Each workload keeps its own cwd and env.
+    if (!ctx.executeCapture) {
+      ctx.stderr.write(
+        'orchd: this shell cannot run nested commands; use `orchd resolve --all` and run the lines\n',
+      );
+      return 1;
+    }
+
+    for (const r of all) {
+      const needs = opts.install && r.install && !ctx.vfs.exists(joinPath(r.cwd, 'node_modules'));
+      if (!needs) continue;
+      const installLine = r.install!.map(shellQuote).join(' ');
+      ctx.stdout.write(`orchd: ${r.workload.name}: installing (${installLine})\n`);
+      try {
+        await ctx.executeCapture(installLine, { cwd: r.cwd });
+      } catch (e) {
+        ctx.stderr.write(`orchd: ${r.workload.name}: install failed: ${(e as Error).message}\n`);
+        return 1;
+      }
+    }
+
+    // Start each workload as a BACKGROUND job. A shell runs one foreground
+    // command at a time and a dev server never exits, so foregrounding would
+    // boot only the first workload. Backgrounding also returns you to the
+    // prompt with everything running (`jobs` lists them).
+    //
+    // The `cd` matters: passing executeCapture a {cwd} does not survive
+    // backgrounding, because the job resolves its paths when it STARTS, by
+    // which time the capture has already restored the previous directory — the
+    // job then fails with ENOENT. For the same reason we let a job settle
+    // before the next `cd` moves the shell out from under it.
+    const settle = opts.settle ?? 500;
+    let prevCwd: string | null = null;
+    for (let i = 0; i < all.length; i++) {
+      const r = all[i];
+      const line = shellLine(r);
+      ctx.stdout.write(`orchd: ${r.workload.name} -> ${line} (cwd ${r.cwd})\n`);
+      try {
+        await ctx.executeCapture(`cd ${shellQuote(r.cwd)} && ${line} &`);
+      } catch (e) {
+        ctx.stderr.write(`orchd: ${r.workload.name}: ${(e as Error).message}\n`);
+        return 1;
+      }
+      // Only pay the settle delay when the next job would move the shell.
+      const nextCwd = all[i + 1]?.cwd;
+      if (nextCwd !== undefined && nextCwd !== r.cwd && settle > 0) {
+        await new Promise((res) => setTimeout(res, settle));
+      }
+      prevCwd = r.cwd;
+    }
+    // Leave the shell where it started rather than inside the last workload.
+    if (prevCwd !== null && prevCwd !== ctx.cwd) {
+      if (settle > 0) await new Promise((res) => setTimeout(res, settle));
+      try {
+        await ctx.executeCapture(`cd ${shellQuote(ctx.cwd)}`);
+      } catch { /* cosmetic only */ }
+    }
+    ctx.stdout.write(`orchd: ${all.length} workload(s) started; \`jobs\` to list them\n`);
+    return 0;
+  }
+
   if (opts.cmd !== 'resolve' && opts.cmd !== 'run') {
     ctx.stderr.write(`orchd: unknown command "${opts.cmd}"\n\n${USAGE}`);
     return 2;
@@ -244,7 +414,7 @@ const orchd: Command = async (ctx: CommandContext): Promise<number> => {
     return 1;
   }
 
-  const line = r.argv.map(shellQuote).join(' ');
+  const line = shellLine(r);
 
   if (opts.cmd === 'resolve') {
     // --json is the machine interface: a host driver needs the working

--- a/packages/lifo-pkg-orchd/src/index.ts
+++ b/packages/lifo-pkg-orchd/src/index.ts
@@ -1,0 +1,305 @@
+/**
+ * orchd — run a workload described by an `orchd.json` that travels with the
+ * project (inside a snapshot, a tarball, or a container image).
+ *
+ * ORCHD (github.com/RapidNative/cloud) provisions per-project workloads across
+ * substrates: host processes, Docker containers, and Lifo sandboxes. The same
+ * `orchd.json` describes all of them, so whatever boots the project can read
+ * one file instead of being handed a command line. Inside a Lifo box that is
+ * this command.
+ *
+ * The interesting part is `profiles`: the command a workload runs depends on
+ * what is executing it. Real Metro wants `expo start --web`; a Lifo box usually
+ * wants `browser-metro`, which bundles via a hosted pre-bundler instead of
+ * reading node_modules. One manifest, one override block.
+ *
+ *   orchd list
+ *   orchd resolve --workload mobile --port 8081
+ *   orchd run     --workload mobile --port 8081
+ */
+import type { Command, CommandContext } from '@lifo-sh/core';
+
+const DEFAULT_PROFILE = 'lifo';
+
+export interface OrchdWorkload {
+  name: string;
+  kind?: string;
+  dir?: string;
+  install?: string[];
+  run?: string[];
+  env?: Record<string, string>;
+  port_env?: string;
+  profiles?: Record<string, Partial<OrchdWorkload>>;
+}
+
+export interface OrchdManifest {
+  name?: string;
+  workloads?: OrchdWorkload[];
+}
+
+const USAGE = `orchd — run a workload from orchd.json
+
+Usage:
+  orchd list                            list workloads in the manifest
+  orchd resolve [options]               print the resolved command line
+  orchd run [options]                   resolve, then run it
+
+Options:
+  -w, --workload <name>   workload to act on (default: the only one, if unambiguous)
+  -p, --port <n>          port to bind; substituted for $PORT (default: $PORT env)
+      --profile <name>    profile to merge (default: ${DEFAULT_PROFILE})
+  -c, --config <path>     manifest path (default: ./orchd.json, then /orchd.json)
+      --json              (resolve) emit {cwd, argv, env, install} instead of a line
+      --no-install        skip the install step even if node_modules is missing
+  -h, --help              show this help
+`;
+
+/** join two path segments without pulling in a path module. */
+function joinPath(base: string, rel?: string): string {
+  if (!rel || rel === '.') return base;
+  if (rel.startsWith('/')) return rel;
+  return (base.endsWith('/') ? base.slice(0, -1) : base) + '/' + rel;
+}
+
+function dirOf(path: string): string {
+  const i = path.lastIndexOf('/');
+  if (i <= 0) return '/';
+  return path.slice(0, i);
+}
+
+/** Quote an argv entry for a shell line, only when it needs it. */
+function shellQuote(arg: string): string {
+  if (arg.length > 0 && !/[\s"'$`\\|&;<>()*?[\]{}!#~]/.test(arg)) return arg;
+  return `'` + arg.replace(/'/g, `'\\''`) + `'`;
+}
+
+/**
+ * Merge a profile over a workload. Scalar and array fields replace wholesale
+ * (a profile overriding `run` means exactly that); `env` merges key-wise so a
+ * profile can add one variable without restating the rest.
+ */
+export function applyProfile(wl: OrchdWorkload, profile: string): OrchdWorkload {
+  const p = wl.profiles?.[profile];
+  if (!p) return { ...wl };
+  return {
+    ...wl,
+    ...p,
+    name: wl.name,
+    env: { ...(wl.env ?? {}), ...(p.env ?? {}) },
+    profiles: wl.profiles,
+  };
+}
+
+/** Substitute $PORT / ${PORT} (and any other provided var) in an argv. */
+export function expandArgv(argv: string[], vars: Record<string, string>): string[] {
+  return argv.map((a) =>
+    a.replace(/\$\{(\w+)\}|\$(\w+)/g, (m, braced, bare) => {
+      const key = braced ?? bare;
+      return key in vars ? vars[key] : m;
+    }),
+  );
+}
+
+export interface Resolved {
+  workload: OrchdWorkload;
+  cwd: string;
+  argv: string[];
+  install?: string[];
+  env: Record<string, string>;
+}
+
+/** Resolve a manifest + selection into everything needed to run. */
+export function resolveWorkload(
+  man: OrchdManifest,
+  opts: { workload?: string; profile?: string; port?: string; configDir: string },
+): Resolved {
+  const workloads = man.workloads ?? [];
+  if (workloads.length === 0) throw new Error('manifest has no workloads');
+
+  let wl: OrchdWorkload | undefined;
+  if (opts.workload) {
+    wl = workloads.find((w) => w.name === opts.workload);
+    if (!wl) {
+      throw new Error(
+        `no workload named "${opts.workload}" (have: ${workloads.map((w) => w.name).join(', ')})`,
+      );
+    }
+  } else if (workloads.length === 1) {
+    wl = workloads[0];
+  } else {
+    throw new Error(
+      `--workload is required (have: ${workloads.map((w) => w.name).join(', ')})`,
+    );
+  }
+
+  const merged = applyProfile(wl, opts.profile ?? DEFAULT_PROFILE);
+  if (!merged.run || merged.run.length === 0) {
+    throw new Error(`workload "${merged.name}" has no run command for this profile`);
+  }
+
+  const vars: Record<string, string> = {};
+  if (opts.port) vars.PORT = opts.port;
+
+  const env: Record<string, string> = { ...(merged.env ?? {}) };
+  // port_env lets a workload receive its port as an env var (e.g. PORT=8081)
+  // rather than an argv flag — both styles appear in real manifests.
+  if (opts.port && merged.port_env) env[merged.port_env] = opts.port;
+
+  return {
+    workload: merged,
+    cwd: joinPath(opts.configDir, merged.dir),
+    argv: expandArgv(merged.run, vars),
+    install: merged.install ? expandArgv(merged.install, vars) : undefined,
+    env,
+  };
+}
+
+function parseArgs(args: string[]) {
+  const out: {
+    cmd?: string; workload?: string; port?: string; profile?: string;
+    config?: string; install: boolean; help: boolean; json: boolean;
+  } = { install: true, help: false, json: false };
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    switch (a) {
+      case '-h': case '--help': out.help = true; break;
+      case '-w': case '--workload': out.workload = args[++i]; break;
+      case '-p': case '--port': out.port = args[++i]; break;
+      case '--profile': out.profile = args[++i]; break;
+      case '-c': case '--config': out.config = args[++i]; break;
+      case '--json': out.json = true; break;
+      case '--no-install': out.install = false; break;
+      default:
+        if (a.startsWith('-')) throw new Error(`unknown option: ${a}`);
+        if (!out.cmd) out.cmd = a;
+        break;
+    }
+  }
+  return out;
+}
+
+/** Find the manifest: explicit path, then ./orchd.json, then /orchd.json. */
+function findManifest(ctx: CommandContext, explicit?: string): string {
+  const candidates = explicit
+    ? [explicit.startsWith('/') ? explicit : joinPath(ctx.cwd, explicit)]
+    : [joinPath(ctx.cwd, 'orchd.json'), '/orchd.json'];
+  for (const c of candidates) {
+    if (ctx.vfs.exists(c)) return c;
+  }
+  throw new Error(`no orchd.json found (looked in: ${candidates.join(', ')})`);
+}
+
+const orchd: Command = async (ctx: CommandContext): Promise<number> => {
+  let opts: ReturnType<typeof parseArgs>;
+  try {
+    // ctx.args holds the arguments only — the command name is not argv[0].
+    opts = parseArgs(ctx.args);
+  } catch (e) {
+    ctx.stderr.write(`orchd: ${(e as Error).message}\n`);
+    return 2;
+  }
+
+  if (opts.help || !opts.cmd) {
+    ctx.stdout.write(USAGE);
+    return opts.help ? 0 : 2;
+  }
+
+  let manifestPath: string;
+  let man: OrchdManifest;
+  try {
+    manifestPath = findManifest(ctx, opts.config);
+    man = JSON.parse(ctx.vfs.readFileString(manifestPath)) as OrchdManifest;
+  } catch (e) {
+    ctx.stderr.write(`orchd: ${(e as Error).message}\n`);
+    return 1;
+  }
+
+  if (opts.cmd === 'list') {
+    for (const w of man.workloads ?? []) {
+      const profiles = Object.keys(w.profiles ?? {});
+      ctx.stdout.write(
+        `${w.name}\t${w.kind ?? '-'}\t${w.dir ?? '.'}` +
+        (profiles.length ? `\tprofiles: ${profiles.join(',')}` : '') + '\n',
+      );
+    }
+    return 0;
+  }
+
+  if (opts.cmd !== 'resolve' && opts.cmd !== 'run') {
+    ctx.stderr.write(`orchd: unknown command "${opts.cmd}"\n\n${USAGE}`);
+    return 2;
+  }
+
+  let r: Resolved;
+  try {
+    r = resolveWorkload(man, {
+      workload: opts.workload,
+      profile: opts.profile,
+      port: opts.port ?? ctx.env.PORT,
+      configDir: dirOf(manifestPath),
+    });
+  } catch (e) {
+    ctx.stderr.write(`orchd: ${(e as Error).message}\n`);
+    return 1;
+  }
+
+  const line = r.argv.map(shellQuote).join(' ');
+
+  if (opts.cmd === 'resolve') {
+    // --json is the machine interface: a host driver needs the working
+    // directory and env too, not just the command line.
+    if (opts.json) {
+      ctx.stdout.write(JSON.stringify({
+        workload: r.workload.name,
+        cwd: r.cwd,
+        argv: r.argv,
+        env: r.env,
+        install: r.install ?? null,
+      }) + '\n');
+      return 0;
+    }
+    ctx.stdout.write(line + '\n');
+    return 0;
+  }
+
+  // run
+  if (!ctx.executeCapture) {
+    ctx.stderr.write(
+      'orchd: this shell cannot run nested commands; use `orchd resolve` and run the printed line\n',
+    );
+    return 1;
+  }
+
+  const needsInstall =
+    opts.install && r.install && !ctx.vfs.exists(joinPath(r.cwd, 'node_modules'));
+  if (needsInstall) {
+    const installLine = r.install!.map(shellQuote).join(' ');
+    ctx.stdout.write(`orchd: installing (${installLine})\n`);
+    try {
+      await ctx.executeCapture(installLine, { cwd: r.cwd });
+    } catch (e) {
+      ctx.stderr.write(`orchd: install failed: ${(e as Error).message}\n`);
+      return 1;
+    }
+  }
+
+  ctx.stdout.write(`orchd: ${r.workload.name} -> ${line} (cwd ${r.cwd})\n`);
+
+  // NOTE: executeCapture buffers stdout/stderr and takes no AbortSignal, so a
+  // long-running server started here produces no output until it exits and is
+  // not torn down when this command is aborted. That is fine for one-shot
+  // workloads; for a dev server prefer `orchd resolve` and let the host run the
+  // line with its own streaming + signal (that is what the ORCHD Lifo driver
+  // does). Kept here because it makes the command usable interactively.
+  try {
+    const res = await ctx.executeCapture(line, { cwd: r.cwd });
+    if (res) ctx.stdout.write(res);
+    return 0;
+  } catch (e) {
+    ctx.stderr.write(`orchd: ${(e as Error).message}\n`);
+    return 1;
+  }
+};
+
+export default orchd;

--- a/packages/lifo-pkg-orchd/tests/orchd.test.ts
+++ b/packages/lifo-pkg-orchd/tests/orchd.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { VFS } from '@lifo-sh/core';
 import type { CommandContext, CommandOutputStream } from '@lifo-sh/core';
-import orchd, { applyProfile, expandArgv, resolveWorkload } from '../src/index.js';
+import orchd, { applyProfile, assignPorts, expandArgv, resolveAll, resolveWorkload } from '../src/index.js';
 
 const MANIFEST = {
   name: 'rapidnative',
@@ -48,6 +48,35 @@ function ctxFor(args: string[], opts: { cwd?: string; files?: Record<string, str
   } as unknown as CommandContext & { stdout: { text: string }; stderr: { text: string } };
   return { ctx, calls, vfs };
 }
+
+describe('cross-workload wiring', () => {
+  const WIRED = {
+    workloads: [
+      { name: 'db', kind: 'tinbase', port: 5432, run: ['tinbase', 'start', '--port', '$PORT'] },
+      {
+        name: 'app', kind: 'node', dir: 'app', run: ['vite', '--port', '$PORT'],
+        env: { API_URL: '${url:db}', DB_PORT: '${port:db}' },
+      },
+    ],
+  };
+
+  it('assigns declared ports first, then fills from the base', () => {
+    expect(assignPorts(WIRED.workloads, 8080)).toEqual({ db: 5432, app: 8080 });
+  });
+
+  it('never reuses a declared port when filling', () => {
+    const wls = [{ name: 'a', port: 8080 }, { name: 'b' }, { name: 'c' }];
+    expect(assignPorts(wls, 8080)).toEqual({ a: 8080, b: 8081, c: 8082 });
+  });
+
+  it('resolves ${url:x} and ${port:x} to a sibling\'s assigned port', () => {
+    const all = resolveAll(WIRED, { configDir: '/p', portBase: 8080 });
+    const app = all.find((r) => r.workload.name === 'app')!;
+    expect(app.env.API_URL).toBe('http://localhost:5432');
+    expect(app.env.DB_PORT).toBe('5432');
+    expect(app.argv).toEqual(['vite', '--port', '8080']);
+  });
+});
 
 describe('resolution', () => {
   it('merges a profile over the base workload', () => {
@@ -106,39 +135,40 @@ describe('command', () => {
   it('resolve prints the command line without running anything', async () => {
     const { ctx, calls } = ctxFor(['resolve', '--workload', 'mobile', '--port', '8081']);
     expect(await orchd(ctx)).toBe(0);
-    expect(ctx.stdout.text.trim()).toBe('browser-metro --port 8081');
+    // env travels with the line as prefix assignments — executeCapture has no env option
+    expect(ctx.stdout.text.trim()).toBe('CI=1 BROWSER=none browser-metro --port 8081');
     expect(calls).toHaveLength(0);
   });
 
   it('honours --profile', async () => {
     const { ctx } = ctxFor(['resolve', '--workload', 'mobile', '--port', '8081', '--profile', 'docker']);
     expect(await orchd(ctx)).toBe(0);
-    expect(ctx.stdout.text.trim()).toBe("npx expo start --web --port 8081");
+    expect(ctx.stdout.text.trim()).toBe('CI=1 npx expo start --web --port 8081');
   });
 
   it('takes the port from $PORT when not passed', async () => {
     const { ctx } = ctxFor(['resolve', '--workload', 'mobile']);
     ctx.env.PORT = '7777';
     expect(await orchd(ctx)).toBe(0);
-    expect(ctx.stdout.text.trim()).toBe('browser-metro --port 7777');
+    expect(ctx.stdout.text.trim()).toBe('CI=1 BROWSER=none browser-metro --port 7777');
   });
 
   it('run executes in the workload directory', async () => {
     const { ctx, calls } = ctxFor(['run', '--workload', 'mobile', '--port', '8081', '--no-install']);
     expect(await orchd(ctx)).toBe(0);
-    expect(calls.at(-1)).toEqual({ input: 'browser-metro --port 8081', cwd: '/proj/mobile' });
+    expect(calls.at(-1)).toEqual({ input: 'CI=1 BROWSER=none browser-metro --port 8081', cwd: '/proj/mobile' });
   });
 
   it('installs first when node_modules is missing', async () => {
     const { ctx, calls } = ctxFor(['run', '--workload', 'api', '--port', '9000']);
     expect(await orchd(ctx)).toBe(0);
-    expect(calls.map((c) => c.input)).toEqual(['npm install', 'node --watch index.js']);
+    expect(calls.map((c) => c.input)).toEqual(['npm install', 'PORT=9000 node --watch index.js']);
   });
 
   it('skips install with --no-install', async () => {
     const { ctx, calls } = ctxFor(['run', '--workload', 'api', '--port', '9000', '--no-install']);
     expect(await orchd(ctx)).toBe(0);
-    expect(calls.map((c) => c.input)).toEqual(['node --watch index.js']);
+    expect(calls.map((c) => c.input)).toEqual(['PORT=9000 node --watch index.js']);
   });
 
   it('falls back to /orchd.json when the cwd has none', async () => {
@@ -146,7 +176,7 @@ describe('command', () => {
       cwd: '/somewhere', files: { '/orchd.json': JSON.stringify(MANIFEST) },
     });
     expect(await orchd(ctx)).toBe(0);
-    expect(ctx.stdout.text.trim()).toBe('browser-metro --port 1');
+    expect(ctx.stdout.text.trim()).toBe('CI=1 BROWSER=none browser-metro --port 1');
   });
 
   it('errors clearly when no manifest exists', async () => {
@@ -181,6 +211,41 @@ describe('command', () => {
       env: { CI: '1', BROWSER: 'none' },
       install: ['npm', 'install'],
     });
+  });
+
+  it('resolve --all assigns a port per workload from the base', async () => {
+    const { ctx } = ctxFor(['resolve', '--all', '--port-base', '8080']);
+    expect(await orchd(ctx)).toBe(0);
+    const lines = ctx.stdout.text.trim().split('\n');
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toContain('db');
+    expect(lines[1]).toContain('PORT=8081');          // api, via port_env
+    expect(lines[2]).toContain('--port 8082');         // mobile, via $PORT
+  });
+
+  it('resolve --all --json emits the whole plan', async () => {
+    const { ctx } = ctxFor(['resolve', '--all', '--json']);
+    expect(await orchd(ctx)).toBe(0);
+    const plan = JSON.parse(ctx.stdout.text);
+    expect(plan.map((p: { workload: string }) => p.workload)).toEqual(['db', 'api', 'mobile']);
+    expect(plan[2].cwd).toBe('/proj/mobile');
+  });
+
+  it('up starts every workload as a background job', async () => {
+    const { ctx, calls } = ctxFor(['up', '--no-install', '--port-base', '9000', '--settle', '0']);
+    expect(await orchd(ctx)).toBe(0);
+    const launches = calls.filter((c) => c.input.endsWith(' &'));
+    expect(launches).toHaveLength(3);
+    // Each job cds itself: a {cwd} option does not survive backgrounding,
+    // because the job resolves paths when it starts — after the restore.
+    expect(launches[2].input).toBe('cd /proj/mobile && CI=1 BROWSER=none browser-metro --port 9002 &');
+    expect(ctx.stdout.text).toContain('3 workload(s) started');
+  });
+
+  it('up returns the shell to where it started', async () => {
+    const { ctx, calls } = ctxFor(['up', '--no-install', '--settle', '0']);
+    expect(await orchd(ctx)).toBe(0);
+    expect(calls.at(-1)!.input).toBe('cd /proj');
   });
 
   it('quotes arguments that need it', async () => {

--- a/packages/lifo-pkg-orchd/tests/orchd.test.ts
+++ b/packages/lifo-pkg-orchd/tests/orchd.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import { VFS } from '@lifo-sh/core';
+import type { CommandContext, CommandOutputStream } from '@lifo-sh/core';
+import orchd, { applyProfile, expandArgv, resolveWorkload } from '../src/index.js';
+
+const MANIFEST = {
+  name: 'rapidnative',
+  workloads: [
+    { name: 'db', kind: 'tinbase', profiles: { lifo: { run: ['npx', 'tinbase', '--engine', 'pgmem'] } } },
+    {
+      name: 'api', kind: 'node', dir: 'api',
+      install: ['npm', 'install'],
+      run: ['node', '--watch', 'index.js'],
+      port_env: 'PORT',
+    },
+    {
+      name: 'mobile', kind: 'node', dir: 'mobile',
+      install: ['npm', 'install'],
+      run: ['npx', 'expo', 'start', '--web', '--port', '$PORT'],
+      env: { CI: '1' },
+      profiles: {
+        lifo: { run: ['browser-metro', '--port', '$PORT'], env: { BROWSER: 'none' } },
+      },
+    },
+  ],
+};
+
+function ctxFor(args: string[], opts: { cwd?: string; files?: Record<string, string>; exec?: (input: string, o?: { cwd?: string }) => Promise<string> } = {}) {
+  const vfs = new VFS();
+  const files = opts.files ?? { '/proj/orchd.json': JSON.stringify(MANIFEST) };
+  for (const [p, c] of Object.entries(files)) {
+    const dir = p.slice(0, p.lastIndexOf('/'));
+    if (dir) vfs.mkdir(dir, { recursive: true });
+    vfs.writeFile(p, c);
+  }
+  const stdout = { text: '', write(t: string) { this.text += t; } };
+  const stderr = { text: '', write(t: string) { this.text += t; } };
+  const calls: { input: string; cwd?: string }[] = [];
+  const ctx = {
+    args,
+    env: { HOME: '/home/user' },
+    cwd: opts.cwd ?? '/proj',
+    vfs,
+    stdout: stdout as CommandOutputStream & { text: string },
+    stderr: stderr as CommandOutputStream & { text: string },
+    signal: new AbortController().signal,
+    executeCapture: opts.exec ?? (async (input: string, o?: { cwd?: string }) => { calls.push({ input, cwd: o?.cwd }); return ''; }),
+  } as unknown as CommandContext & { stdout: { text: string }; stderr: { text: string } };
+  return { ctx, calls, vfs };
+}
+
+describe('resolution', () => {
+  it('merges a profile over the base workload', () => {
+    const wl = MANIFEST.workloads[2];
+    const merged = applyProfile(wl, 'lifo');
+    expect(merged.run).toEqual(['browser-metro', '--port', '$PORT']);
+    // env merges key-wise rather than replacing
+    expect(merged.env).toEqual({ CI: '1', BROWSER: 'none' });
+    expect(merged.name).toBe('mobile');
+  });
+
+  it('leaves the base untouched when the profile is absent', () => {
+    const merged = applyProfile(MANIFEST.workloads[1], 'lifo');
+    expect(merged.run).toEqual(['node', '--watch', 'index.js']);
+  });
+
+  it('expands $PORT and ${PORT}', () => {
+    expect(expandArgv(['a', '$PORT', '${PORT}', '$OTHER'], { PORT: '8081' }))
+      .toEqual(['a', '8081', '8081', '$OTHER']);
+  });
+
+  it('resolves cwd from the manifest directory plus dir', () => {
+    const r = resolveWorkload(MANIFEST, { workload: 'mobile', port: '8081', configDir: '/proj' });
+    expect(r.cwd).toBe('/proj/mobile');
+    expect(r.argv).toEqual(['browser-metro', '--port', '8081']);
+  });
+
+  it('passes the port via port_env when the workload asks for it', () => {
+    const r = resolveWorkload(MANIFEST, { workload: 'api', port: '9000', configDir: '/proj' });
+    expect(r.env.PORT).toBe('9000');
+  });
+
+  it('requires --workload when the manifest is ambiguous', () => {
+    expect(() => resolveWorkload(MANIFEST, { configDir: '/proj' })).toThrow(/--workload is required/);
+  });
+
+  it('defaults to the only workload when unambiguous', () => {
+    const one = { workloads: [{ name: 'solo', run: ['echo', 'hi'] }] };
+    expect(resolveWorkload(one, { configDir: '/' }).workload.name).toBe('solo');
+  });
+
+  it('names the available workloads when one is not found', () => {
+    expect(() => resolveWorkload(MANIFEST, { workload: 'nope', configDir: '/proj' }))
+      .toThrow(/have: db, api, mobile/);
+  });
+});
+
+describe('command', () => {
+  it('lists workloads', async () => {
+    const { ctx } = ctxFor(['list']);
+    expect(await orchd(ctx)).toBe(0);
+    expect(ctx.stdout.text).toContain('mobile');
+    expect(ctx.stdout.text).toContain('profiles: lifo');
+  });
+
+  it('resolve prints the command line without running anything', async () => {
+    const { ctx, calls } = ctxFor(['resolve', '--workload', 'mobile', '--port', '8081']);
+    expect(await orchd(ctx)).toBe(0);
+    expect(ctx.stdout.text.trim()).toBe('browser-metro --port 8081');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('honours --profile', async () => {
+    const { ctx } = ctxFor(['resolve', '--workload', 'mobile', '--port', '8081', '--profile', 'docker']);
+    expect(await orchd(ctx)).toBe(0);
+    expect(ctx.stdout.text.trim()).toBe("npx expo start --web --port 8081");
+  });
+
+  it('takes the port from $PORT when not passed', async () => {
+    const { ctx } = ctxFor(['resolve', '--workload', 'mobile']);
+    ctx.env.PORT = '7777';
+    expect(await orchd(ctx)).toBe(0);
+    expect(ctx.stdout.text.trim()).toBe('browser-metro --port 7777');
+  });
+
+  it('run executes in the workload directory', async () => {
+    const { ctx, calls } = ctxFor(['run', '--workload', 'mobile', '--port', '8081', '--no-install']);
+    expect(await orchd(ctx)).toBe(0);
+    expect(calls.at(-1)).toEqual({ input: 'browser-metro --port 8081', cwd: '/proj/mobile' });
+  });
+
+  it('installs first when node_modules is missing', async () => {
+    const { ctx, calls } = ctxFor(['run', '--workload', 'api', '--port', '9000']);
+    expect(await orchd(ctx)).toBe(0);
+    expect(calls.map((c) => c.input)).toEqual(['npm install', 'node --watch index.js']);
+  });
+
+  it('skips install with --no-install', async () => {
+    const { ctx, calls } = ctxFor(['run', '--workload', 'api', '--port', '9000', '--no-install']);
+    expect(await orchd(ctx)).toBe(0);
+    expect(calls.map((c) => c.input)).toEqual(['node --watch index.js']);
+  });
+
+  it('falls back to /orchd.json when the cwd has none', async () => {
+    const { ctx } = ctxFor(['resolve', '--workload', 'mobile', '--port', '1'], {
+      cwd: '/somewhere', files: { '/orchd.json': JSON.stringify(MANIFEST) },
+    });
+    expect(await orchd(ctx)).toBe(0);
+    expect(ctx.stdout.text.trim()).toBe('browser-metro --port 1');
+  });
+
+  it('errors clearly when no manifest exists', async () => {
+    const { ctx } = ctxFor(['list'], { cwd: '/empty', files: {} });
+    expect(await orchd(ctx)).toBe(1);
+    expect(ctx.stderr.text).toContain('no orchd.json found');
+  });
+
+  it('rejects unknown options and commands', async () => {
+    const { ctx } = ctxFor(['resolve', '--bogus']);
+    expect(await orchd(ctx)).toBe(2);
+    expect(ctx.stderr.text).toContain('unknown option');
+
+    const b = ctxFor(['frobnicate']);
+    expect(await orchd(b.ctx)).toBe(2);
+    expect(b.ctx.stderr.text).toContain('unknown command');
+  });
+
+  it('prints usage with --help', async () => {
+    const { ctx } = ctxFor(['--help']);
+    expect(await orchd(ctx)).toBe(0);
+    expect(ctx.stdout.text).toContain('orchd resolve');
+  });
+
+  it('resolve --json emits cwd, argv and env for a host driver', async () => {
+    const { ctx } = ctxFor(['resolve', '--workload', 'mobile', '--port', '8081', '--json']);
+    expect(await orchd(ctx)).toBe(0);
+    expect(JSON.parse(ctx.stdout.text)).toEqual({
+      workload: 'mobile',
+      cwd: '/proj/mobile',
+      argv: ['browser-metro', '--port', '8081'],
+      env: { CI: '1', BROWSER: 'none' },
+      install: ['npm', 'install'],
+    });
+  });
+
+  it('quotes arguments that need it', async () => {
+    const man = { workloads: [{ name: 'x', run: ['sh', '-c', 'echo hi && echo bye'] }] };
+    const { ctx } = ctxFor(['resolve'], { files: { '/proj/orchd.json': JSON.stringify(man) } });
+    expect(await orchd(ctx)).toBe(0);
+    expect(ctx.stdout.text.trim()).toBe("sh -c 'echo hi && echo bye'");
+  });
+});

--- a/packages/lifo-pkg-orchd/tsconfig.build.json
+++ b/packages/lifo-pkg-orchd/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["tests"]
+}

--- a/packages/lifo-pkg-orchd/tsconfig.json
+++ b/packages/lifo-pkg-orchd/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2022", "module": "ES2022", "moduleResolution": "bundler",
+    "strict": true, "esModuleInterop": true, "skipLibCheck": true,
+    "declaration": true, "declarationMap": true, "outDir": "dist", "rootDir": "src",
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src"]
+}

--- a/packages/lifo-pkg-orchd/vite.config.ts
+++ b/packages/lifo-pkg-orchd/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+
+export default defineConfig({
+  plugins: [dts({ tsconfigPath: './tsconfig.build.json' })],
+  build: {
+    lib: { entry: 'src/index.ts', formats: ['es'], fileName: 'index' },
+    rollupOptions: { external: ['@lifo-sh/core'] },
+  },
+  test: { globals: true, environment: 'node' },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       lifo-pkg-nano:
         specifier: workspace:*
         version: link:../../packages/lifo-pkg-nano
+      lifo-pkg-orchd:
+        specifier: workspace:*
+        version: link:../../packages/lifo-pkg-orchd
       lifo-pkg-vi:
         specifier: workspace:*
         version: link:../../packages/lifo-pkg-vi

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,6 +382,24 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(supports-color@8.1.1)(tsx@4.21.0)
 
+  packages/lifo-pkg-orchd:
+    devDependencies:
+      '@lifo-sh/core':
+        specifier: workspace:*
+        version: link:../core
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+      vite-plugin-dts:
+        specifier: ^4.5.0
+        version: 4.5.4(@types/node@22.19.11)(rollup@4.59.0)(supports-color@8.1.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(supports-color@8.1.1)(tsx@4.21.0)
+
   packages/lifo-pkg-vi:
     devDependencies:
       '@lifo-sh/core':
@@ -3805,10 +3823,6 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
@@ -6177,7 +6191,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.59.0
 
@@ -6539,7 +6553,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.28':
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.7
       '@vue/shared': 3.5.28
       entities: 7.0.1
       estree-walker: 2.0.2
@@ -7193,10 +7207,6 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
-
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -7885,8 +7895,6 @@ snapshots:
 
   picomatch@2.3.1: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.5: {}
 
   pify@4.0.1: {}
@@ -8446,8 +8454,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinypool@1.1.1: {}
 
@@ -8642,8 +8650,8 @@ snapshots:
   vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
       postcss: 8.5.6
       rollup: 4.59.0
       tinyglobby: 0.2.15


### PR DESCRIPTION
Adds `lifo-pkg-orchd`, a package that registers an `orchd` command inside a Lifo box.

[ORCHD](https://github.com/RapidNative/cloud) provisions per-project workloads across substrates — host processes, Docker containers, and Lifo boxes. Its `orchd.json` travels *with* the project (inside a snapshot, a tarball, or an image), so whatever boots the project can read one file instead of being handed a command line. Inside Lifo, that is this command.

```console
$ orchd list
db      tinbase .
api     node    api
mobile  node    mobile  profiles: lifo

$ orchd resolve --workload mobile --port 8082
browser-metro . --port 8082

$ orchd resolve --workload mobile --port 8082 --json
{"workload":"mobile","cwd":"/mobile","argv":["browser-metro",".","--port","8082"],"env":{},"install":["npm","install"]}
```

## Why profiles

Which command a workload runs depends on what is executing it. Real Metro wants `expo start --web`; a Lifo box usually wants `browser-metro`, which bundles via the hosted pre-bundler and reads no `node_modules`. One manifest, one override block:

```jsonc
"run": ["npx", "expo", "start", "--web", "--port", "$PORT"],
"profiles": { "lifo": { "run": ["browser-metro", ".", "--port", "$PORT"] } }
```

`run`/`install`/`dir` replace wholesale; `env` merges key-wise; `$PORT` and `${PORT}` are substituted in argv, or passed as an env var via `port_env`.

## `resolve` vs `run`

`resolve` is the interface for a supervising host — it emits the command without running it, so the host keeps its own streaming and abort handling. `run` goes through `ctx.executeCapture`, which buffers stdout/stderr and takes no `AbortSignal`; a dev server started that way produces no output until it exits and isn't torn down on abort. Rather than paper over that, `run` is documented as the interactive/one-shot convenience and the README points hosts at `resolve --json`.

If you'd prefer `run` to be able to supervise properly, the missing primitive is an `executeCapture` variant that streams and accepts a signal — happy to follow up separately.

## Verification

- 21 unit tests (`pnpm test`) covering profile merging, `$PORT` expansion, `port_env`, cwd resolution, manifest discovery (`./orchd.json` → `/orchd.json`), install-if-missing, shell quoting, and the error paths.
- End-to-end against a **real ORCHD image**: a 24 KB rapidnative tarball imported with `importVfsSnapshot`, `orchd resolve` read the `orchd.json` that came with it, and the resolved `browser-metro` line served a **7.04 MB bundle**.

## One upstream quirk found

`browser-metro` drops its first argument (`ctx.args.slice(1)` at `packages/core/src/commands/system/browser-metro.ts:274`), unlike `systemctl`/`bc`, which treat `args[0]` as a real argument. So `browser-metro --port 8082` silently loses the flag and binds the default 8081. The example profile passes the project dir first to work around it, and the README notes it. Probably worth fixing separately — I didn't touch it here since other callers may rely on the current shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)