### PR TITLE
fix(browser-metro): treat numeric lineHeight as px in the className p…

### DIFF
--- a/packages/core/src/commands/system/browser-metro-shims.ts
+++ b/packages/core/src/commands/system/browser-metro-shims.ts
@@ -58,9 +58,12 @@ var React = require("react");
 var _orig = React.createElement;
 
 // React's set of CSS properties whose numeric values are unitless (no px
-// suffix). Mirrors React DOM's internal list. Used when applying user
-// style via element.style[k] = v in a ref callback — numeric values for
-// any other key default to pixels (RN convention).
+// suffix). Mirrors React DOM's internal list, EXCEPT lineHeight: CSS allows
+// unitless line-height (a font-size multiplier) but RN/react-native-web
+// treat numeric lineHeight as pixels, so it must get a px suffix here.
+// Used when applying user style via element.style[k] = v in a ref
+// callback — numeric values for any other key default to pixels (RN
+// convention).
 var _UNITLESS = {
   animationIterationCount: true, aspectRatio: true, borderImageOutset: true,
   borderImageSlice: true, borderImageWidth: true, boxFlex: true,
@@ -69,7 +72,7 @@ var _UNITLESS = {
   flexNegative: true, flexOrder: true, gridArea: true, gridRow: true,
   gridRowEnd: true, gridRowSpan: true, gridRowStart: true, gridColumn: true,
   gridColumnEnd: true, gridColumnSpan: true, gridColumnStart: true,
-  fontWeight: true, lineClamp: true, lineHeight: true, opacity: true,
+  fontWeight: true, lineClamp: true, opacity: true,
   order: true, orphans: true, scale: true, tabSize: true, widows: true,
   zIndex: true, zoom: true,
 };


### PR DESCRIPTION
…atch

The deferred-user-style path of CLASSNAME_PATCH_MODULE (taken when an element has both className and a plain-object style) applies style keys via element.style[k] with a px suffix for numbers, except keys in a _UNITLESS list copied from React DOM. That list includes lineHeight, because CSS allows unitless line-height as a font-size multiplier — but React Native and react-native-web treat numeric lineHeight as pixels.

A Text like className="text-center" style={{fontSize: 28, lineHeight: 36}} therefore rendered 36x28 = 1008px-tall line boxes in the web preview, blowing screens apart vertically, while style-only elements (which go through RNW's own normalization) rendered correctly.

Remove lineHeight from the unitless list so it gets the px suffix, matching RN semantics and RNW's behaviour.