### PR TITLE
release: @lifo-sh/core + lifo-sh 0.10.2

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # lifo-sh
 
+## 0.10.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @lifo-sh/core@0.10.2
+
 ## 0.10.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-sh",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Run Lifo (a Linux-like OS) in your terminal -- npx lifo-sh",
   "license": "MIT",
   "repository": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @lifo-sh/core
 
+## 0.10.2
+
+### Patch Changes
+
+- browser-metro: treat a numeric `lineHeight` as pixels
+
+  The className patch used React DOM's unitless-property list verbatim, which
+  includes `lineHeight` — correct for CSS, where a bare `line-height` is a font-size
+  multiplier, but wrong for React Native. `lineHeight: 24` in an app's style means
+  **24 pixels**; applied as `line-height: 24` it became a 24× multiplier, so text
+  rendered with enormous line spacing in the preview.
+
+  `lineHeight` is removed from that list, so it gets the `px` suffix like every other
+  dimensional property, matching RN and react-native-web. String values are still
+  passed through untouched, so `lineHeight: '1.5'` keeps working for anyone who wants
+  CSS semantics deliberately.
+
+  Also adds the first tests for these shims — the unit-suffix rule is now pinned
+  (`lineHeight` → px; `opacity`/`flex`/`fontWeight` untouched; strings preserved),
+  plus a check that the injected module still parses, since a syntax error there is
+  silent until an app renders.
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/core",
-  "version": "0.10.0",
+  "version": "0.10.2",
   "description": "Linux-like OS engine for JavaScript -- kernel, shell, VFS, and 60+ commands",
   "license": "MIT",
   "repository": {

--- a/packages/core/tests/commands/browser-metro-shims.test.ts
+++ b/packages/core/tests/commands/browser-metro-shims.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { CLASSNAME_PATCH_MODULE } from '../../src/commands/system/browser-metro-shims.js';
+
+/**
+ * The className patch is injected into the preview as source text, so the only
+ * way to test its behaviour is to lift the relevant pieces out and run them.
+ *
+ * What's pinned here is the unit-suffix rule, which had a real bug: `lineHeight`
+ * sat in React DOM's unitless list, so a numeric `lineHeight: 24` was applied as
+ * `line-height: 24` — a 24× font-size multiplier in CSS — where React Native and
+ * react-native-web mean 24 pixels. Text rendered with enormous line spacing.
+ */
+
+/** Evaluate the `_UNITLESS` table straight out of the injected module. */
+function unitlessTable(): Record<string, true> {
+  const match = CLASSNAME_PATCH_MODULE.match(/var _UNITLESS = (\{[\s\S]*?\n\};)/);
+  if (!match) throw new Error('_UNITLESS not found in CLASSNAME_PATCH_MODULE');
+  return new Function(`return ${match[1].replace(/;$/, '')};`)() as Record<string, true>;
+}
+
+/** The rule the shim applies: numbers get px unless the key is unitless. */
+function applied(key: string, value: number | string): string | number {
+  const unitless = unitlessTable();
+  if (typeof value === 'number' && !unitless[key]) return `${value}px`;
+  return value;
+}
+
+describe('className patch — numeric style units', () => {
+  // Regression: lineHeight used to be listed as unitless.
+  it('gives a numeric lineHeight a px suffix (RN semantics, not CSS)', () => {
+    expect(unitlessTable().lineHeight).toBeUndefined();
+    expect(applied('lineHeight', 24)).toBe('24px');
+  });
+
+  it('still leaves genuinely unitless properties alone', () => {
+    const unitless = unitlessTable();
+    for (const key of ['opacity', 'flex', 'flexGrow', 'fontWeight', 'zIndex', 'aspectRatio', 'lineClamp']) {
+      expect(unitless[key], `${key} should be unitless`).toBe(true);
+      expect(applied(key, 1)).toBe(1);
+    }
+  });
+
+  it('adds px to the usual dimensional properties', () => {
+    for (const key of ['width', 'height', 'margin', 'padding', 'top', 'fontSize', 'borderRadius']) {
+      expect(applied(key, 12)).toBe('12px');
+    }
+  });
+
+  it('leaves string values untouched, so explicit units survive', () => {
+    expect(applied('lineHeight', '1.5')).toBe('1.5');
+    expect(applied('width', '50%')).toBe('50%');
+    expect(applied('fontSize', '2rem')).toBe('2rem');
+  });
+
+  it('the patch module still parses as JavaScript', () => {
+    // It is injected into the preview verbatim; a syntax error there is silent
+    // until an app renders.
+    expect(() => new Function(CLASSNAME_PATCH_MODULE)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Releases the `browser-metro` `lineHeight` fix from #73, **which merged without a changeset** — so as things stood, nothing would have shipped. This adds the changeset, the version bumps, and the first tests for those shims.

## The fix, and why it mattered

The className patch used React DOM's unitless-property list verbatim, and that list includes `lineHeight`. Correct for CSS, where a bare `line-height` is a font-size multiplier — wrong for React Native, where `lineHeight: 24` means **24 pixels**. Applied as `line-height: 24` it became a **24× multiplier**, so preview text rendered with enormous line spacing.

```diff
- fontWeight: true, lineClamp: true, lineHeight: true, opacity: true,
+ fontWeight: true, lineClamp: true, opacity: true,
```

String values still pass through untouched, so `lineHeight: '1.5'` keeps CSS semantics for anyone who wants them deliberately.

## First tests for these shims

The patch is injected as source text, so the test lifts `_UNITLESS` out of the module and applies the same rule the shim does:

- numeric `lineHeight` → `24px` **(the regression)**
- `opacity` / `flex` / `flexGrow` / `fontWeight` / `zIndex` / `aspectRatio` / `lineClamp` left alone
- dimensional properties (`width`, `fontSize`, `borderRadius`, …) suffixed
- string values preserved
- the injected module still parses — a syntax error there is silent until an app renders

**Verified by reintroduction:** putting `lineHeight` back in the unitless list fails the suite (`expected true to be undefined`); removing it passes. I also unpacked the built tarball and confirmed the shipped `dist` no longer lists `lineHeight` as unitless, rather than trusting the source.

## Version note

`@lifo-sh/core` goes **0.10.0 → 0.10.2**, skipping 0.10.1. changesets keeps core/ui/cli on a shared version via `linked`, and `lifo-sh` was already at 0.10.1 from the CLI-only patch, so the group's next patch is 0.10.2. `@lifo-sh/ui` stays at 0.10.0 — it isn't part of this release and its `workspace:^` peer already admits 0.10.2.

No hand-pinning this time: a `patch` doesn't trigger the core↔ui peer escalation that turns a `minor` into `1.0.0`. That escalation is still worth removing.

## Also noticed

While tracking down what to release: `feat/lifo-pkg-orchd` has three unmerged commits (`lifo-pkg-orchd`, an ORCHD playground example, and `orchd up`). Not in this release, and note that `lifo-pkg-orchd` is **not** in the changesets `ignore` list — unlike the other `lifo-pkg-*` packages — so it'll be versioned and published once it lands unless that's deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)