### PR TITLE
docs: add a Related projects section with a RapidNative backlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,5 +140,4 @@ See them all on [rapidnative.com/open-source](https://www.rapidnative.com/open-s
 
 ## License
 
-
 MIT

--- a/README.md
+++ b/README.md
@@ -123,6 +123,22 @@ src/
 tests/                   # Mirrors src/ structure with full coverage
 ```
 
+## Related projects
+
+Lifo is built by the team behind **[RapidNative](https://rapidnative.com)** — AI that
+generates production-ready React Native apps and UIs from a prompt — alongside these
+open-source tools:
+
+| Project | What it is |
+| --- | --- |
+| [RapidNative](https://rapidnative.com) | AI that generates production-ready React Native apps and UIs from a prompt |
+| [tinbase](https://tinbase.dev) | A Supabase-compatible backend without Docker — one process, real Postgres, runs in the browser |
+| [ORCHD](https://rapidnative.github.io/orchd) | A multi-tenant workload orchestrator — per-tenant workloads that sleep when idle and wake on the next request |
+| [jetplane](https://sanketsahu.github.io/jetplane) | A Metro plugin and a thin dev server for Expo — many dev environments per machine |
+
+See them all on [rapidnative.com/open-source](https://www.rapidnative.com/open-source).
+
 ## License
+
 
 MIT


### PR DESCRIPTION
## What

The README linked to none of the sibling projects. Adds a **Related projects** table before the license section — RapidNative, tinbase, ORCHD, jetplane — plus a backlink to [rapidnative.com](https://rapidnative.com) and [/open-source](https://www.rapidnative.com/open-source).

**ORCHD** is new to the family: a multi-tenant workload orchestrator ([docs](https://rapidnative.github.io/orchd/docs/) · [repo](https://github.com/RapidNative/orchd)) that reads the same `orchd.json` the `orchd` npm package in this repo does.

Companion PRs: the footer link on [lifo-sh/website#60](https://github.com/lifo-sh/website/pull/60), the same in tinbase and jetplane, reverse links on ORCHD's own site, and ORCHD on the RapidNative open-source page.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)