### PR TITLE
fix(browser-metro): merge forwarded $$css token objects in the classN…

### DIFF
--- a/.changeset/classname-patch-merge-forwarded-tokens.md
+++ b/.changeset/classname-patch-merge-forwarded-tokens.md
@@ -1,0 +1,5 @@
+---
+"@lifo-sh/core": patch
+---
+
+browser-metro className patch: merge forwarded `$$css` token objects instead of dropping them. When a custom component's caller-supplied `className` (already converted to a `$$css` style object) was spread via `{...rest}` onto an inner element that had its own `className`, the patch treated it as a plain user style and deferred it to per-property `el.style["gap-3"] = "gap-3"` writes — invalid CSS properties, silently discarded — so the caller's classes never rendered. Token objects are now merged into one `$$css` object, caller tokens last, matching `cn(base, className)` precedence.

--- a/packages/core/src/commands/system/browser-metro-shims.ts
+++ b/packages/core/src/commands/system/browser-metro-shims.ts
@@ -195,13 +195,24 @@ React.createElement = function() {
   // ref callback that writes via element.style[k] = v after mount.
   var deferredUserStyle = null;
   if (cssObj && cleanedStyle && typeof cleanedStyle === "object" && !Array.isArray(cleanedStyle)) {
-    // Plain object: defer to ref only if it has any real keys. An empty
-    // object (often the post-_stripUndefined shape of a buggy user style)
-    // collapses to just cssObj — same as having no user style at all.
-    if (Object.keys(cleanedStyle).length > 0) {
-      deferredUserStyle = cleanedStyle;
+    if (cleanedStyle.$$css === true) {
+      // The style is itself a $$css token object — a parent component's
+      // converted className forwarded through {...rest} (e.g. a Surface
+      // wrapper spreading caller props onto its inner View). Merge the two
+      // token sets into ONE $$css object; the defer-to-ref path below would
+      // write tokens like el.style["gap-3"] = "gap-3" — invalid CSS
+      // properties, silently dropped — and the caller's classes would vanish.
+      // Caller tokens go last, mirroring cn(base, className) precedence.
+      props.style = Object.assign({}, cssObj, cleanedStyle);
+    } else {
+      // Plain object: defer to ref only if it has any real keys. An empty
+      // object (often the post-_stripUndefined shape of a buggy user style)
+      // collapses to just cssObj — same as having no user style at all.
+      if (Object.keys(cleanedStyle).length > 0) {
+        deferredUserStyle = cleanedStyle;
+      }
+      props.style = cssObj;
     }
-    props.style = cssObj;
   } else if (cssObj && Array.isArray(cleanedStyle) && cleanedStyle.length > 0) {
     // Array form — preserve previous behavior, styleq handles arrays.
     props.style = [cssObj].concat(cleanedStyle);


### PR DESCRIPTION
…ame patch

The createElement patch converts className on EVERY non-host component — including custom wrappers like a Surface/Card. The wrapper's caller-side classes arrive at its inner element as a $$css token object in the style prop (via {...rest}), and the patch's plain-object branch deferred that to per-property el.style['gap-3'] = 'gap-3' writes — invalid CSS properties, silently discarded. Result: the wrapper's own classes rendered, the caller's vanished (native NativeWind is unaffected — it never converts className on custom components, so this only broke the web preview).

A style that is itself a $$css object is now merged with the element's own className tokens into one $$css object, caller tokens last, matching cn(base, className) precedence.