### PR TITLE
chore: version @lifo-sh/core 0.10.4

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/core",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Linux-like OS engine for JavaScript -- kernel, shell, VFS, and 60+ commands",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump `@lifo-sh/core` version to 0.10.4
- Already published to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)