### PR TITLE
chore(core): browser-metro 1.0.33 — working Alert in the web preview

### DIFF
--- a/.changeset/browser-metro-1-0-33-alert.md
+++ b/.changeset/browser-metro-1-0-33-alert.md
@@ -1,0 +1,5 @@
+---
+"@lifo-sh/core": patch
+---
+
+Bump browser-metro to 1.0.33: `Alert.alert` / `Alert.prompt` now work in the web preview — the react-native shim renders an iOS-style DOM dialog (all button counts, cancel/destructive styles, prompt input) instead of react-native-web's silent no-op. Also carries the router-shim blob-uuid route fix line (1.0.32).

--- a/.changeset/browser-metro-1-0-33-alert.md
+++ b/.changeset/browser-metro-1-0-33-alert.md
@@ -1,5 +1,0 @@
----
-"@lifo-sh/core": patch
----
-
-Bump browser-metro to 1.0.33: `Alert.alert` / `Alert.prompt` now work in the web preview — the react-native shim renders an iOS-style DOM dialog (all button counts, cancel/destructive styles, prompt input) instead of react-native-web's silent no-op. Also carries the router-shim blob-uuid route fix line (1.0.32).

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # lifo-sh
 
+## 0.10.5
+
+### Patch Changes
+
+- Updated dependencies [b305914]
+  - @lifo-sh/core@0.10.5
+
 ## 0.10.3
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifo-sh",
-  "version": "0.10.3",
+  "version": "0.10.5",
   "description": "Run Lifo (a Linux-like OS) in your terminal -- npx lifo-sh",
   "license": "MIT",
   "repository": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lifo-sh/core
 
+## 0.10.5
+
+### Patch Changes
+
+- b305914: Bump browser-metro to 1.0.33: `Alert.alert` / `Alert.prompt` now work in the web preview — the react-native shim renders an iOS-style DOM dialog (all button counts, cancel/destructive styles, prompt input) instead of react-native-web's silent no-op. Also carries the router-shim blob-uuid route fix line (1.0.32).
+
 ## 0.10.3
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/core",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Linux-like OS engine for JavaScript -- kernel, shell, VFS, and 60+ commands",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "acorn": "^8.17.0",
-    "browser-metro": "1.0.31",
+    "browser-metro": "1.0.33",
     "ws": "^8.19.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
         specifier: ^8.17.0
         version: 8.17.0
       browser-metro:
-        specifier: 1.0.32
-        version: 1.0.32
+        specifier: 1.0.33
+        version: 1.0.33
       ws:
         specifier: ^8.19.0
         version: 8.19.0
@@ -2573,8 +2573,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browser-metro@1.0.32:
-    resolution: {integrity: sha512-P0Fafi5ENgn2jseeym85WIkgSpJmm3CQqNYcsqKqSGO+glRViJhvSKaIF9jMYFT6Rd2+liFcdlYbMgzsfKvZBA==}
+  browser-metro@1.0.33:
+    resolution: {integrity: sha512-ZVvm5Wa9hci+3NYT5a1zcDfXxh5mBTjCB+aLlPRlZ9BlKvTtZyxcPj/vtQwAO0TWy124HZ0/S+EySUnXCCpcyw==}
 
   browserslist@4.28.4:
     resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
@@ -6724,7 +6724,7 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browser-metro@1.0.32:
+  browser-metro@1.0.33:
     dependencies:
       '@sveltejs/acorn-typescript': 1.0.11(acorn@8.17.0)
       acorn: 8.17.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,4 +12,4 @@ allowBuilds:
   msw: false
 
 minimumReleaseAgeExclude:
-  - browser-metro@1.0.32
+  - browser-metro@1.0.32 || 1.0.33


### PR DESCRIPTION
react-native-web ships Alert as a silent no-op; browser-metro 1.0.33 shims the react-native module to render an iOS-style DOM dialog (all button counts, cancel/destructive styles, Alert.prompt input, options.cancelable). Exact pin, so embedders get the shim regardless of their own hoisting.