### PR TITLE
Reposition: name serverless functions as a first-class target

### DIFF
--- a/.changeset/positioning-copy.md
+++ b/.changeset/positioning-copy.md
@@ -1,0 +1,8 @@
+---
+'@lifo-sh/core': patch
+---
+
+Update the package description to match Lifo's positioning: "A tiny Linux-like
+OS in TypeScript for browsers, Node and serverless". No code change — but the
+npm description is the first thing most people read, so it should not describe a
+narrower set of runtimes than the library supports.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lifo
 
-A Linux-like operating system that runs anywhere JavaScript does -- in a browser tab or a Node.js process (server-side). Not a VM, not an emulator -- a clean-room reimplementation of Unix in TypeScript, where the JS runtime is the kernel and its APIs are the system calls.
+A tiny Linux-like operating system, written in TypeScript, that runs anywhere JavaScript does -- a browser tab, a Node.js process, a serverless function. Not a VM, not an emulator -- a clean-room reimplementation of Unix in TypeScript, where the JS runtime is the kernel and its APIs are the system calls.
 
 ```
 ┌──────────────────────────────────────────────────┐

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lifo-sh/core",
   "version": "0.10.5",
-  "description": "Linux-like OS engine for JavaScript -- kernel, shell, VFS, and 60+ commands",
+  "description": "A tiny Linux-like OS in TypeScript for browsers, Node and serverless -- kernel, shell, VFS, and 60+ commands",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Repo side of the positioning change. Pairs with the website sweep (lifo-sh/website, `copy/positioning`).

New line: **A tiny Linux-like OS in TypeScript — for browsers, Node and serverless functions.**

This repo already said "Linux-like operating system" rather than "VM", so here it's only about reach — the README and `@lifo-sh/core`'s npm description both stopped at browser + Node:

- `README.md` — now "a browser tab, a Node.js process, a serverless function", and leads with "tiny".
- `packages/core/package.json` — description updated (changeset: core patch). It's the first thing most people read on npm, and it described a narrower set of runtimes than the library supports.

Serverless isn't a new claim: `content/docs/introduction.mdx` on the website already documented Vercel / Cloudflare Workers / Deno.

🤖 Generated with [Claude Code](https://claude.com/claude-code)