### PR TITLE
chore: version @lifo-sh/core 0.10.7

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/core",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "A tiny Linux-like OS in TypeScript for browsers, Node and serverless -- kernel, shell, VFS, and 60+ commands",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Bumps `@lifo-sh/core` from `0.10.6` → `0.10.7`
- Includes updated package description (repositioning copy for browsers, Node, and serverless)

## Test plan
- [ ] Verify `npm publish` succeeds from `packages/core`
- [ ] Confirm the new description appears correctly on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)