### PR TITLE
chore: version @lifo-sh/core 0.10.9 (browser-metro 1.0.35 — type:module)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/core",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "description": "A tiny Linux-like OS in TypeScript for browsers, Node and serverless -- kernel, shell, VFS, and 60+ commands",
   "license": "MIT",
   "repository": {
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "acorn": "^8.17.0",
-    "browser-metro": "1.0.34",
+    "browser-metro": "1.0.35",
     "ws": "^8.19.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
         specifier: ^8.17.0
         version: 8.17.0
       browser-metro:
-        specifier: 1.0.34
-        version: 1.0.34
+        specifier: 1.0.35
+        version: 1.0.35
       ws:
         specifier: ^8.19.0
         version: 8.19.0
@@ -2573,8 +2573,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browser-metro@1.0.34:
-    resolution: {integrity: sha512-hqSFNJ7EqRMEoTPd7wlqaBLgLe2Sbm1XF3HpW2pe/qls2zEYk9S2dE4lRqcwvpU5YOHMDKlDD3uwnMwh+lP85Q==}
+  browser-metro@1.0.35:
+    resolution: {integrity: sha512-2cbg+6AZS5dRKhlPyEGsT3lIXcCkFzskHkWGwkoV9Hqx4bEWLTmKjDZm0J5tNOJ+NfI3RvRBfA1/DbZ+ihq70A==}
 
   browserslist@4.28.4:
     resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
@@ -6724,7 +6724,7 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browser-metro@1.0.34:
+  browser-metro@1.0.35:
     dependencies:
       '@sveltejs/acorn-typescript': 1.0.11(acorn@8.17.0)
       acorn: 8.17.0


### PR DESCRIPTION
browser-metro's dist is ESM syntax but declared no "type", so 0.10.8's statically-imported external broke under Next/Turbopack server externals (CJS lexer): Named export 'createDataBxPathPlugin' not found. 1.0.35 declares type:module; this bump carries correct metadata through the chain so the website's postinstall patch can be retired.