### PR TITLE
fix(core): browser-metro 1.0.36 — pin @react-native/* to RN core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifo-sh/core",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "description": "A tiny Linux-like OS in TypeScript for browsers, Node and serverless -- kernel, shell, VFS, and 60+ commands",
   "license": "MIT",
   "repository": {
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "acorn": "^8.17.0",
-    "browser-metro": "1.0.35",
+    "browser-metro": "1.0.36",
     "ws": "^8.19.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
         specifier: ^8.17.0
         version: 8.17.0
       browser-metro:
-        specifier: 1.0.35
-        version: 1.0.35
+        specifier: 1.0.36
+        version: 1.0.36
       ws:
         specifier: ^8.19.0
         version: 8.19.0
@@ -2573,8 +2573,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browser-metro@1.0.35:
-    resolution: {integrity: sha512-2cbg+6AZS5dRKhlPyEGsT3lIXcCkFzskHkWGwkoV9Hqx4bEWLTmKjDZm0J5tNOJ+NfI3RvRBfA1/DbZ+ihq70A==}
+  browser-metro@1.0.36:
+    resolution: {integrity: sha512-bSdPJZZPyqztI9wz5JDRkXoDbUBSL30E0yKVRJpyhJxAEqLVHyvz4hyvrM/qnTh55cHmPfJBtIiSuuhr1rYhPw==}
 
   browserslist@4.28.4:
     resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
@@ -6724,7 +6724,7 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browser-metro@1.0.35:
+  browser-metro@1.0.36:
     dependencies:
       '@sveltejs/acorn-typescript': 1.0.11(acorn@8.17.0)
       acorn: 8.17.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,4 +12,4 @@ allowBuilds:
   msw: false
 
 minimumReleaseAgeExclude:
-  - browser-metro@1.0.32 || 1.0.33
+  - browser-metro@1.0.32 || 1.0.33 || 1.0.36


### PR DESCRIPTION
browser-metro 1.0.36 resolves `@react-native/*` packages at react-native core's declared version instead of letting them fall through to @latest.

Without it, @react-native/assets-registry@0.87.0 (published 2026-08-11) reaches every preview that rebuilds: it rewrote registry.js into `require('react-native').AssetRegistry.registerAsset`, and browser-metro aliases react-native to react-native-web, which has no top-level AssetRegistry. Projects died on "Cannot read properties of undefined (reading 'registerAsset')" with no change of their own.

browser-metro is an external import here, not bundled, so consumers pick the fix up through this dependency — which is why @lifo-sh/core has to be republished for it to reach the preview at all.

Version bumped to 0.10.10 for that publish. pnpm added 1.0.36 to minimumReleaseAgeExclude, matching the existing entries for 1.0.32 / 1.0.33 — the release is hours old and the age gate would otherwise refuse it.