### PR TITLE
fix(browser-metro): register assets written after startup in the bund…

### DIFF
--- a/.changeset/late-asset-registration.md
+++ b/.changeset/late-asset-registration.md
@@ -1,0 +1,10 @@
+---
+"@lifo-sh/core": patch
+---
+
+browser-metro: assets written to the VFS after the command started (a chat
+attachment uploaded mid-session, an image the agent downloads) are now
+registered in the bundler VFS as external entries and reported as a change.
+They used to be dropped from the change list, so a `require()` of a new image
+crashed the preview with "Module not found: /assets/<file>" until the sandbox
+was recreated.

--- a/packages/core/src/commands/system/browser-metro.ts
+++ b/packages/core/src/commands/system/browser-metro.ts
@@ -277,6 +277,31 @@ function buildEditorHeadBlock(env: Record<string, string>, tailwindConfigScript:
 
 interface HmrEntry { seq: number; update: { updatedModules: Record<string, string>; removedModules: string[]; reverseDepsMap?: Record<string, string[]> } }
 
+/**
+ * Register (or refresh) a binary asset in the bundler VFS.
+ *
+ * Assets that exist when the command starts are seeded by readFileMap as
+ * `{ content: '', isExternal: true }`, which is what makes the bundler emit a
+ * `{ uri: ASSET_PREFIX + path }` stub for them. Assets written AFTER startup
+ * (a chat attachment uploaded mid-session, an image the agent downloads) used
+ * to be dropped from the change list entirely — the bundler VFS never learned
+ * the path existed, `walkDeps` skipped the unresolvable require, and the
+ * preview crashed with "Module not found: /assets/<file>" until the sandbox was
+ * recreated. Registering the entry here and reporting it as a change makes the
+ * next rebuild add the asset module (and, via HMR, re-execute its dependents).
+ *
+ * VirtualFS.write() always marks entries non-external (the stub would then
+ * export the bare filename instead of a URI), and browser-metro 1.0.36 has no
+ * external-aware write — so the entry goes in through the public map API.
+ */
+export function upsertExternalAsset(bvfs: VirtualFS, rel: string): FileChange['type'] {
+  const existed = bvfs.exists(rel);
+  const files = bvfs.toFileMap();
+  files[rel] = { content: '', isExternal: true };
+  bvfs.replaceAll(files);
+  return existed ? 'update' : 'create';
+}
+
 export function createBrowserMetroCommand(kernel: Kernel): Command {
   return async (ctx) => {
     const rest = ctx.args.slice(1);
@@ -438,7 +463,13 @@ export function createBrowserMetroCommand(kernel: Kernel): Command {
           if (bvfs.exists(rel)) { bvfs.delete(rel); changes.push({ path: rel, type: 'delete' }); if (rel.startsWith('/app/')) routeStructureChanged = true; }
           continue;
         }
-        if (ASSET_EXT.test(rel)) { assetBlobs.delete(ASSET_PREFIX + rel); continue; }
+        if (ASSET_EXT.test(rel)) {
+          // Bytes changed (or arrived): drop the cached blob so materializeAssets
+          // re-reads the VFS, and make sure the bundler can resolve the path.
+          assetBlobs.delete(ASSET_PREFIX + rel);
+          changes.push({ path: rel, type: upsertExternalAsset(bvfs, rel) });
+          continue;
+        }
         const existed = bvfs.exists(rel);
         try { bvfs.write(rel, decoder.decode(kernel.vfs.readFile(abs) as Uint8Array)); } catch { continue; }
         changes.push({ path: rel, type: existed ? 'update' : 'create' });

--- a/packages/core/tests/commands/browser-metro-assets.test.ts
+++ b/packages/core/tests/commands/browser-metro-assets.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { VirtualFS } from 'browser-metro';
+import { upsertExternalAsset } from '../../src/commands/system/browser-metro.js';
+
+/**
+ * The bundler only resolves a require() to a path that `exists()` in ITS VFS
+ * (walkDeps skips anything else), and only emits the `{ uri }` stub an <Image>
+ * needs when that entry is marked external. readFileMap seeds both at startup;
+ * this helper is what the watch loop uses for assets that arrive later.
+ *
+ * Regression pinned here: a chat-attached image uploaded mid-session was
+ * written to the kernel VFS but dropped from the bundler's change list, so the
+ * agent's `require('../../assets/avatar.jpeg')` crashed the preview with
+ * "Module not found: /assets/avatar.jpeg" until the sandbox was recreated.
+ */
+describe('upsertExternalAsset — assets written after startup', () => {
+  it('registers a new asset as an external entry the bundler can resolve', () => {
+    const bvfs = new VirtualFS({ '/index.tsx': { content: 'export {}', isExternal: false } });
+    expect(bvfs.exists('/assets/avatar.jpeg')).toBe(false);
+
+    const type = upsertExternalAsset(bvfs, '/assets/avatar.jpeg');
+
+    expect(type).toBe('create');
+    expect(bvfs.exists('/assets/avatar.jpeg')).toBe(true);
+    expect(bvfs.isExternalAsset('/assets/avatar.jpeg')).toBe(true);
+    // Binary bytes must never be decoded into the bundler's text map.
+    expect(bvfs.read('/assets/avatar.jpeg')).toBe('');
+  });
+
+  it('reports a re-written asset as an update and keeps it external', () => {
+    const bvfs = new VirtualFS({ '/assets/logo.png': { content: '', isExternal: true } });
+
+    expect(upsertExternalAsset(bvfs, '/assets/logo.png')).toBe('update');
+    expect(bvfs.isExternalAsset('/assets/logo.png')).toBe(true);
+  });
+
+  it('leaves every other entry untouched', () => {
+    const bvfs = new VirtualFS({
+      '/index.tsx': { content: 'export {}', isExternal: false },
+      '/assets/icon.png': { content: '', isExternal: true },
+    });
+
+    upsertExternalAsset(bvfs, '/assets/avatar.jpeg');
+
+    expect(bvfs.read('/index.tsx')).toBe('export {}');
+    expect(bvfs.isExternalAsset('/index.tsx')).toBe(false);
+    expect(bvfs.isExternalAsset('/assets/icon.png')).toBe(true);
+    expect(bvfs.list().sort()).toEqual(['/assets/avatar.jpeg', '/assets/icon.png', '/index.tsx']);
+  });
+
+  it('is what VirtualFS.write() cannot do — a plain write is not external', () => {
+    // Documents WHY the helper exists: write() would make the bundler emit a
+    // bare-filename stub instead of the `{ uri }` an <Image source> needs.
+    const bvfs = new VirtualFS({});
+    bvfs.write('/assets/plain.png', '');
+    expect(bvfs.isExternalAsset('/assets/plain.png')).toBe(false);
+  });
+});


### PR DESCRIPTION
…ler VFS

An asset that lands in the kernel VFS after the command has started (a chat attachment uploaded mid-session, an image the agent downloads) was dropped from the change list in the watch loop, so the bundler VFS never learned the path existed. walkDeps then skipped the agent's require() and the preview crashed with "Module not found: /assets/<file>" until the sandbox was recreated — which the agent read as "the upload saved a 0-byte file".

The watch loop now upserts the asset as an external entry (the same shape readFileMap seeds at startup, so the bundler emits the `{ uri }` stub) and reports it as a create/update, and the cached blob URL is dropped so materializeAssets re-reads the new bytes.


Claude-Session: https://claude.ai/code/session_011ASUpuxm3rdc43yVDrUkPM